### PR TITLE
chore(reporting): configure incremental updates for staging models

### DIFF
--- a/meltano/transform/models/staging/stg_account_balances.sql
+++ b/meltano/transform/models/staging/stg_account_balances.sql
@@ -13,6 +13,7 @@ with ordered as (
         currency,
         recorded_at,
         values,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by account_id
@@ -23,7 +24,7 @@ with ordered as (
     from {{ source("lana", "public_cala_balance_history_view") }}
 
     {% if is_incremental() %}
-    where recorded_at >= (select coalesce(max(recorded_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_balances.sql
+++ b/meltano/transform/models/staging/stg_account_balances.sql
@@ -1,3 +1,10 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'account_id',
+    full_refresh = true,
+) }}
+-- TODO: remove full_refresh config after rollout
+
 with ordered as (
 
     select
@@ -14,6 +21,10 @@ with ordered as (
             as order_received_desc
 
     from {{ source("lana", "public_cala_balance_history_view") }}
+
+    {% if is_incremental() %}
+    where recorded_at >= (select coalesce(max(recorded_at),'1900-01-01') from {{ this }} )
+    {% endif %}
 
 )
 

--- a/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
@@ -1,3 +1,10 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'account_set_id',
+    full_refresh = true,
+) }}
+-- TODO: remove full_refresh config after rollout
+
 with ordered as (
 
     select
@@ -13,6 +20,10 @@ with ordered as (
 
     from
         {{ source("lana", "public_cala_account_set_member_account_sets_view") }}
+
+    {% if is_incremental() %}
+    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    {% endif %}
 
 )
 

--- a/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
@@ -11,6 +11,7 @@ with ordered as (
         account_set_id,
         member_account_set_id,
         created_at,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by account_set_id
@@ -22,7 +23,7 @@ with ordered as (
         {{ source("lana", "public_cala_account_set_member_account_sets_view") }}
 
     {% if is_incremental() %}
-    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_set_member_accounts.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_accounts.sql
@@ -12,6 +12,7 @@ with ordered as (
         member_account_id,
         transitive,
         created_at,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by account_set_id, member_account_id
@@ -22,7 +23,7 @@ with ordered as (
     from {{ source("lana", "public_cala_account_set_member_accounts_view") }}
 
     {% if is_incremental() %}
-    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_set_member_accounts.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_accounts.sql
@@ -1,3 +1,10 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['account_set_id', 'member_account_id'],
+    full_refresh = true,
+) }}
+-- TODO: remove full_refresh config after rollout
+
 with ordered as (
 
     select
@@ -13,6 +20,10 @@ with ordered as (
             as order_received_desc
 
     from {{ source("lana", "public_cala_account_set_member_accounts_view") }}
+
+    {% if is_incremental() %}
+    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    {% endif %}
 
 )
 

--- a/meltano/transform/models/staging/stg_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_sets.sql
@@ -12,6 +12,7 @@ with ordered as (
         journal_id,
         name as set_name,
         created_at,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by id
@@ -22,7 +23,7 @@ with ordered as (
     from {{ source("lana", "public_cala_account_sets_view") }}
 
     {% if is_incremental() %}
-    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_sets.sql
@@ -1,3 +1,10 @@
+{{ config(
+    materialized='incremental',
+    unique_key= 'id',
+    full_refresh=true,
+) }}
+-- TODO: remove full_refresh config after rollout
+
 with ordered as (
 
     select
@@ -13,6 +20,10 @@ with ordered as (
             as order_received_desc
 
     from {{ source("lana", "public_cala_account_sets_view") }}
+
+    {% if is_incremental() %}
+    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    {% endif %}
 
 )
 

--- a/meltano/transform/models/staging/stg_accounts.sql
+++ b/meltano/transform/models/staging/stg_accounts.sql
@@ -1,3 +1,10 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    full_refresh = true,
+) }}
+-- TODO: remove full_refresh config after rollout
+
 with ordered as (
 
     select
@@ -15,6 +22,10 @@ with ordered as (
             as order_received_desc
 
     from {{ source("lana", "public_cala_accounts_view") }}
+
+    {% if is_incremental() %}
+    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    {% endif %}
 
 )
 

--- a/meltano/transform/models/staging/stg_accounts.sql
+++ b/meltano/transform/models/staging/stg_accounts.sql
@@ -14,6 +14,7 @@ with ordered as (
         normal_balance_type,
         latest_values,
         created_at,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by id
@@ -24,7 +25,7 @@ with ordered as (
     from {{ source("lana", "public_cala_accounts_view") }}
 
     {% if is_incremental() %}
-    where created_at >= (select coalesce(max(created_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_credit_facility_events.sql
+++ b/meltano/transform/models/staging/stg_credit_facility_events.sql
@@ -13,6 +13,7 @@ with ordered as (
         event_type,
         event,
         recorded_at,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by id, sequence
@@ -23,7 +24,7 @@ with ordered as (
     from {{ source("lana", "public_credit_facility_events_view") }}
 
     {% if is_incremental() %}
-    where recorded_at >= (select coalesce(max(recorded_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_customer_events.sql
+++ b/meltano/transform/models/staging/stg_customer_events.sql
@@ -13,6 +13,7 @@ with ordered as (
         event_type,
         event,
         recorded_at,
+        _sdc_batched_at,
         row_number()
             over (
                 partition by id, sequence
@@ -23,7 +24,7 @@ with ordered as (
     from {{ source("lana", "public_customer_events_view") }}
 
     {% if is_incremental() %}
-    where recorded_at >= (select coalesce(max(recorded_at),'1900-01-01') from {{ this }} )
+    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_customer_events.sql
+++ b/meltano/transform/models/staging/stg_customer_events.sql
@@ -1,3 +1,10 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
+) }}
+-- TODO: remove full_refresh config after rollout
+
 with ordered as (
 
     select
@@ -14,6 +21,10 @@ with ordered as (
             as order_received_desc
 
     from {{ source("lana", "public_customer_events_view") }}
+
+    {% if is_incremental() %}
+    where recorded_at >= (select coalesce(max(recorded_at),'1900-01-01') from {{ this }} )
+    {% endif %}
 
 )
 


### PR DESCRIPTION
Even without real production data, many of the source tables created by `tap-postgres` are already hundreds of thousands of rows long. This might not be an issue once incremental loading is configured, but in the meantime this is a simple fix that will prevent running dbt from taking too long in the future.