### PR TITLE
fix: meltano alias in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
       };
       mkAlias = alias: command: pkgs.writeShellScriptBin alias command;
       aliases = [
-        (mkAlias "meltano" "docker compose run meltano --")
+        (mkAlias "meltano" ''docker compose run meltano -- "$@"'')
       ];
       nativeBuildInputs = with pkgs;
         [


### PR DESCRIPTION
This change ensures that any additional arguments passed to the `meltano` alias command are correctly forwarded.

* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L37-R37): Modified the `meltano` alias to include `"$@"` to forward additional arguments.