### PR TITLE
chore: remove ApprovalProcessStarted event from credit facility

### DIFF
--- a/lana/app/src/credit_facility/repayment_plan.rs
+++ b/lana/app/src/credit_facility/repayment_plan.rs
@@ -232,6 +232,7 @@ mod tests {
                 terms: terms(),
                 audit_info: dummy_audit_info(),
                 deposit_account_id,
+                approval_process_id: ApprovalProcessId::new(),
             },
             CreditFacilityEvent::Activated {
                 ledger_tx_id: LedgerTxId::new(),


### PR DESCRIPTION
This is not equivilent to the Disbursal and Withdrawal entities where the approval_process_id is recorded in the Initialized event.