### PR TITLE
chore: query dbt reports instead of dataform reports

### DIFF
--- a/bats/z-report.bats
+++ b/bats/z-report.bats
@@ -51,7 +51,7 @@ wait_for_complete() {
   echo $(graphql_output)
   links=$(graphql_output .data.reportDownloadLinksGenerate.links)
   length=$(echo $links | jq -r 'length')
-  [[ "$length" -gt "1" ]] || exit 1
+  [[ "$length" -gt "0" ]] || exit 1
 
   for url in $(echo $links | jq -r '.[].url'); do
     xml_file_contents=$(curl -fsSL "$url") || exit 1

--- a/lana/app/src/report/config.rs
+++ b/lana/app/src/report/config.rs
@@ -25,7 +25,7 @@ impl ReportConfig {
     ) -> ReportConfig {
         Self {
             dataform_repo: format!("{}-repo", name_prefix),
-            dataform_output_dataset: format!("dataform_{}", name_prefix),
+            dataform_output_dataset: format!("dbt_{}", name_prefix),
             dataform_release_config: format!("{}-release", name_prefix),
             dev_disable_auto_create,
             service_account: Some(service_account),

--- a/lana/app/src/report/upload.rs
+++ b/lana/app/src/report/upload.rs
@@ -31,7 +31,7 @@ pub async fn execute(
     for report_name in bq::find_report_outputs(config).await? {
         let day = chrono::Utc::now().format("%Y-%m-%d").to_string();
 
-        let rows = match bq::query_report(config, &report_name, &day).await {
+        let rows = match bq::query_report(config, &report_name).await {
             Ok(rows) => rows,
             Err(e) => {
                 res.push(ReportFileUpload::Failure {
@@ -128,15 +128,14 @@ pub(super) mod bq {
     pub(super) async fn query_report(
         config: &ReportConfig,
         report: &str,
-        day: &str,
     ) -> Result<Vec<QueryRow>, ReportError> {
         let client =
             Client::from_service_account_key(config.service_account().service_account_key(), false)
                 .await?;
         let gcp_project = &config.service_account().gcp_project;
         let query = format!(
-            "SELECT * FROM `{}.{}.{}`('{}')",
-            gcp_project, config.dataform_output_dataset, report, day
+            "SELECT * FROM `{}.{}.{}`",
+            gcp_project, config.dataform_output_dataset, report
         );
         let res = client
             .job()


### PR DESCRIPTION
The code that compiles and executes the dataform workflow still needs to be removed.