### PR TITLE
chore: remove statements db-op commits

### DIFF
--- a/lana/app/src/balance_sheet/ledger/mod.rs
+++ b/lana/app/src/balance_sheet/ledger/mod.rs
@@ -342,8 +342,6 @@ impl BalanceSheetLedger {
             .get_member_account_sets_in_op(&mut op, ids.assets)
             .await?;
 
-        op.commit().await?;
-
         Ok(BalanceSheet {
             id: balance_sheet_set.id,
             name: balance_sheet_set.name,

--- a/lana/app/src/profit_and_loss/ledger/mod.rs
+++ b/lana/app/src/profit_and_loss/ledger/mod.rs
@@ -259,8 +259,6 @@ impl ProfitAndLossStatementLedger {
             .get_member_account_sets_in_op(&mut op, ids.expenses)
             .await?;
 
-        op.commit().await?;
-
         Ok(ProfitAndLossStatement {
             id: pl_statement_set.id.into(),
             name: pl_statement_set.name,

--- a/lana/app/src/trial_balance/ledger/mod.rs
+++ b/lana/app/src/trial_balance/ledger/mod.rs
@@ -165,8 +165,6 @@ impl TrialBalanceLedger {
 
         let accounts = self.get_member_account_sets_in_op(&mut op, id).await?;
 
-        op.commit().await?;
-
         Ok(StatementAccountSetWithAccounts {
             id: trial_balance_set.id,
             name: trial_balance_set.name,


### PR DESCRIPTION
## Description

This is to allow the read-only transaction to rollback (via Drop) instead of explicitly committing and possible having an error thrown if there was another update elsewhere. Read needs to be internally consistent, but not necessarily at the latest state of the db.