### PR TITLE
chore(reporting): materialize raw credit facility events

### DIFF
--- a/meltano/transform/models/staging/stg_credit_facility_events.sql
+++ b/meltano/transform/models/staging/stg_credit_facility_events.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 with ordered as (
 
     select
@@ -8,7 +10,7 @@ with ordered as (
         recorded_at,
         row_number()
             over (
-                partition by id
+                partition by id, sequence
                 order by _sdc_received_at desc
             )
             as order_received_desc


### PR DESCRIPTION
This is necessary for holistics since otherwise we would have to grant the service account permission to query even our raw data.