### PR TITLE
chore: remove chart transaction account

### DIFF
--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -10,7 +10,7 @@ use crate::{
     primitives::{
         ChartAccountDetails, ChartCreationDetails, ChartId, LedgerAccountId, LedgerAccountSetId,
     },
-    NewChartAccountDetails,
+    ControlSubAccountDetails,
 };
 
 pub use super::error::*;
@@ -136,11 +136,20 @@ impl Chart {
     pub fn find_control_sub_account_by_reference(
         &self,
         reference_to_check: String,
-    ) -> Option<ControlSubAccountPath> {
+    ) -> Option<ControlSubAccountDetails> {
         self.events.iter_all().rev().find_map(|event| match event {
             ChartEvent::ControlSubAccountAdded {
-                path, reference, ..
-            } if reference_to_check == *reference => Some(*path),
+                path,
+                id: account_set_id,
+                name,
+                reference,
+                ..
+            } if reference_to_check == *reference => Some(ControlSubAccountDetails {
+                path: *path,
+                account_set_id: *account_set_id,
+                name: name.to_string(),
+                reference: reference.to_string(),
+            }),
             _ => None,
         })
     }
@@ -152,7 +161,7 @@ impl Chart {
         name: String,
         reference: String,
         audit_info: AuditInfo,
-    ) -> Result<NewChartAccountDetails, ChartError> {
+    ) -> Result<ControlSubAccountDetails, ChartError> {
         if self
             .find_control_sub_account_by_reference(reference.to_string())
             .is_some()
@@ -170,7 +179,7 @@ impl Chart {
             audit_info,
         });
 
