### PR TITLE
fix(reporting): replace xml special characters

### DIFF
--- a/meltano/transform/models/outputs/el-salvador-ssf/report_npb4_16_01_saldo_cuenta_xml.sql
+++ b/meltano/transform/models/outputs/el-salvador-ssf/report_npb4_16_01_saldo_cuenta_xml.sql
@@ -2,7 +2,7 @@
 
 select
     right(id_codigo_cuenta, 10) as id_codigo_cuenta,
-    left(nom_cuenta, 80) as nom_cuenta,
+    left(regexp_replace(nom_cuenta, r'[&<>"]', '_'), 80) as nom_cuenta,
     format('%.2f', round(valor, 2)) as valor
 
 from {{ ref('int_npb4_16_01_saldo_cuenta_xml_raw') }}


### PR DESCRIPTION
This is a quick fix to allow xml parsers to parse generated xml. A future PR can replace this and escape special characters as part of the xml serialization.