### PR TITLE
fix: handle zero disbursed amount for check_disbursal function

### DIFF
--- a/lana/app/src/terms/value.rs
+++ b/lana/app/src/terms/value.rs
@@ -131,6 +131,10 @@ impl CVLPct {
         Self(Decimal::from(value))
     }
 
+    pub fn is_zero(&self) -> bool {
+        *self == Self::ZERO
+    }
+
     pub fn scale(&self, value: UsdCents) -> UsdCents {
         let cents = value.to_usd() * dec!(100) * (self.0 / dec!(100));
         UsdCents::from(


### PR DESCRIPTION
## Description

This makes it so that the check falls back to the `total` cvl in `FacilityCVL` since that value will always be lower than the `disbursed` cvl.

The issue here was that with a structuring fee of `0` the projected cvl had a `disbursed` value of 0 which caused the activation job to error [here](https://github.com/GaloyMoney/lana-bank/blob/5d4e539fc0b5c19db893e0558657a08733b34ed2/lana/app/src/credit_facility/processes/activate_credit_facility/mod.rs#L90).