-        Ok(NewChartAccountDetails {
+        Ok(ControlSubAccountDetails {
             path,
             account_set_id: id,
             name,
@@ -371,7 +380,7 @@ mod tests {
             )
             .unwrap();
 
-        let NewChartAccountDetails {
+        let ControlSubAccountDetails {
             path:
                 ControlSubAccountPath {
                     category,
@@ -527,7 +536,7 @@ mod tests {
             )
             .unwrap();
 
-        let NewChartAccountDetails {
+        let ControlSubAccountDetails {
             path:
                 ControlSubAccountPath {
                     category,

--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -7,7 +7,9 @@ use es_entity::*;
 
 use crate::{
     path::*,
-    primitives::{ChartAccountDetails, ChartCreationDetails, ChartId, LedgerAccountId},
+    primitives::{
+        ChartAccountDetails, ChartCreationDetails, ChartId, LedgerAccountId, LedgerAccountSetId,
+    },
 };
 
 pub use super::error::*;
@@ -29,6 +31,7 @@ pub enum ChartEvent {
         audit_info: AuditInfo,
     },
     ControlSubAccountAdded {
+        id: LedgerAccountSetId,
         encoded_path: String,
         path: ControlSubAccountPath,
         name: String,
@@ -143,6 +146,7 @@ impl Chart {
 
     pub fn create_control_sub_account(
         &mut self,
+        id: LedgerAccountSetId,
         control_account: ControlAccountPath,
         name: String,
         reference: String,
@@ -157,6 +161,7 @@ impl Chart {
 
         let path = self.next_control_sub_account(control_account)?;
         self.events.push(ChartEvent::ControlSubAccountAdded {
+            id,
             encoded_path: path.path_encode(self.id),
             path,
             name,
@@ -366,6 +371,7 @@ mod tests {
             index,
         } = chart
             .create_control_sub_account(
+                LedgerAccountSetId::new(),
                 control_account,
                 "Current Assets".to_string(),
                 "current-assets".to_string(),
@@ -390,6 +396,7 @@ mod tests {
             .unwrap();
         chart
             .create_control_sub_account(
+                LedgerAccountSetId::new(),
                 control_account,
                 "Current Assets #1".to_string(),
                 "current-assets".to_string(),
@@ -398,6 +405,7 @@ mod tests {
             .unwrap();
 
         match chart.create_control_sub_account(
+            LedgerAccountSetId::new(),
             control_account,
             "Current Assets #2".to_string(),
             "current-assets".to_string(),
@@ -428,6 +436,7 @@ mod tests {
             .unwrap();
         let control_sub_account = chart
             .create_control_sub_account(
+                LedgerAccountSetId::new(),
                 control_account,
                 "Current Assets".to_string(),
                 "current-assets".to_string(),
@@ -500,6 +509,7 @@ mod tests {
 
         chart
             .create_control_sub_account(
+                LedgerAccountSetId::new(),
                 control_account,
                 "First".to_string(),
                 "first-asset".to_string(),
@@ -513,6 +523,7 @@ mod tests {
             index,
         } = chart
             .create_control_sub_account(
+                LedgerAccountSetId::new(),
                 control_account,
                 "Second".to_string(),
                 "second-asset".to_string(),
@@ -537,6 +548,7 @@ mod tests {
             .unwrap();
         let control_sub_account = chart
             .create_control_sub_account(
+                LedgerAccountSetId::new(),
                 control_account,
                 "Current Assets".to_string(),
                 "current-assets".to_string(),

--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -10,6 +10,7 @@ use crate::{
     primitives::{
         ChartAccountDetails, ChartCreationDetails, ChartId, LedgerAccountId, LedgerAccountSetId,
     },
+    NewChartAccountDetails,
 };
 
 pub use super::error::*;
@@ -151,7 +152,7 @@ impl Chart {
         name: String,
         reference: String,
         audit_info: AuditInfo,
-    ) -> Result<ControlSubAccountPath, ChartError> {
+    ) -> Result<NewChartAccountDetails, ChartError> {
         if self
             .find_control_sub_account_by_reference(reference.to_string())
             .is_some()
@@ -164,12 +165,17 @@ impl Chart {
             id,
             encoded_path: path.path_encode(self.id),
             path,
-            name,
-            reference,
+            name: name.to_string(),
+            reference: reference.to_string(),
             audit_info,
         });
 
-        Ok(path)
+        Ok(NewChartAccountDetails {
+            path,
+            account_set_id: id,
+            name,
+            reference,
+        })
     }
 
     fn next_transaction_account(
@@ -365,10 +371,14 @@ mod tests {
             )
             .unwrap();
 
-        let ControlSubAccountPath {
-            category,
-            control_index,
-            index,
+        let NewChartAccountDetails {
+            path:
+                ControlSubAccountPath {
+                    category,
+                    control_index,
+                    index,
+                },
+            ..
         } = chart
             .create_control_sub_account(
                 LedgerAccountSetId::new(),
@@ -457,7 +467,7 @@ mod tests {
             .add_transaction_account(
                 ChartCreationDetails {
                     account_id: LedgerAccountId::new(),
-                    control_sub_account,
+                    control_sub_account: control_sub_account.path,
                     name: "Cash".to_string(),
                     description: "Cash account".to_string(),
                 },
@@ -517,10 +527,14 @@ mod tests {
             )
             .unwrap();
 
-        let ControlSubAccountPath {
-            category,
-            control_index,
-            index,
+        let NewChartAccountDetails {
+            path:
+                ControlSubAccountPath {
+                    category,
+                    control_index,
+                    index,
+                },
+            ..
         } = chart
             .create_control_sub_account(
                 LedgerAccountSetId::new(),
@@ -560,7 +574,7 @@ mod tests {
             .add_transaction_account(
                 ChartCreationDetails {
                     account_id: LedgerAccountId::new(),
-                    control_sub_account,
+                    control_sub_account: control_sub_account.path,
                     name: "First".to_string(),
                     description: "First transaction account".to_string(),
                 },
@@ -581,7 +595,7 @@ mod tests {
             .add_transaction_account(
                 ChartCreationDetails {
                     account_id: LedgerAccountId::new(),
-                    control_sub_account,
+                    control_sub_account: control_sub_account.path,
                     name: "Second".to_string(),
                     description: "Second transaction account".to_string(),
                 },

--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -211,29 +211,6 @@ impl Chart {
             description: creation_details.description,
         })
     }
-
-    pub fn find_account_by_encoded_path(
-        &self,
-        encoded_path: String,
-    ) -> Option<ChartAccountDetails> {
-        self.events.iter_all().rev().find_map(|event| match event {
-            ChartEvent::TransactionAccountAdded {
-                id,
-                encoded_path: encoded_path_from_event,
-                path,
-                name,
-                description,
-                ..
-            } if *encoded_path_from_event == encoded_path => Some(ChartAccountDetails {
-                account_id: *id,
-                path: *path,
-                encoded_path: encoded_path_from_event.to_string(),
-                name: name.to_string(),
-                description: description.to_string(),
-            }),
-            _ => None,
-        })
-    }
 }
 
 impl TryFromEvents<ChartEvent> for Chart {
@@ -603,50 +580,5 @@ mod tests {
         assert_eq!(control_index, AccountIdx::FIRST);
         assert_eq!(control_sub_index, AccountIdx::FIRST);
         assert_eq!(index, AccountIdx::FIRST.next());
-    }
-
-    #[test]
-    fn test_find_account() {
-        let mut chart = init_chart_of_events();
-        let audit_info = dummy_audit_info();
-
-        let category = ChartCategory::Assets;
-        let control_account = chart
-            .create_control_account(
-                category,
-                "Assets".to_string(),
-                "assets".to_string(),
-                audit_info.clone(),
-            )
-            .unwrap();
-        let control_sub_account = chart
-            .create_control_sub_account(
-                control_account,
-                "Current Assets".to_string(),
-                "current-assets".to_string(),
-                audit_info.clone(),
-            )
-            .unwrap();
-        let transaction_account = chart
-            .add_transaction_account(
-                ChartCreationDetails {
-                    account_id: LedgerAccountId::new(),
-                    control_sub_account,
-                    name: "Cash".to_string(),
-                    description: "Cash account".to_string(),
-                },
-                audit_info,
-            )
-            .unwrap();
-
-        let found = chart
-            .find_account_by_encoded_path(transaction_account.encoded_path)
-            .unwrap();
-        assert_eq!(found.path, transaction_account.path);
-        assert_eq!(found.name, "Cash");
-
-        assert!(chart
-            .find_account_by_encoded_path("20101001".to_string())
-            .is_none());
     }
 }

--- a/core/chart-of-accounts/src/error.rs
+++ b/core/chart-of-accounts/src/error.rs
@@ -12,4 +12,6 @@ pub enum CoreChartOfAccountsError {
     AuditError(#[from] audit::error::AuditError),
     #[error("CoreChartOfAccountsError - CalaAccountError: {0}")]
     CalaAccount(#[from] cala_ledger::account::error::AccountError),
+    #[error("CoreChartOfAccountsError - CalaAccountSetError: {0}")]
+    CalaAccountSet(#[from] cala_ledger::account_set::error::AccountSetError),
 }

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -261,27 +261,4 @@ where
 
         Ok(path)
     }
-
-    #[instrument(name = "chart_of_accounts.find_account_in_chart", skip(self))]
-    pub async fn find_account_in_chart(
-        &self,
-        sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
-        chart_id: impl Into<ChartId> + std::fmt::Debug,
-        encoded_path: String,
-    ) -> Result<Option<ChartAccountDetails>, CoreChartOfAccountsError> {
-        let chart_id = chart_id.into();
-        self.authz
-            .enforce_permission(
-                sub,
-                CoreChartOfAccountsObject::chart(chart_id),
-                CoreChartOfAccountsAction::CHART_FIND_TRANSACTION_ACCOUNT,
-            )
-            .await?;
-
-        let chart = self.repo.find_by_id(chart_id).await?;
-
-        let account_details = chart.find_account_by_encoded_path(encoded_path);
-
-        Ok(account_details)
-    }
 }

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -69,7 +69,7 @@ where
     pub fn transaction_account_factory(
         &self,
         chart_id: ChartId,
-        control_sub_account: ControlSubAccountPath,
+        control_sub_account: ControlSubAccountDetails,
     ) -> TransactionAccountFactory {
         TransactionAccountFactory::new(&self.repo, &self.cala, chart_id, control_sub_account)
     }
@@ -213,7 +213,7 @@ where
         &self,
         chart_id: impl Into<ChartId>,
         reference: String,
-    ) -> Result<Option<ControlSubAccountPath>, CoreChartOfAccountsError> {
+    ) -> Result<Option<ControlSubAccountDetails>, CoreChartOfAccountsError> {
         let chart_id = chart_id.into();
 
         let mut op = self.repo.begin_op().await?;
@@ -239,7 +239,7 @@ where
         control_account: ControlAccountPath,
         name: String,
         reference: String,
-    ) -> Result<ControlSubAccountPath, CoreChartOfAccountsError> {
+    ) -> Result<ControlSubAccountDetails, CoreChartOfAccountsError> {
         let id = id.into();
         let chart_id = chart_id.into();
 
@@ -279,6 +279,6 @@ where
 
         op.commit().await?;
 
-        Ok(account_set_details.path)
+        Ok(account_set_details)
     }
 }

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -27,6 +27,7 @@ where
     repo: ChartRepo,
     cala: CalaLedger,
     authz: Perms,
+    journal_id: LedgerJournalId,
 }
 
 impl<Perms> Clone for CoreChartOfAccounts<Perms>
@@ -38,6 +39,7 @@ where
             repo: self.repo.clone(),
             cala: self.cala.clone(),
             authz: self.authz.clone(),
+            journal_id: self.journal_id,
         }
     }
 }
@@ -52,12 +54,14 @@ where
         pool: &sqlx::PgPool,
         authz: &Perms,
         cala: &CalaLedger,
+        journal_id: LedgerJournalId,
     ) -> Result<Self, CoreChartOfAccountsError> {
         let chart_of_account = ChartRepo::new(pool);
         let res = Self {
             repo: chart_of_account,
             cala: cala.clone(),
             authz: authz.clone(),
+            journal_id,
         };
         Ok(res)
     }
@@ -262,6 +266,7 @@ where
         let mut op = self.cala.ledger_operation_from_db_op(op);
         let new_account_set = NewAccountSet::builder()
             .id(account_set_details.account_set_id)
+            .journal_id(self.journal_id)
             .name(account_set_details.name.to_string())
             .description(account_set_details.name.to_string())
             .normal_balance_type(account_set_details.path.normal_balance_type())

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -230,11 +230,13 @@ where
 
     pub async fn create_control_sub_account(
         &self,
+        id: impl Into<LedgerAccountSetId> + std::fmt::Debug,
         chart_id: impl Into<ChartId> + std::fmt::Debug,
         control_account: ControlAccountPath,
         name: String,
         reference: String,
     ) -> Result<ControlSubAccountPath, CoreChartOfAccountsError> {
+        let id = id.into();
         let chart_id = chart_id.into();
 
         let mut op = self.repo.begin_op().await?;
@@ -252,7 +254,7 @@ where
         let mut chart = self.repo.find_by_id(chart_id).await?;
 
         let path =
-            chart.create_control_sub_account(control_account, name, reference, audit_info)?;
+            chart.create_control_sub_account(id, control_account, name, reference, audit_info)?;
 
         let mut op = self.repo.begin_op().await?;
         self.repo.update_in_op(&mut op, &mut chart).await?;

--- a/core/chart-of-accounts/src/path/error.rs
+++ b/core/chart-of-accounts/src/path/error.rs
@@ -10,8 +10,6 @@ pub enum ChartPathError {
     InvalidCategoryForNewControlAccount,
     #[error("ChartError - InvalidControlAccountPathForNewControlSubAccount")]
     InvalidControlAccountPathForNewControlSubAccount,
-    #[error("ChartError - InvalidSubControlAccountPathForNewTransactionAccount")]
-    InvalidSubControlAccountPathForNewTransactionAccount,
     #[error("ChartError - ControlIndexOverflowForCategory: Category '{0}'")]
     ControlIndexOverflowForCategory(ChartCategory),
     #[error(

--- a/core/chart-of-accounts/src/path/mod.rs
+++ b/core/chart-of-accounts/src/path/mod.rs
@@ -153,6 +153,13 @@ impl ControlSubAccountPath {
         format!("{}::{}", chart_id, self)
     }
 
+    pub fn normal_balance_type(&self) -> DebitOrCredit {
+        match self.category {
+            ChartCategory::Assets | ChartCategory::Expenses => DebitOrCredit::Debit,
+            _ => DebitOrCredit::Credit,
+        }
+    }
+
     pub fn control_account(&self) -> ControlAccountPath {
         ControlAccountPath {
             category: self.category,

--- a/core/chart-of-accounts/src/path/mod.rs
+++ b/core/chart-of-accounts/src/path/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::primitives::{ChartId, DebitOrCredit};
 use error::*;
 
-const ENCODED_PATH_WIDTH: usize = 8;
+const ENCODED_PATH_WIDTH: usize = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
 pub struct AccountIdx(u64);
@@ -25,7 +25,6 @@ impl From<u32> for AccountIdx {
 impl AccountIdx {
     pub const FIRST: Self = Self(1);
     pub const MAX_TWO_DIGIT: Self = Self(99);
-    pub const MAX_THREE_DIGIT: Self = Self(999);
 
     pub const fn next(&self) -> Self {
         Self(self.0 + 1)
@@ -178,7 +177,7 @@ mod tests {
         #[test]
         fn test_category_formatting() {
             let path = ChartCategory::Assets;
-            assert_eq!(path.to_string(), "10000000");
+            assert_eq!(path.to_string(), "10000");
         }
 
         #[test]
@@ -187,7 +186,7 @@ mod tests {
                 category: ChartCategory::Liabilities,
                 index: 1.into(),
             };
-            assert_eq!(path.to_string(), "20100000");
+            assert_eq!(path.to_string(), "20100");
         }
 
         #[test]
@@ -197,7 +196,7 @@ mod tests {
                 control_index: 1.into(),
                 index: 2.into(),
             };
-            assert_eq!(path.to_string(), "30102000");
+            assert_eq!(path.to_string(), "30102");
         }
     }
 

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -3,7 +3,10 @@ use std::{fmt::Display, str::FromStr};
 use authz::AllOrOne;
 use serde::{Deserialize, Serialize};
 
-pub use cala_ledger::{primitives::AccountId as LedgerAccountId, DebitOrCredit};
+pub use cala_ledger::{
+    primitives::AccountId as LedgerAccountId, primitives::AccountSetId as LedgerAccountSetId,
+    DebitOrCredit,
+};
 
 pub use crate::path::ChartCategory;
 use crate::path::{ControlSubAccountPath, TransactionAccountPath};

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -140,3 +140,11 @@ pub struct ChartCreationDetails {
     pub name: String,
     pub description: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewChartAccountDetails {
+    pub path: ControlSubAccountPath,
+    pub account_set_id: LedgerAccountSetId,
+    pub name: String,
+    pub reference: String,
+}

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 pub use cala_ledger::{
     primitives::AccountId as LedgerAccountId, primitives::AccountSetId as LedgerAccountSetId,
-    DebitOrCredit,
+    primitives::JournalId as LedgerJournalId, DebitOrCredit,
 };
 
 pub use crate::path::ChartCategory;

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -142,7 +142,7 @@ pub struct ChartCreationDetails {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NewChartAccountDetails {
+pub struct ControlSubAccountDetails {
     pub path: ControlSubAccountPath,
     pub account_set_id: LedgerAccountSetId,
     pub name: String,

--- a/core/chart-of-accounts/src/primitives.rs
+++ b/core/chart-of-accounts/src/primitives.rs
@@ -9,7 +9,7 @@ pub use cala_ledger::{
 };
 
 pub use crate::path::ChartCategory;
-use crate::path::{ControlSubAccountPath, TransactionAccountPath};
+use crate::path::ControlSubAccountPath;
 
 es_entity::entity_id! {
     ChartId,
@@ -78,8 +78,6 @@ impl CoreChartOfAccountsAction {
         CoreChartOfAccountsAction::ChartAction(ChartAction::CreateControlSubAccount);
     pub const CHART_FIND_CONTROL_SUB_ACCOUNT: Self =
         CoreChartOfAccountsAction::ChartAction(ChartAction::FindControlSubAccount);
-    pub const CHART_FIND_TRANSACTION_ACCOUNT: Self =
-        CoreChartOfAccountsAction::ChartAction(ChartAction::FindTransactionAccount);
 }
 
 impl Display for CoreChartOfAccountsAction {
@@ -115,7 +113,6 @@ pub enum ChartAction {
     FindControlAccount,
     CreateControlSubAccount,
     FindControlSubAccount,
-    FindTransactionAccount,
 }
 
 impl From<ChartAction> for CoreChartOfAccountsAction {
@@ -127,7 +124,6 @@ impl From<ChartAction> for CoreChartOfAccountsAction {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChartAccountDetails {
     pub account_id: LedgerAccountId,
-    pub path: TransactionAccountPath,
     pub encoded_path: String,
     pub name: String,
     pub description: String,

--- a/core/chart-of-accounts/src/transaction_account_factory.rs
+++ b/core/chart-of-accounts/src/transaction_account_factory.rs
@@ -61,11 +61,16 @@ impl TransactionAccountFactory {
             .name(account_details.name.to_string())
             .description(account_details.description.to_string())
             .code(account_details.encoded_path.to_string())
-            .normal_balance_type(account_details.path.normal_balance_type())
+            .normal_balance_type(self.control_sub_account.path.normal_balance_type())
             .build()
             .expect("Could not build new account");
 
-        self.cala.accounts().create_in_op(op, new_account).await?;
+        let account = self.cala.accounts().create_in_op(op, new_account).await?;
+
+        self.cala
+            .account_sets()
+            .add_member_in_op(op, self.control_sub_account.account_set_id, account.id)
+            .await?;
 
         Ok(account_details)
     }

--- a/core/chart-of-accounts/src/transaction_account_factory.rs
+++ b/core/chart-of-accounts/src/transaction_account_factory.rs
@@ -2,18 +2,18 @@ use audit::AuditInfo;
 use cala_ledger::{account::*, CalaLedger, LedgerOperation};
 
 use crate::{
-    chart_of_accounts::ChartRepo,
     error::CoreChartOfAccountsError,
-    path::ControlSubAccountPath,
     primitives::{ChartAccountDetails, ChartCreationDetails, ChartId, LedgerAccountId},
 };
+
+use super::{ChartRepo, ControlSubAccountDetails};
 
 #[derive(Clone)]
 pub struct TransactionAccountFactory {
     repo: ChartRepo,
     cala: CalaLedger,
     chart_id: ChartId,
-    control_sub_account: ControlSubAccountPath,
+    control_sub_account: ControlSubAccountDetails,
 }
 
 impl TransactionAccountFactory {
@@ -21,7 +21,7 @@ impl TransactionAccountFactory {
         repo: &ChartRepo,
         cala: &CalaLedger,
         chart_id: ChartId,
-        control_sub_account: ControlSubAccountPath,
+        control_sub_account: ControlSubAccountDetails,
     ) -> Self {
         Self {
             repo: repo.clone(),
@@ -47,7 +47,7 @@ impl TransactionAccountFactory {
         let account_details = chart.add_transaction_account(
             ChartCreationDetails {
                 account_id: account_id.into(),
-                control_sub_account: self.control_sub_account,
+                control_sub_account: self.control_sub_account.path,
                 name: name.to_string(),
                 description: description.to_string(),
             },

--- a/core/chart-of-accounts/tests/chart_of_accounts.rs
+++ b/core/chart-of-accounts/tests/chart_of_accounts.rs
@@ -72,7 +72,7 @@ async fn create_and_populate() -> anyhow::Result<()> {
         )
         .await?;
     assert_eq!(
-        control_sub_account_code.control_account(),
+        control_sub_account_code.path.control_account(),
         control_account_code
     );
 

--- a/core/chart-of-accounts/tests/chart_of_accounts.rs
+++ b/core/chart-of-accounts/tests/chart_of_accounts.rs
@@ -49,6 +49,7 @@ async fn create_and_populate() -> anyhow::Result<()> {
     let control_sub_account_name = "Fixed-Term Credit Facilities Receivable";
     let control_sub_account_code = chart_of_accounts
         .create_control_sub_account(
+            LedgerAccountSetId::new(),
             chart_id,
             control_account_code,
             control_sub_account_name.to_string(),

--- a/core/deposit/src/primitives.rs
+++ b/core/deposit/src/primitives.rs
@@ -6,7 +6,7 @@ pub use chart_of_accounts::ChartId;
 pub use governance::{ApprovalProcessId, GovernanceAction, GovernanceObject};
 
 pub use cala_ledger::primitives::{
-    AccountId as LedgerAccountId, JournalId as LedgerJournalId,
+    AccountId as LedgerAccountId, AccountSetId as LedgerAccountSetId, JournalId as LedgerJournalId,
     TransactionId as LedgerTransactionId,
 };
 

--- a/core/deposit/tests/deposit.rs
+++ b/core/deposit/tests/deposit.rs
@@ -12,6 +12,8 @@ use helpers::{action, event, object};
 async fn deposit() -> anyhow::Result<()> {
     use rand::Rng;
 
+    use crate::LedgerJournalId;
+
     let pool = helpers::init_pool().await?;
 
     let outbox = outbox::Outbox::<event::DummyEvent>::init(&pool).await?;
@@ -30,7 +32,7 @@ async fn deposit() -> anyhow::Result<()> {
     let omnibus_code = journal_id.to_string();
 
     let chart_id = ChartId::new();
-    let chart_of_accounts = CoreChartOfAccounts::init(&pool, &authz, &cala).await?;
+    let chart_of_accounts = CoreChartOfAccounts::init(&pool, &authz, &cala, journal_id).await?;
     chart_of_accounts
         .create_chart(
             chart_id,

--- a/core/deposit/tests/deposit.rs
+++ b/core/deposit/tests/deposit.rs
@@ -48,6 +48,7 @@ async fn deposit() -> anyhow::Result<()> {
         .await?;
     let control_sub_account_path = chart_of_accounts
         .create_control_sub_account(
+            LedgerAccountSetId::new(),
             chart_id,
             control_account_path,
             "User Deposits".to_string(),

--- a/core/deposit/tests/withdraw.rs
+++ b/core/deposit/tests/withdraw.rs
@@ -49,6 +49,7 @@ async fn overdraw_and_cancel_withdrawal() -> anyhow::Result<()> {
         .await?;
     let control_sub_account_path = chart_of_accounts
         .create_control_sub_account(
+            LedgerAccountSetId::new(),
             chart_id,
             control_account_path,
             "User Deposits".to_string(),

--- a/core/deposit/tests/withdraw.rs
+++ b/core/deposit/tests/withdraw.rs
@@ -13,6 +13,8 @@ use helpers::{action, event, object};
 async fn overdraw_and_cancel_withdrawal() -> anyhow::Result<()> {
     use rand::Rng;
 
+    use crate::LedgerJournalId;
+
     let pool = helpers::init_pool().await?;
 
     let outbox = outbox::Outbox::<event::DummyEvent>::init(&pool).await?;
@@ -31,7 +33,7 @@ async fn overdraw_and_cancel_withdrawal() -> anyhow::Result<()> {
     let omnibus_code = journal_id.to_string();
 
     let chart_id = ChartId::new();
-    let chart_of_accounts = CoreChartOfAccounts::init(&pool, &authz, &cala).await?;
+    let chart_of_accounts = CoreChartOfAccounts::init(&pool, &authz, &cala, journal_id).await?;
     chart_of_accounts
         .create_chart(
             chart_id,

--- a/lana/app/src/accounting_init/mod.rs
+++ b/lana/app/src/accounting_init/mod.rs
@@ -4,7 +4,7 @@ mod seed;
 
 pub mod error;
 
-use chart_of_accounts::{ChartId, ControlSubAccountPath};
+use chart_of_accounts::ChartId;
 
 use crate::chart_of_accounts::ChartOfAccounts;
 

--- a/lana/app/src/accounting_init/mod.rs
+++ b/lana/app/src/accounting_init/mod.rs
@@ -8,24 +8,33 @@ use chart_of_accounts::{ChartId, ControlSubAccountPath};
 
 use crate::chart_of_accounts::ChartOfAccounts;
 
-use cala_ledger::{CalaLedger, JournalId};
+use cala_ledger::CalaLedger;
 
 use error::*;
 use primitives::*;
 
 #[derive(Clone)]
-pub struct AccountingInit {
-    pub journal_id: JournalId,
+pub struct JournalInit {
+    pub journal_id: LedgerJournalId,
+}
+
+impl JournalInit {
+    pub async fn journal(cala: &CalaLedger) -> Result<Self, AccountingInitError> {
+        seed::journal(cala).await
+    }
+}
+
+#[derive(Clone)]
+pub struct ChartsInit {
     pub chart_ids: ChartIds,
     pub deposits: DepositsAccountPaths,
     pub credit_facilities: CreditFacilitiesAccountPaths,
 }
 
-impl AccountingInit {
-    pub async fn execute(
-        cala: &CalaLedger,
+impl ChartsInit {
+    pub async fn charts_of_accounts(
         chart_of_accounts: &ChartOfAccounts,
     ) -> Result<Self, AccountingInitError> {
-        seed::execute(cala, chart_of_accounts).await
+        seed::charts_of_accounts(chart_of_accounts).await
     }
 }

--- a/lana/app/src/accounting_init/primitives.rs
+++ b/lana/app/src/accounting_init/primitives.rs
@@ -1,6 +1,6 @@
 pub use cala_ledger::primitives::JournalId as LedgerJournalId;
 
-use chart_of_accounts::{ChartId, ControlSubAccountPath};
+use chart_of_accounts::{ChartId, ControlSubAccountDetails};
 
 #[derive(Clone, Copy)]
 pub struct ChartIds {
@@ -10,15 +10,15 @@ pub struct ChartIds {
 
 #[derive(Clone)]
 pub struct DepositsAccountPaths {
-    pub deposits: ControlSubAccountPath,
+    pub deposits: ControlSubAccountDetails,
 }
 
 #[derive(Clone)]
 pub struct CreditFacilitiesAccountPaths {
-    pub collateral: ControlSubAccountPath,
-    pub facility: ControlSubAccountPath,
-    pub disbursed_receivable: ControlSubAccountPath,
-    pub interest_receivable: ControlSubAccountPath,
-    pub interest_income: ControlSubAccountPath,
-    pub fee_income: ControlSubAccountPath,
+    pub collateral: ControlSubAccountDetails,
+    pub facility: ControlSubAccountDetails,
+    pub disbursed_receivable: ControlSubAccountDetails,
+    pub interest_receivable: ControlSubAccountDetails,
+    pub interest_income: ControlSubAccountDetails,
+    pub fee_income: ControlSubAccountDetails,
 }

--- a/lana/app/src/accounting_init/primitives.rs
+++ b/lana/app/src/accounting_init/primitives.rs
@@ -1,3 +1,5 @@
+pub use cala_ledger::primitives::JournalId as LedgerJournalId;
+
 use chart_of_accounts::{ChartId, ControlSubAccountPath};
 
 #[derive(Clone, Copy)]

--- a/lana/app/src/accounting_init/seed.rs
+++ b/lana/app/src/accounting_init/seed.rs
@@ -1,5 +1,7 @@
 use chart_of_accounts::ChartCategory;
 
+use crate::primitives::LedgerAccountSetId;
+
 use super::{constants::*, *};
 
 pub(super) async fn execute(
@@ -79,8 +81,10 @@ async fn create_charts_of_accounts(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn create_control_sub_account(
     chart_of_accounts: &ChartOfAccounts,
+    id: LedgerAccountSetId,
     chart_id: ChartId,
     category: ChartCategory,
     control_name: String,
@@ -107,7 +111,7 @@ async fn create_control_sub_account(
         Some(path) => path,
         None => {
             chart_of_accounts
-                .create_control_sub_account(chart_id, control_path, sub_name, sub_reference)
+                .create_control_sub_account(id, chart_id, control_path, sub_name, sub_reference)
                 .await?
         }
     };
@@ -121,6 +125,7 @@ async fn create_deposits_account_paths(
 ) -> Result<DepositsAccountPaths, AccountingInitError> {
     let deposits = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.primary,
         chart_of_accounts::ChartCategory::Liabilities,
         DEPOSITS_CONTROL_ACCOUNT_NAME.to_string(),
@@ -139,6 +144,7 @@ async fn create_credit_facilities_account_paths(
 ) -> Result<CreditFacilitiesAccountPaths, AccountingInitError> {
     let collateral = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.off_balance_sheet,
         chart_of_accounts::ChartCategory::Liabilities,
         CREDIT_FACILITIES_COLLATERAL_CONTROL_ACCOUNT_NAME.to_string(),
@@ -150,6 +156,7 @@ async fn create_credit_facilities_account_paths(
 
     let facility = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.off_balance_sheet,
         chart_of_accounts::ChartCategory::Assets,
         CREDIT_FACILITIES_FACILITY_CONTROL_ACCOUNT_NAME.to_string(),
@@ -161,6 +168,7 @@ async fn create_credit_facilities_account_paths(
 
     let disbursed_receivable = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.primary,
         chart_of_accounts::ChartCategory::Assets,
         CREDIT_FACILITIES_DISBURSED_RECEIVABLE_CONTROL_ACCOUNT_NAME.to_string(),
@@ -172,6 +180,7 @@ async fn create_credit_facilities_account_paths(
 
     let interest_receivable = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.primary,
         chart_of_accounts::ChartCategory::Assets,
         CREDIT_FACILITIES_INTEREST_RECEIVABLE_CONTROL_ACCOUNT_NAME.to_string(),
@@ -183,6 +192,7 @@ async fn create_credit_facilities_account_paths(
 
     let interest_income = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.primary,
         chart_of_accounts::ChartCategory::Revenues,
         CREDIT_FACILITIES_INTEREST_INCOME_CONTROL_ACCOUNT_NAME.to_string(),
@@ -194,6 +204,7 @@ async fn create_credit_facilities_account_paths(
 
     let fee_income = create_control_sub_account(
         chart_of_accounts,
+        LedgerAccountSetId::new(),
         chart_ids.primary,
         chart_of_accounts::ChartCategory::Revenues,
         CREDIT_FACILITIES_FEE_INCOME_CONTROL_ACCOUNT_NAME.to_string(),

--- a/lana/app/src/accounting_init/seed.rs
+++ b/lana/app/src/accounting_init/seed.rs
@@ -1,4 +1,4 @@
-use chart_of_accounts::ChartCategory;
+use chart_of_accounts::{ChartCategory, ControlSubAccountDetails};
 
 use crate::primitives::LedgerAccountSetId;
 
@@ -91,7 +91,7 @@ async fn create_control_sub_account(
     control_reference: String,
     sub_name: String,
     sub_reference: String,
-) -> Result<ControlSubAccountPath, AccountingInitError> {
+) -> Result<ControlSubAccountDetails, AccountingInitError> {
     let control_path = match chart_of_accounts
         .find_control_account_by_reference(chart_id, control_reference.clone())
         .await?
@@ -104,11 +104,11 @@ async fn create_control_sub_account(
         }
     };
 
-    let control_sub_path = match chart_of_accounts
+    let control_sub_account = match chart_of_accounts
         .find_control_sub_account_by_reference(chart_id, sub_reference.clone())
         .await?
     {
-        Some(path) => path,
+        Some(account_details) => account_details,
         None => {
             chart_of_accounts
                 .create_control_sub_account(id, chart_id, control_path, sub_name, sub_reference)
@@ -116,7 +116,7 @@ async fn create_control_sub_account(
         }
     };
 
-    Ok(control_sub_path)
+    Ok(control_sub_account)
 }
 
 async fn create_deposits_account_paths(


### PR DESCRIPTION
~**_DO NOT MERGE_ before #1248**~

## Description

Transaction accounts aren't tracked in the chart. They don't get a GL code, and are simply detail accounts for the control sub-account they fall under.

The `add_transaction_account` is a no-op after this PR with a note to tie it back to the chart by using some sort of a `ControlSubAccount` entity representation to track member accounts added to it