### PR TITLE
refactor: change chart 'code' abstraction to 'path'

### DIFF
--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -54,7 +54,7 @@ pub struct Chart {
 }
 
 impl Chart {
-    fn next_control_account(&self, category: ChartCategoryPath) -> Result<ChartPath, ChartError> {
+    fn next_control_account(&self, category: ChartCategory) -> Result<ChartPath, ChartError> {
         Ok(self
             .events
             .iter_all()
@@ -82,7 +82,7 @@ impl Chart {
 
     pub fn create_control_account(
         &mut self,
-        category: ChartCategoryPath,
+        category: ChartCategory,
         name: String,
         reference: String,
         audit_info: AuditInfo,
@@ -281,7 +281,7 @@ impl IntoEvents<ChartEvent> for NewChart {
 
 #[cfg(test)]
 mod tests {
-    use crate::path::{AccountIdx, ChartCategoryPath};
+    use crate::path::{AccountIdx, ChartCategory};
 
     use super::*;
 
@@ -332,7 +332,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         match chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -340,7 +340,7 @@ mod tests {
             .unwrap()
         {
             ChartPath::ControlAccount { category, index } => {
-                assert_eq!(category, ChartCategoryPath::Assets);
+                assert_eq!(category, ChartCategory::Assets);
                 assert_eq!(index, AccountIdx::FIRST);
             }
             other => panic!("Expected FIRST control account, got {:?}", other),
@@ -352,7 +352,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets #1".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -360,7 +360,7 @@ mod tests {
             .unwrap();
 
         match chart.create_control_account(
-            ChartCategoryPath::Assets,
+            ChartCategory::Assets,
             "Assets #2".to_string(),
             "assets".to_string(),
             dummy_audit_info(),
@@ -379,7 +379,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -400,7 +400,7 @@ mod tests {
                 control_index,
                 index,
             } => {
-                assert_eq!(category, ChartCategoryPath::Assets);
+                assert_eq!(category, ChartCategory::Assets);
                 assert_eq!(control_index, AccountIdx::FIRST);
                 assert_eq!(index, AccountIdx::FIRST);
             }
@@ -413,7 +413,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -451,7 +451,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -488,7 +488,7 @@ mod tests {
                     },
                 ..
             } => {
-                assert_eq!(category, ChartCategoryPath::Assets);
+                assert_eq!(category, ChartCategory::Assets);
                 assert_eq!(control_index, AccountIdx::FIRST);
                 assert_eq!(control_sub_index, AccountIdx::FIRST);
                 assert_eq!(index, AccountIdx::FIRST);
@@ -503,7 +503,7 @@ mod tests {
 
         chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "First".to_string(),
                 "assets-01".to_string(),
                 dummy_audit_info(),
@@ -512,7 +512,7 @@ mod tests {
 
         match chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Second".to_string(),
                 "assets-02".to_string(),
                 dummy_audit_info(),
@@ -520,7 +520,7 @@ mod tests {
             .unwrap()
         {
             ChartPath::ControlAccount { category, index } => {
-                assert_eq!(category, ChartCategoryPath::Assets);
+                assert_eq!(category, ChartCategory::Assets);
                 assert_eq!(index, AccountIdx::FIRST.next());
             }
             other => panic!("Expected SECOND control account, got {:?}", other),
@@ -532,7 +532,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -562,7 +562,7 @@ mod tests {
                 control_index,
                 index,
             } => {
-                assert_eq!(category, ChartCategoryPath::Assets);
+                assert_eq!(category, ChartCategory::Assets);
                 assert_eq!(control_index, AccountIdx::FIRST);
                 assert_eq!(index, AccountIdx::FIRST.next());
             }
@@ -575,7 +575,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartCategoryPath::Assets,
+                ChartCategory::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -624,7 +624,7 @@ mod tests {
                     },
                 ..
             } => {
-                assert_eq!(category, ChartCategoryPath::Assets);
+                assert_eq!(category, ChartCategory::Assets);
                 assert_eq!(control_index, AccountIdx::FIRST);
                 assert_eq!(control_sub_index, AccountIdx::FIRST);
                 assert_eq!(index, AccountIdx::FIRST.next());
@@ -638,7 +638,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let audit_info = dummy_audit_info();
 
-        let category = ChartCategoryPath::Assets;
+        let category = ChartCategory::Assets;
         let control_account = chart
             .create_control_account(
                 category,

--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -54,20 +54,18 @@ pub struct Chart {
 }
 
 impl Chart {
-    fn next_control_account(&self, category: ChartPath) -> Result<ChartPath, ChartError> {
+    fn next_control_account(&self, category: ChartCategoryPath) -> Result<ChartPath, ChartError> {
         Ok(self
             .events
             .iter_all()
             .rev()
             .find_map(|event| match event {
-                ChartEvent::ControlAccountAdded { path, .. }
-                    if path.category() == category.category() =>
-                {
+                ChartEvent::ControlAccountAdded { path, .. } if path.category() == category => {
                     Some(path.next())
                 }
                 _ => None,
             })
-            .unwrap_or_else(|| ChartPath::first_control_account(category))?)
+            .unwrap_or_else(|| Ok(ChartPath::first_control_account(category)))?)
     }
 
     pub fn find_control_account_by_reference(
@@ -84,7 +82,7 @@ impl Chart {
 
     pub fn create_control_account(
         &mut self,
-        category: ChartPath,
+        category: ChartCategoryPath,
         name: String,
         reference: String,
         audit_info: AuditInfo,
@@ -334,7 +332,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         match chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -354,7 +352,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets #1".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -362,7 +360,7 @@ mod tests {
             .unwrap();
 
         match chart.create_control_account(
-            ChartPath::Category(ChartCategoryPath::Assets),
+            ChartCategoryPath::Assets,
             "Assets #2".to_string(),
             "assets".to_string(),
             dummy_audit_info(),
@@ -381,7 +379,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -415,7 +413,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -453,7 +451,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -505,7 +503,7 @@ mod tests {
 
         chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "First".to_string(),
                 "assets-01".to_string(),
                 dummy_audit_info(),
@@ -514,7 +512,7 @@ mod tests {
 
         match chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Second".to_string(),
                 "assets-02".to_string(),
                 dummy_audit_info(),
@@ -534,7 +532,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -577,7 +575,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let control_account = chart
             .create_control_account(
-                ChartPath::Category(ChartCategoryPath::Assets),
+                ChartCategoryPath::Assets,
                 "Assets".to_string(),
                 "assets".to_string(),
                 dummy_audit_info(),
@@ -640,7 +638,7 @@ mod tests {
         let mut chart = init_chart_of_events();
         let audit_info = dummy_audit_info();
 
-        let category = ChartPath::Category(ChartCategoryPath::Assets);
+        let category = ChartCategoryPath::Assets;
         let control_account = chart
             .create_control_account(
                 category,

--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -199,7 +199,7 @@ impl Chart {
 
         Ok(ChartAccountDetails {
             account_id: creation_details.account_id,
-            code: path.to_code(self.id),
+            code: path.path_encode(self.id),
             path,
             name: creation_details.name,
             description: creation_details.description,
@@ -217,7 +217,7 @@ impl Chart {
             } if *path == account_path => Some(ChartAccountDetails {
                 account_id: *id,
                 path: *path,
-                code: path.to_code(self.id),
+                code: path.path_encode(self.id),
                 name: name.to_string(),
                 description: description.to_string(),
             }),

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -174,7 +174,7 @@ where
     pub async fn create_control_account(
         &self,
         chart_id: impl Into<ChartId>,
-        category: CategoryPath,
+        category: ChartCategory,
         name: String,
         reference: String,
     ) -> Result<ChartPath, CoreChartOfAccountsError> {

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -265,7 +265,7 @@ where
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
         chart_id: impl Into<ChartId> + std::fmt::Debug,
-        code: impl Into<ChartPath> + std::fmt::Debug,
+        encoded_path: String,
     ) -> Result<Option<ChartAccountDetails>, CoreChartOfAccountsError> {
         let chart_id = chart_id.into();
         self.authz
@@ -278,7 +278,7 @@ where
 
         let chart = self.repo.find_by_id(chart_id).await?;
 
-        let account_details = chart.find_account(code.into());
+        let account_details = chart.find_account_by_encoded_path(encoded_path);
 
         Ok(account_details)
     }

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -15,6 +15,8 @@ use authz::PermissionCheck;
 
 use chart_of_accounts::*;
 use error::*;
+use path::ControlAccountPath;
+pub use path::ControlSubAccountPath;
 pub use primitives::*;
 pub use transaction_account_factory::*;
 
@@ -63,7 +65,7 @@ where
     pub fn transaction_account_factory(
         &self,
         chart_id: ChartId,
-        control_sub_account: ChartPath,
+        control_sub_account: ControlSubAccountPath,
     ) -> TransactionAccountFactory {
         TransactionAccountFactory::new(&self.repo, &self.cala, chart_id, control_sub_account)
     }
@@ -152,7 +154,7 @@ where
         &self,
         chart_id: impl Into<ChartId>,
         reference: String,
-    ) -> Result<Option<ChartPath>, CoreChartOfAccountsError> {
+    ) -> Result<Option<ControlAccountPath>, CoreChartOfAccountsError> {
         let chart_id = chart_id.into();
 
         let mut op = self.repo.begin_op().await?;
@@ -177,7 +179,7 @@ where
         category: ChartCategory,
         name: String,
         reference: String,
-    ) -> Result<ChartPath, CoreChartOfAccountsError> {
+    ) -> Result<ControlAccountPath, CoreChartOfAccountsError> {
         let chart_id = chart_id.into();
 
         let mut op = self.repo.begin_op().await?;
@@ -194,20 +196,20 @@ where
 
         let mut chart = self.repo.find_by_id(chart_id).await?;
 
-        let code = chart.create_control_account(category, name, reference, audit_info)?;
+        let path = chart.create_control_account(category, name, reference, audit_info)?;
 
         self.repo.update_in_op(&mut op, &mut chart).await?;
 
         op.commit().await?;
 
-        Ok(code)
+        Ok(path)
     }
 
     pub async fn find_control_sub_account_by_reference(
         &self,
         chart_id: impl Into<ChartId>,
         reference: String,
-    ) -> Result<Option<ChartPath>, CoreChartOfAccountsError> {
+    ) -> Result<Option<ControlSubAccountPath>, CoreChartOfAccountsError> {
         let chart_id = chart_id.into();
 
         let mut op = self.repo.begin_op().await?;
@@ -229,10 +231,10 @@ where
     pub async fn create_control_sub_account(
         &self,
         chart_id: impl Into<ChartId> + std::fmt::Debug,
-        control_account: ChartPath,
+        control_account: ControlAccountPath,
         name: String,
         reference: String,
-    ) -> Result<ChartPath, CoreChartOfAccountsError> {
+    ) -> Result<ControlSubAccountPath, CoreChartOfAccountsError> {
         let chart_id = chart_id.into();
 
         let mut op = self.repo.begin_op().await?;
@@ -249,7 +251,7 @@ where
 
         let mut chart = self.repo.find_by_id(chart_id).await?;
 
-        let code =
+        let path =
             chart.create_control_sub_account(control_account, name, reference, audit_info)?;
 
         let mut op = self.repo.begin_op().await?;
@@ -257,7 +259,7 @@ where
 
         op.commit().await?;
 
-        Ok(code)
+        Ok(path)
     }
 
     #[instrument(name = "chart_of_accounts.find_account_in_chart", skip(self))]

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -174,7 +174,7 @@ where
     pub async fn create_control_account(
         &self,
         chart_id: impl Into<ChartId>,
-        category: ChartPath,
+        category: CategoryPath,
         name: String,
         reference: String,
     ) -> Result<ChartPath, CoreChartOfAccountsError> {

--- a/core/chart-of-accounts/src/path/error.rs
+++ b/core/chart-of-accounts/src/path/error.rs
@@ -1,25 +1,25 @@
 use thiserror::Error;
 
-use crate::path::{AccountIdx, ChartCategoryPath};
+use crate::path::{AccountIdx, ChartCategory};
 
 #[derive(Error, Debug)]
 pub enum ChartPathError {
     #[error("ChartError - ParseIntError: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
-    #[error("ChartError - InvalidCategoryPathForNewControlAccount")]
-    InvalidCategoryPathForNewControlAccount,
+    #[error("ChartError - InvalidCategoryForNewControlAccount")]
+    InvalidCategoryForNewControlAccount,
     #[error("ChartError - InvalidControlAccountPathForNewControlSubAccount")]
     InvalidControlAccountPathForNewControlSubAccount,
     #[error("ChartError - InvalidSubControlAccountPathForNewTransactionAccount")]
     InvalidSubControlAccountPathForNewTransactionAccount,
     #[error("ChartError - ControlIndexOverflowForCategory: Category '{0}'")]
-    ControlIndexOverflowForCategory(ChartCategoryPath),
+    ControlIndexOverflowForCategory(ChartCategory),
     #[error(
         "ChartError - ControlSubIndexOverflowForControlAccount: Category '{0}' / Control '{1}'"
     )]
-    ControlSubIndexOverflowForControlAccount(ChartCategoryPath, AccountIdx),
+    ControlSubIndexOverflowForControlAccount(ChartCategory, AccountIdx),
     #[error("ChartError - TransactionIndexOverflowForControlSubAccount: Category '{0}' / Control '{1}' / Sub-control '{2}'")]
-    TransactionIndexOverflowForControlSubAccount(ChartCategoryPath, AccountIdx, AccountIdx),
+    TransactionIndexOverflowForControlSubAccount(ChartCategory, AccountIdx, AccountIdx),
     #[error("ChartError - InvalidCodeLength: {0}")]
     InvalidCodeLength(String),
     #[error("ChartError - InvalidCategoryNumber: {0}")]

--- a/core/chart-of-accounts/src/path/mod.rs
+++ b/core/chart-of-accounts/src/path/mod.rs
@@ -57,75 +57,43 @@ impl ChartCategory {
             Self::Expenses => AccountIdx::from(5),
         }
     }
-}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ChartPath {
-    ControlAccount {
-        category: ChartCategory,
-        index: AccountIdx,
-    },
-    ControlSubAccount {
-        category: ChartCategory,
-        control_index: AccountIdx,
-        index: AccountIdx,
-    },
-    TransactionAccount {
-        category: ChartCategory,
-        control_index: AccountIdx,
-        control_sub_index: AccountIdx,
-        index: AccountIdx,
-    },
-}
-
-impl std::fmt::Display for ChartPath {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ControlAccount { category, index } => {
-                write!(
-                    f,
-                    "{:0<ENCODED_PATH_WIDTH$}",
-                    format!("{:01}{:02}", category.index(), index)
-                )
-            }
-            Self::ControlSubAccount {
-                category,
-                control_index,
-                index,
-            } => {
-                write!(
-                    f,
-                    "{:0<ENCODED_PATH_WIDTH$}",
-                    format!("{:01}{:02}{:02}", category.index(), control_index, index)
-                )
-            }
-            Self::TransactionAccount {
-                category,
-                control_index,
-                control_sub_index,
-                index,
-            } => {
-                write!(
-                    f,
-                    "{:0<ENCODED_PATH_WIDTH$}",
-                    format!(
-                        "{:01}{:02}{:02}{:03}",
-                        category.index(),
-                        control_index,
-                        control_sub_index,
-                        index
-                    )
-                )
-            }
+    pub const fn first_control_account(&self) -> ControlAccountPath {
+        ControlAccountPath {
+            category: *self,
+            index: AccountIdx::FIRST,
         }
     }
 }
 
-impl ChartPath {
-    pub fn normal_balance_type(&self) -> DebitOrCredit {
-        match self.category() {
-            ChartCategory::Assets | ChartCategory::Expenses => DebitOrCredit::Debit,
-            _ => DebitOrCredit::Credit,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlAccountPath {
+    pub category: ChartCategory,
+    pub index: AccountIdx,
+}
+
+impl std::fmt::Display for ControlAccountPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:0<ENCODED_PATH_WIDTH$}",
+            format!("{:01}{:02}", self.category.index(), self.index)
+        )
+    }
+}
+
+impl ControlAccountPath {
+    pub fn next(&self) -> Result<Self, ChartPathError> {
+        let next_index = self.index.next();
+        if next_index > AccountIdx::MAX_TWO_DIGIT {
+            Err(ChartPathError::ControlIndexOverflowForCategory(
+                self.category,
+            ))
+        } else {
+            Ok(Self {
+                category: self.category,
+                index: next_index,
+            })
         }
     }
 
@@ -133,151 +101,143 @@ impl ChartPath {
         format!("{}::{}", chart_id, self)
     }
 
-    pub fn category(&self) -> ChartCategory {
-        match *self {
-            Self::ControlAccount { category, .. } => category,
-            Self::ControlSubAccount { category, .. } => category,
-            Self::TransactionAccount { category, .. } => category,
-        }
-    }
-
-    pub fn control_account(&self) -> ChartPath {
-        match *self {
-            Self::ControlAccount { category, index } => Self::ControlAccount { category, index },
-            Self::ControlSubAccount {
-                category,
-                control_index,
-                ..
-            } => Self::ControlAccount {
-                category,
-                index: control_index,
-            },
-            Self::TransactionAccount {
-                category,
-                control_index,
-                ..
-            } => Self::ControlAccount {
-                category,
-                index: control_index,
-            },
-        }
-    }
-
-    pub fn control_sub_account(&self) -> Option<ChartPath> {
-        match *self {
-            Self::TransactionAccount {
-                category,
-                control_index,
-                control_sub_index,
-                ..
-            } => Some(Self::ControlSubAccount {
-                category,
-                control_index,
-                index: control_sub_index,
-            }),
-            Self::ControlSubAccount {
-                category,
-                control_index,
-                index,
-            } => Some(Self::ControlSubAccount {
-                category,
-                control_index,
-                index,
-            }),
-            _ => None,
-        }
-    }
-
-    pub const fn first_control_account(category: ChartCategory) -> Self {
-        Self::ControlAccount {
-            category,
+    pub const fn first_control_sub_account(&self) -> ControlSubAccountPath {
+        ControlSubAccountPath {
+            category: self.category,
+            control_index: self.index,
             index: AccountIdx::FIRST,
         }
     }
+}
 
-    pub fn first_control_sub_account(control_account: &Self) -> Result<Self, ChartPathError> {
-        match control_account {
-            Self::ControlAccount { category, index } => Ok(Self::ControlSubAccount {
-                category: *category,
-                control_index: *index,
-                index: AccountIdx::FIRST,
-            }),
-            _ => Err(ChartPathError::InvalidControlAccountPathForNewControlSubAccount),
-        }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlSubAccountPath {
+    pub category: ChartCategory,
+    pub control_index: AccountIdx,
+    pub index: AccountIdx,
+}
+
+impl std::fmt::Display for ControlSubAccountPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:0<ENCODED_PATH_WIDTH$}",
+            format!(
+                "{:01}{:02}{:02}",
+                self.category.index(),
+                self.control_index,
+                self.index
+            )
+        )
     }
+}
 
-    pub fn first_transaction_account(control_sub_account: &Self) -> Result<Self, ChartPathError> {
-        match control_sub_account {
-            Self::ControlSubAccount {
-                category,
-                control_index,
-                index,
-            } => Ok(Self::TransactionAccount {
-                category: *category,
-                control_index: *control_index,
-                control_sub_index: *index,
-                index: AccountIdx::FIRST,
-            }),
-            _ => Err(ChartPathError::InvalidSubControlAccountPathForNewTransactionAccount),
-        }
-    }
-
+impl ControlSubAccountPath {
     pub fn next(&self) -> Result<Self, ChartPathError> {
-        match *self {
-            Self::ControlAccount { category, index } => {
-                let next_index = index.next();
-                if next_index > AccountIdx::MAX_TWO_DIGIT {
-                    Err(ChartPathError::ControlIndexOverflowForCategory(category))
-                } else {
-                    Ok(Self::ControlAccount {
-                        category,
-                        index: next_index,
-                    })
-                }
-            }
-            Self::ControlSubAccount {
-                category,
-                control_index,
-                index,
-            } => {
-                let next_index = index.next();
-                if next_index > AccountIdx::MAX_TWO_DIGIT {
-                    Err(ChartPathError::ControlSubIndexOverflowForControlAccount(
-                        category,
-                        control_index,
-                    ))
-                } else {
-                    Ok(Self::ControlSubAccount {
-                        category,
-                        control_index,
-                        index: next_index,
-                    })
-                }
-            }
-            Self::TransactionAccount {
-                category,
-                control_index,
-                control_sub_index,
-                index,
-            } => {
-                let next_index = index.next();
-                if next_index > AccountIdx::MAX_THREE_DIGIT {
-                    Err(
-                        ChartPathError::TransactionIndexOverflowForControlSubAccount(
-                            category,
-                            control_index,
-                            control_sub_index,
-                        ),
-                    )
-                } else {
-                    Ok(Self::TransactionAccount {
-                        category,
-                        control_index,
-                        control_sub_index,
-                        index: next_index,
-                    })
-                }
-            }
+        let next_index = self.index.next();
+        if next_index > AccountIdx::MAX_TWO_DIGIT {
+            Err(ChartPathError::ControlSubIndexOverflowForControlAccount(
+                self.category,
+                self.control_index,
+            ))
+        } else {
+            Ok(Self {
+                category: self.category,
+                control_index: self.control_index,
+                index: next_index,
+            })
+        }
+    }
+
+    pub fn path_encode(&self, chart_id: ChartId) -> String {
+        format!("{}::{}", chart_id, self)
+    }
+
+    pub fn control_account(&self) -> ControlAccountPath {
+        ControlAccountPath {
+            category: self.category,
+            index: self.control_index,
+        }
+    }
+
+    pub fn first_transaction_account(&self) -> TransactionAccountPath {
+        TransactionAccountPath {
+            category: self.category,
+            control_index: self.control_index,
+            control_sub_index: self.index,
+            index: AccountIdx::FIRST,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransactionAccountPath {
+    pub category: ChartCategory,
+    pub control_index: AccountIdx,
+    pub control_sub_index: AccountIdx,
+    pub index: AccountIdx,
+}
+
+impl std::fmt::Display for TransactionAccountPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:0<ENCODED_PATH_WIDTH$}",
+            format!(
+                "{:01}{:02}{:02}{:03}",
+                self.category.index(),
+                self.control_index,
+                self.control_sub_index,
+                self.index
+            )
+        )
+    }
+}
+
+impl TransactionAccountPath {
+    pub fn next(&self) -> Result<Self, ChartPathError> {
+        let next_index = self.index.next();
+        if next_index > AccountIdx::MAX_THREE_DIGIT {
+            Err(
+                ChartPathError::TransactionIndexOverflowForControlSubAccount(
+                    self.category,
+                    self.control_index,
+                    self.control_sub_index,
+                ),
+            )
+        } else {
+            Ok(Self {
+                category: self.category,
+                control_index: self.control_index,
+                control_sub_index: self.control_sub_index,
+                index: next_index,
+            })
+        }
+    }
+
+    pub fn path_encode(&self, chart_id: ChartId) -> String {
+        format!("{}::{}", chart_id, self)
+    }
+
+    pub fn normal_balance_type(&self) -> DebitOrCredit {
+        match self.category {
+            ChartCategory::Assets | ChartCategory::Expenses => DebitOrCredit::Debit,
+            _ => DebitOrCredit::Credit,
+        }
+    }
+
+    pub fn control_account(&self) -> ControlAccountPath {
+        ControlAccountPath {
+            category: self.category,
+            index: self.control_index,
+        }
+    }
+
+    pub fn control_sub_account(&self) -> ControlSubAccountPath {
+        ControlSubAccountPath {
+            category: self.category,
+            control_index: self.control_index,
+            index: self.control_index,
         }
     }
 }
@@ -291,96 +251,38 @@ mod tests {
 
         #[test]
         fn test_category_formatting() {
-            let code = ChartCategory::Assets;
-            assert_eq!(code.to_string(), "10000000");
+            let path = ChartCategory::Assets;
+            assert_eq!(path.to_string(), "10000000");
         }
 
         #[test]
         fn test_control_account_formatting() {
-            let code = ChartPath::ControlAccount {
+            let path = ControlAccountPath {
                 category: ChartCategory::Liabilities,
                 index: 1.into(),
             };
-            assert_eq!(code.to_string(), "20100000");
+            assert_eq!(path.to_string(), "20100000");
         }
 
         #[test]
         fn test_control_sub_account_formatting() {
-            let code = ChartPath::ControlSubAccount {
+            let path = ControlSubAccountPath {
                 category: ChartCategory::Equity,
                 control_index: 1.into(),
                 index: 2.into(),
             };
-            assert_eq!(code.to_string(), "30102000");
+            assert_eq!(path.to_string(), "30102000");
         }
 
         #[test]
         fn test_transaction_account_formatting() {
-            let code = ChartPath::TransactionAccount {
+            let path = TransactionAccountPath {
                 category: ChartCategory::Revenues,
                 control_index: 1.into(),
                 control_sub_index: 2.into(),
                 index: 3.into(),
             };
-            assert_eq!(code.to_string(), "40102003");
-        }
-    }
-
-    mod category_extraction_tests {
-        use super::*;
-
-        #[test]
-        fn test_category_from_control_account() {
-            for category in [
-                ChartCategory::Assets,
-                ChartCategory::Liabilities,
-                ChartCategory::Equity,
-                ChartCategory::Revenues,
-                ChartCategory::Expenses,
-            ] {
-                let code = ChartPath::ControlAccount {
-                    category,
-                    index: 1.into(),
-                };
-                assert_eq!(code.category(), category);
-            }
-        }
-
-        #[test]
-        fn test_category_from_control_sub_account() {
-            for category in [
-                ChartCategory::Assets,
-                ChartCategory::Liabilities,
-                ChartCategory::Equity,
-                ChartCategory::Revenues,
-                ChartCategory::Expenses,
-            ] {
-                let code = ChartPath::ControlSubAccount {
-                    category,
-                    control_index: 1.into(),
-                    index: 2.into(),
-                };
-                assert_eq!(code.category(), category);
-            }
-        }
-
-        #[test]
-        fn test_category_from_transaction_account() {
-            for category in [
-                ChartCategory::Assets,
-                ChartCategory::Liabilities,
-                ChartCategory::Equity,
-                ChartCategory::Revenues,
-                ChartCategory::Expenses,
-            ] {
-                let code = ChartPath::TransactionAccount {
-                    category,
-                    control_index: 1.into(),
-                    control_sub_index: 2.into(),
-                    index: 3.into(),
-                };
-                assert_eq!(code.category(), category);
-            }
+            assert_eq!(path.to_string(), "40102003");
         }
     }
 
@@ -389,14 +291,14 @@ mod tests {
 
         const CATEGORY: ChartCategory = ChartCategory::Assets;
         const CONTROL_INDEX: AccountIdx = AccountIdx::FIRST;
-        const EXPECTED: ChartPath = ChartPath::ControlAccount {
+        const EXPECTED: ControlAccountPath = ControlAccountPath {
             category: CATEGORY,
             index: CONTROL_INDEX,
         };
 
         #[test]
         fn test_control_account_from_transaction_account() {
-            let transaction = ChartPath::TransactionAccount {
+            let transaction = TransactionAccountPath {
                 category: CATEGORY,
                 control_index: CONTROL_INDEX,
                 control_sub_index: 2.into(),
@@ -408,23 +310,13 @@ mod tests {
 
         #[test]
         fn test_control_account_from_control_sub_account() {
-            let sub_account = ChartPath::ControlSubAccount {
+            let sub_account = ControlSubAccountPath {
                 category: CATEGORY,
                 control_index: CONTROL_INDEX,
                 index: 2.into(),
             };
 
             assert_eq!(sub_account.control_account(), EXPECTED);
-        }
-
-        #[test]
-        fn test_control_account_from_control_account() {
-            let control_account = ChartPath::ControlAccount {
-                category: CATEGORY,
-                index: CONTROL_INDEX,
-            };
-
-            assert_eq!(control_account.control_account(), EXPECTED);
         }
     }
 
@@ -434,7 +326,7 @@ mod tests {
         const CATEGORY: ChartCategory = ChartCategory::Assets;
         const CONTROL_INDEX: AccountIdx = AccountIdx::FIRST;
         const SUB_INDEX: AccountIdx = AccountIdx::FIRST;
-        const EXPECTED: ChartPath = ChartPath::ControlSubAccount {
+        const EXPECTED: ControlSubAccountPath = ControlSubAccountPath {
             category: CATEGORY,
             control_index: CONTROL_INDEX,
             index: SUB_INDEX,
@@ -442,35 +334,14 @@ mod tests {
 
         #[test]
         fn test_control_sub_account_from_transaction_account() {
-            let transaction = ChartPath::TransactionAccount {
+            let transaction = TransactionAccountPath {
                 category: CATEGORY,
                 control_index: CONTROL_INDEX,
                 control_sub_index: SUB_INDEX,
                 index: 3.into(),
             };
 
-            assert_eq!(transaction.control_sub_account(), Some(EXPECTED));
-        }
-
-        #[test]
-        fn test_control_sub_account_from_control_sub_account() {
-            let sub_account = ChartPath::ControlSubAccount {
-                category: CATEGORY,
-                control_index: CONTROL_INDEX,
-                index: SUB_INDEX,
-            };
-
-            assert_eq!(sub_account.control_sub_account(), Some(EXPECTED));
-        }
-
-        #[test]
-        fn test_control_sub_account_from_control_account_returns_none() {
-            let control_account = ChartPath::ControlAccount {
-                category: CATEGORY,
-                index: CONTROL_INDEX,
-            };
-
-            assert_eq!(control_account.control_sub_account(), None);
+            assert_eq!(transaction.control_sub_account(), EXPECTED);
         }
     }
 
@@ -480,11 +351,11 @@ mod tests {
         #[test]
         fn test_first_control_account_creation() {
             let category = ChartCategory::Assets;
-            let control = ChartPath::first_control_account(category);
+            let control = category.first_control_account();
 
             assert_eq!(
                 control,
-                ChartPath::ControlAccount {
+                ControlAccountPath {
                     category: ChartCategory::Assets,
                     index: AccountIdx::FIRST,
                 }
@@ -493,15 +364,15 @@ mod tests {
 
         #[test]
         fn test_first_control_sub_account_creation() {
-            let control = ChartPath::ControlAccount {
+            let control_account = ControlAccountPath {
                 category: ChartCategory::Assets,
                 index: AccountIdx::FIRST,
             };
 
-            let sub = ChartPath::first_control_sub_account(&control).unwrap();
+            let sub = control_account.first_control_sub_account();
             assert_eq!(
                 sub,
-                ChartPath::ControlSubAccount {
+                ControlSubAccountPath {
                     category: ChartCategory::Assets,
                     control_index: AccountIdx::FIRST,
                     index: AccountIdx::FIRST,
@@ -510,42 +381,23 @@ mod tests {
         }
 
         #[test]
-        fn test_first_control_sub_account_invalid_input() {
-            let invalid_input = ChartPath::ControlSubAccount {
-                category: ChartCategory::Assets,
-                control_index: 1.into(),
-                index: 1.into(),
-            };
-            assert!(ChartPath::first_control_sub_account(&invalid_input).is_err());
-        }
-
-        #[test]
         fn test_first_transaction_account_creation() {
-            let sub = ChartPath::ControlSubAccount {
+            let sub_account = ControlSubAccountPath {
                 category: ChartCategory::Assets,
                 control_index: AccountIdx::FIRST,
                 index: AccountIdx::FIRST,
             };
 
-            let transaction = ChartPath::first_transaction_account(&sub).unwrap();
+            let transaction = sub_account.first_transaction_account();
             assert_eq!(
                 transaction,
-                ChartPath::TransactionAccount {
+                TransactionAccountPath {
                     category: ChartCategory::Assets,
                     control_index: AccountIdx::FIRST,
                     control_sub_index: AccountIdx::FIRST,
                     index: AccountIdx::FIRST,
                 }
             );
-        }
-
-        #[test]
-        fn test_first_transaction_account_invalid_input() {
-            let invalid_input = ChartPath::ControlAccount {
-                category: ChartCategory::Assets,
-                index: 1.into(),
-            };
-            assert!(ChartPath::first_transaction_account(&invalid_input).is_err());
         }
     }
 
@@ -554,15 +406,15 @@ mod tests {
 
         #[test]
         fn test_next_control_account_success() {
-            let control = ChartPath::ControlAccount {
+            let control_account = ControlAccountPath {
                 category: ChartCategory::Assets,
                 index: 1.into(),
             };
 
-            let next_control = control.next().unwrap();
+            let next_control = control_account.next().unwrap();
             assert_eq!(
                 next_control,
-                ChartPath::ControlAccount {
+                ControlAccountPath {
                     category: ChartCategory::Assets,
                     index: 2.into(),
                 }
@@ -571,7 +423,7 @@ mod tests {
 
         #[test]
         fn test_next_control_account_overflow() {
-            let max_control = ChartPath::ControlAccount {
+            let max_control = ControlAccountPath {
                 category: ChartCategory::Assets,
                 index: AccountIdx::MAX_TWO_DIGIT,
             };
@@ -580,7 +432,7 @@ mod tests {
 
         #[test]
         fn test_next_control_sub_account_success() {
-            let sub = ChartPath::ControlSubAccount {
+            let sub = ControlSubAccountPath {
                 category: ChartCategory::Assets,
                 control_index: 1.into(),
                 index: 1.into(),
@@ -589,7 +441,7 @@ mod tests {
             let next_sub = sub.next().unwrap();
             assert_eq!(
                 next_sub,
-                ChartPath::ControlSubAccount {
+                ControlSubAccountPath {
                     category: ChartCategory::Assets,
                     control_index: 1.into(),
                     index: 2.into(),
@@ -599,7 +451,7 @@ mod tests {
 
         #[test]
         fn test_next_control_sub_account_overflow() {
-            let max_sub = ChartPath::ControlSubAccount {
+            let max_sub = ControlSubAccountPath {
                 category: ChartCategory::Assets,
                 control_index: 1.into(),
                 index: AccountIdx::MAX_TWO_DIGIT,
@@ -609,7 +461,7 @@ mod tests {
 
         #[test]
         fn test_next_transaction_account_success() {
-            let transaction = ChartPath::TransactionAccount {
+            let transaction = TransactionAccountPath {
                 category: ChartCategory::Assets,
                 control_index: 1.into(),
                 control_sub_index: 1.into(),
@@ -619,7 +471,7 @@ mod tests {
             let next_transaction = transaction.next().unwrap();
             assert_eq!(
                 next_transaction,
-                ChartPath::TransactionAccount {
+                TransactionAccountPath {
                     category: ChartCategory::Assets,
                     control_index: 1.into(),
                     control_sub_index: 1.into(),
@@ -630,7 +482,7 @@ mod tests {
 
         #[test]
         fn test_next_transaction_account_overflow() {
-            let max_transaction = ChartPath::TransactionAccount {
+            let max_transaction = TransactionAccountPath {
                 category: ChartCategory::Assets,
                 control_index: 1.into(),
                 control_sub_index: 1.into(),

--- a/core/chart-of-accounts/src/path/mod.rs
+++ b/core/chart-of-accounts/src/path/mod.rs
@@ -298,7 +298,7 @@ mod tests {
         #[test]
         fn test_category_formatting() {
             let code = ChartPath::Category(ChartCategoryPath::Assets);
-            assert_eq!(code.to_string(), "1000000");
+            assert_eq!(code.to_string(), "10000000");
         }
 
         #[test]
@@ -307,7 +307,7 @@ mod tests {
                 category: ChartCategoryPath::Liabilities,
                 index: 1.into(),
             };
-            assert_eq!(code.to_string(), "2010000");
+            assert_eq!(code.to_string(), "20100000");
         }
 
         #[test]

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 pub use cala_ledger::{primitives::AccountId as LedgerAccountId, DebitOrCredit};
 
-pub use crate::path::{ChartCategoryPath as CategoryPath, ChartPath};
+pub use crate::path::{ChartCategory, ChartPath};
 
 es_entity::entity_id! {
     ChartId,

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 
 pub use cala_ledger::{primitives::AccountId as LedgerAccountId, DebitOrCredit};
 
-pub use crate::path::{ChartCategory, ChartPath};
+pub use crate::path::ChartCategory;
+use crate::path::{ControlSubAccountPath, TransactionAccountPath};
 
 es_entity::entity_id! {
     ChartId,
@@ -123,7 +124,7 @@ impl From<ChartAction> for CoreChartOfAccountsAction {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChartAccountDetails {
     pub account_id: LedgerAccountId,
-    pub path: ChartPath,
+    pub path: TransactionAccountPath,
     pub encoded_path: String,
     pub name: String,
     pub description: String,
@@ -131,7 +132,7 @@ pub struct ChartAccountDetails {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChartCreationDetails {
-    pub parent_path: ChartPath,
+    pub control_sub_account: ControlSubAccountPath,
     pub account_id: LedgerAccountId,
     pub name: String,
     pub description: String,

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -124,7 +124,7 @@ impl From<ChartAction> for CoreChartOfAccountsAction {
 pub struct ChartAccountDetails {
     pub account_id: LedgerAccountId,
     pub path: ChartPath,
-    pub code: String,
+    pub encoded_path: String,
     pub name: String,
     pub description: String,
 }

--- a/core/chart-of-accounts/src/transaction_account_factory.rs
+++ b/core/chart-of-accounts/src/transaction_account_factory.rs
@@ -4,7 +4,7 @@ use cala_ledger::{account::*, CalaLedger, LedgerOperation};
 use crate::{
     chart_of_accounts::ChartRepo,
     error::CoreChartOfAccountsError,
-    path::ChartPath,
+    path::ControlSubAccountPath,
     primitives::{ChartAccountDetails, ChartCreationDetails, ChartId, LedgerAccountId},
 };
 
@@ -13,7 +13,7 @@ pub struct TransactionAccountFactory {
     repo: ChartRepo,
     cala: CalaLedger,
     chart_id: ChartId,
-    control_sub_account: ChartPath,
+    control_sub_account: ControlSubAccountPath,
 }
 
 impl TransactionAccountFactory {
@@ -21,7 +21,7 @@ impl TransactionAccountFactory {
         repo: &ChartRepo,
         cala: &CalaLedger,
         chart_id: ChartId,
-        control_sub_account: ChartPath,
+        control_sub_account: ControlSubAccountPath,
     ) -> Self {
         Self {
             repo: repo.clone(),
@@ -47,7 +47,7 @@ impl TransactionAccountFactory {
         let account_details = chart.add_transaction_account(
             ChartCreationDetails {
                 account_id: account_id.into(),
-                parent_path: self.control_sub_account,
+                control_sub_account: self.control_sub_account,
                 name: name.to_string(),
                 description: description.to_string(),
             },

--- a/core/chart-of-accounts/src/transaction_account_factory.rs
+++ b/core/chart-of-accounts/src/transaction_account_factory.rs
@@ -60,7 +60,7 @@ impl TransactionAccountFactory {
             .id(account_details.account_id)
             .name(account_details.name.to_string())
             .description(account_details.description.to_string())
-            .code(account_details.code.to_string())
+            .code(account_details.encoded_path.to_string())
             .normal_balance_type(account_details.path.normal_balance_type())
             .build()
             .expect("Could not build new account");

--- a/core/chart-of-accounts/tests/chart_of_accounts.rs
+++ b/core/chart-of-accounts/tests/chart_of_accounts.rs
@@ -40,7 +40,7 @@ async fn create_and_populate() -> anyhow::Result<()> {
     let control_account_code = chart_of_accounts
         .create_control_account(
             chart_id,
-            CategoryPath::Assets,
+            ChartCategory::Assets,
             "Credit Facilities Receivable".to_string(),
             "credit-facilities-receivable".to_string(),
         )

--- a/core/chart-of-accounts/tests/chart_of_accounts.rs
+++ b/core/chart-of-accounts/tests/chart_of_accounts.rs
@@ -40,7 +40,7 @@ async fn create_and_populate() -> anyhow::Result<()> {
     let control_account_code = chart_of_accounts
         .create_control_account(
             chart_id,
-            "10000000".parse()?,
+            ChartPath::Category(CategoryPath::Assets),
             "Credit Facilities Receivable".to_string(),
             "credit-facilities-receivable".to_string(),
         )

--- a/core/chart-of-accounts/tests/chart_of_accounts.rs
+++ b/core/chart-of-accounts/tests/chart_of_accounts.rs
@@ -40,7 +40,7 @@ async fn create_and_populate() -> anyhow::Result<()> {
     let control_account_code = chart_of_accounts
         .create_control_account(
             chart_id,
-            ChartPath::Category(CategoryPath::Assets),
+            CategoryPath::Assets,
             "Credit Facilities Receivable".to_string(),
             "credit-facilities-receivable".to_string(),
         )
@@ -57,7 +57,7 @@ async fn create_and_populate() -> anyhow::Result<()> {
         .await?;
     assert_eq!(
         control_sub_account_code.control_account(),
-        Some(control_account_code)
+        control_account_code
     );
 
     Ok(())

--- a/core/deposit/src/ledger/mod.rs
+++ b/core/deposit/src/ledger/mod.rs
@@ -147,10 +147,10 @@ impl DepositLedger {
 
     async fn create_deposit_omnibus_account(
         cala: &CalaLedger,
-        code: String,
+        encoded_path: String,
     ) -> Result<AccountId, DepositLedgerError> {
         let new_account = NewAccount::builder()
-            .code(&code)
+            .code(&encoded_path)
             .id(AccountId::new())
             .name("Deposit Omnibus Account")
             .description("Omnibus Account for Deposit module")
@@ -159,7 +159,7 @@ impl DepositLedger {
             .expect("Couldn't create onchain incoming account");
         match cala.accounts().create(new_account).await {
             Err(AccountError::CodeAlreadyExists) => {
-                let account = cala.accounts().find_by_code(code).await?;
+                let account = cala.accounts().find_by_code(encoded_path).await?;
                 Ok(account.id)
             }
             Err(e) => Err(e.into()),

--- a/core/deposit/tests/deposit.rs
+++ b/core/deposit/tests/deposit.rs
@@ -4,7 +4,7 @@ use rust_decimal_macros::dec;
 
 use authz::dummy::DummySubject;
 use cala_ledger::{CalaLedger, CalaLedgerConfig};
-use chart_of_accounts::{CategoryPath, ChartPath, CoreChartOfAccounts};
+use chart_of_accounts::{CategoryPath, CoreChartOfAccounts};
 use deposit::*;
 use helpers::{action, event, object};
 
@@ -41,7 +41,7 @@ async fn deposit() -> anyhow::Result<()> {
     let control_account_path = chart_of_accounts
         .create_control_account(
             chart_id,
-            ChartPath::Category(CategoryPath::Liabilities),
+            CategoryPath::Liabilities,
             "Deposits".to_string(),
             "deposits".to_string(),
         )

--- a/core/deposit/tests/deposit.rs
+++ b/core/deposit/tests/deposit.rs
@@ -4,7 +4,7 @@ use rust_decimal_macros::dec;
 
 use authz::dummy::DummySubject;
 use cala_ledger::{CalaLedger, CalaLedgerConfig};
-use chart_of_accounts::{CategoryPath, CoreChartOfAccounts};
+use chart_of_accounts::{ChartCategory, CoreChartOfAccounts};
 use deposit::*;
 use helpers::{action, event, object};
 
@@ -41,7 +41,7 @@ async fn deposit() -> anyhow::Result<()> {
     let control_account_path = chart_of_accounts
         .create_control_account(
             chart_id,
-            CategoryPath::Liabilities,
+            ChartCategory::Liabilities,
             "Deposits".to_string(),
             "deposits".to_string(),
         )

--- a/core/deposit/tests/withdraw.rs
+++ b/core/deposit/tests/withdraw.rs
@@ -4,7 +4,7 @@ use rust_decimal_macros::dec;
 
 use authz::dummy::DummySubject;
 use cala_ledger::{CalaLedger, CalaLedgerConfig};
-use chart_of_accounts::{CategoryPath, ChartPath, CoreChartOfAccounts};
+use chart_of_accounts::{CategoryPath, CoreChartOfAccounts};
 use deposit::*;
 
 use helpers::{action, event, object};
@@ -42,7 +42,7 @@ async fn cancel_withdrawal() -> anyhow::Result<()> {
     let control_account_path = chart_of_accounts
         .create_control_account(
             chart_id,
-            ChartPath::Category(CategoryPath::Liabilities),
+            CategoryPath::Liabilities,
             "Deposits".to_string(),
             "deposits".to_string(),
         )

--- a/core/deposit/tests/withdraw.rs
+++ b/core/deposit/tests/withdraw.rs
@@ -4,7 +4,7 @@ use rust_decimal_macros::dec;
 
 use authz::dummy::DummySubject;
 use cala_ledger::{CalaLedger, CalaLedgerConfig};
-use chart_of_accounts::{CategoryPath, CoreChartOfAccounts};
+use chart_of_accounts::{ChartCategory, CoreChartOfAccounts};
 use deposit::*;
 
 use helpers::{action, event, object};
@@ -42,7 +42,7 @@ async fn cancel_withdrawal() -> anyhow::Result<()> {
     let control_account_path = chart_of_accounts
         .create_control_account(
             chart_id,
-            CategoryPath::Liabilities,
+            ChartCategory::Liabilities,
             "Deposits".to_string(),
             "deposits".to_string(),
         )

--- a/lana/app/src/accounting_init/mod.rs
+++ b/lana/app/src/accounting_init/mod.rs
@@ -4,7 +4,7 @@ mod seed;
 
 pub mod error;
 
-use chart_of_accounts::{ChartId, ChartPath};
+use chart_of_accounts::{ChartId, ControlSubAccountPath};
 
 use crate::chart_of_accounts::ChartOfAccounts;
 

--- a/lana/app/src/accounting_init/primitives.rs
+++ b/lana/app/src/accounting_init/primitives.rs
@@ -1,4 +1,4 @@
-use chart_of_accounts::{ChartId, ChartPath};
+use chart_of_accounts::{ChartId, ControlSubAccountPath};
 
 #[derive(Clone, Copy)]
 pub struct ChartIds {
@@ -8,15 +8,15 @@ pub struct ChartIds {
 
 #[derive(Clone)]
 pub struct DepositsAccountPaths {
-    pub deposits: ChartPath,
+    pub deposits: ControlSubAccountPath,
 }
 
 #[derive(Clone)]
 pub struct CreditFacilitiesAccountPaths {
-    pub collateral: ChartPath,
-    pub facility: ChartPath,
-    pub disbursed_receivable: ChartPath,
-    pub interest_receivable: ChartPath,
-    pub interest_income: ChartPath,
-    pub fee_income: ChartPath,
+    pub collateral: ControlSubAccountPath,
+    pub facility: ControlSubAccountPath,
+    pub disbursed_receivable: ControlSubAccountPath,
+    pub interest_receivable: ControlSubAccountPath,
+    pub interest_income: ControlSubAccountPath,
+    pub fee_income: ControlSubAccountPath,
 }

--- a/lana/app/src/accounting_init/seed.rs
+++ b/lana/app/src/accounting_init/seed.rs
@@ -1,4 +1,4 @@
-use chart_of_accounts::CategoryPath;
+use chart_of_accounts::ChartCategory;
 
 use super::{constants::*, *};
 
@@ -82,7 +82,7 @@ async fn create_charts_of_accounts(
 async fn create_control_sub_account(
     chart_of_accounts: &ChartOfAccounts,
     chart_id: ChartId,
-    category: CategoryPath,
+    category: ChartCategory,
     control_name: String,
     control_reference: String,
     sub_name: String,
@@ -122,7 +122,7 @@ async fn create_deposits_account_paths(
     let deposits = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        chart_of_accounts::CategoryPath::Liabilities,
+        chart_of_accounts::ChartCategory::Liabilities,
         DEPOSITS_CONTROL_ACCOUNT_NAME.to_string(),
         DEPOSITS_CONTROL_ACCOUNT_REF.to_string(),
         DEPOSITS_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -140,7 +140,7 @@ async fn create_credit_facilities_account_paths(
     let collateral = create_control_sub_account(
         chart_of_accounts,
         chart_ids.off_balance_sheet,
-        chart_of_accounts::CategoryPath::Liabilities,
+        chart_of_accounts::ChartCategory::Liabilities,
         CREDIT_FACILITIES_COLLATERAL_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_COLLATERAL_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_COLLATERAL_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -151,7 +151,7 @@ async fn create_credit_facilities_account_paths(
     let facility = create_control_sub_account(
         chart_of_accounts,
         chart_ids.off_balance_sheet,
-        chart_of_accounts::CategoryPath::Assets,
+        chart_of_accounts::ChartCategory::Assets,
         CREDIT_FACILITIES_FACILITY_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_FACILITY_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_FACILITY_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -162,7 +162,7 @@ async fn create_credit_facilities_account_paths(
     let disbursed_receivable = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        chart_of_accounts::CategoryPath::Assets,
+        chart_of_accounts::ChartCategory::Assets,
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -173,7 +173,7 @@ async fn create_credit_facilities_account_paths(
     let interest_receivable = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        chart_of_accounts::CategoryPath::Assets,
+        chart_of_accounts::ChartCategory::Assets,
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -184,7 +184,7 @@ async fn create_credit_facilities_account_paths(
     let interest_income = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        chart_of_accounts::CategoryPath::Revenues,
+        chart_of_accounts::ChartCategory::Revenues,
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -195,7 +195,7 @@ async fn create_credit_facilities_account_paths(
     let fee_income = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        chart_of_accounts::CategoryPath::Revenues,
+        chart_of_accounts::ChartCategory::Revenues,
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_SUB_ACCOUNT_NAME.to_string(),

--- a/lana/app/src/accounting_init/seed.rs
+++ b/lana/app/src/accounting_init/seed.rs
@@ -87,7 +87,7 @@ async fn create_control_sub_account(
     control_reference: String,
     sub_name: String,
     sub_reference: String,
-) -> Result<ChartPath, AccountingInitError> {
+) -> Result<ControlSubAccountPath, AccountingInitError> {
     let control_path = match chart_of_accounts
         .find_control_account_by_reference(chart_id, control_reference.clone())
         .await?

--- a/lana/app/src/accounting_init/seed.rs
+++ b/lana/app/src/accounting_init/seed.rs
@@ -1,3 +1,5 @@
+use chart_of_accounts::CategoryPath;
+
 use super::{constants::*, *};
 
 pub(super) async fn execute(
@@ -80,7 +82,7 @@ async fn create_charts_of_accounts(
 async fn create_control_sub_account(
     chart_of_accounts: &ChartOfAccounts,
     chart_id: ChartId,
-    category: ChartPath,
+    category: CategoryPath,
     control_name: String,
     control_reference: String,
     sub_name: String,
@@ -120,7 +122,7 @@ async fn create_deposits_account_paths(
     let deposits = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Liabilities),
+        chart_of_accounts::CategoryPath::Liabilities,
         DEPOSITS_CONTROL_ACCOUNT_NAME.to_string(),
         DEPOSITS_CONTROL_ACCOUNT_REF.to_string(),
         DEPOSITS_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -138,7 +140,7 @@ async fn create_credit_facilities_account_paths(
     let collateral = create_control_sub_account(
         chart_of_accounts,
         chart_ids.off_balance_sheet,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Liabilities),
+        chart_of_accounts::CategoryPath::Liabilities,
         CREDIT_FACILITIES_COLLATERAL_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_COLLATERAL_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_COLLATERAL_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -149,7 +151,7 @@ async fn create_credit_facilities_account_paths(
     let facility = create_control_sub_account(
         chart_of_accounts,
         chart_ids.off_balance_sheet,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Assets),
+        chart_of_accounts::CategoryPath::Assets,
         CREDIT_FACILITIES_FACILITY_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_FACILITY_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_FACILITY_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -160,7 +162,7 @@ async fn create_credit_facilities_account_paths(
     let disbursed_receivable = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Assets),
+        chart_of_accounts::CategoryPath::Assets,
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -171,7 +173,7 @@ async fn create_credit_facilities_account_paths(
     let interest_receivable = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Assets),
+        chart_of_accounts::CategoryPath::Assets,
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -182,7 +184,7 @@ async fn create_credit_facilities_account_paths(
     let interest_income = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Revenues),
+        chart_of_accounts::CategoryPath::Revenues,
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_SUB_ACCOUNT_NAME.to_string(),
@@ -193,7 +195,7 @@ async fn create_credit_facilities_account_paths(
     let fee_income = create_control_sub_account(
         chart_of_accounts,
         chart_ids.primary,
-        ChartPath::Category(chart_of_accounts::CategoryPath::Revenues),
+        chart_of_accounts::CategoryPath::Revenues,
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_ACCOUNT_NAME.to_string(),
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_ACCOUNT_REF.to_string(),
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_SUB_ACCOUNT_NAME.to_string(),

--- a/lana/app/src/credit_facility/ledger/mod.rs
+++ b/lana/app/src/credit_facility/ledger/mod.rs
@@ -377,10 +377,10 @@ impl CreditLedger {
 
     async fn create_bank_collateral_account(
         cala: &CalaLedger,
-        code: String,
+        encoded_path: String,
     ) -> Result<AccountId, CreditLedgerError> {
         let new_account = NewAccount::builder()
-            .code(&code)
+            .code(&encoded_path)
             .id(AccountId::new())
             .name("Bank collateral account")
             .description("Bank collateral account")
@@ -389,7 +389,7 @@ impl CreditLedger {
             .expect("Couldn't create onchain incoming account");
         match cala.accounts().create(new_account).await {
             Err(AccountError::CodeAlreadyExists) => {
-                let account = cala.accounts().find_by_code(code).await?;
+                let account = cala.accounts().find_by_code(encoded_path).await?;
                 Ok(account.id)
             }
             Err(e) => Err(e.into()),
@@ -399,10 +399,10 @@ impl CreditLedger {
 
     async fn create_credit_omnibus_account(
         cala: &CalaLedger,
-        code: String,
+        encoded_path: String,
     ) -> Result<AccountId, CreditLedgerError> {
         let new_account = NewAccount::builder()
-            .code(&code)
+            .code(&encoded_path)
             .id(AccountId::new())
             .name("Credit Omnibus Account")
             .description("Omnibus Account for Credit module")
@@ -411,7 +411,7 @@ impl CreditLedger {
             .expect("Couldn't create credit omnibus account");
         match cala.accounts().create(new_account).await {
             Err(AccountError::CodeAlreadyExists) => {
-                let account = cala.accounts().find_by_code(code).await?;
+                let account = cala.accounts().find_by_code(encoded_path).await?;
                 Ok(account.id)
             }
             Err(e) => Err(e.into()),


### PR DESCRIPTION
## Description

This PR is to:
- rename 'code' concept to 'path'
- remove 'decoding' of stringified path and instead store as value in `Path` type
- separate `Category` from `Path` type (and refactor `index` on category)
- break up `ChartPath` enum into separate structs