### PR TITLE
chore(reporting): cache market data from bitfinex

### DIFF
--- a/meltano/transform/models/sources.yml
+++ b/meltano/transform/models/sources.yml
@@ -77,6 +77,24 @@ sources:
             count: 1
             period: day
 
+      - name: bitfinex_trades_view
+        freshness:
+          warn_after:
+            count: 1
+            period: hour
+          error_after:
+            count: 1
+            period: day
+
+      - name: bitfinex_order_book_view
+        freshness:
+          warn_after:
+            count: 1
+            period: hour
+          error_after:
+            count: 1
+            period: day
+
       - name: sumsub_applicants_view
         freshness:
           warn_after:

--- a/meltano/transform/models/staging/stg_account_balances.sql
+++ b/meltano/transform/models/staging/stg_account_balances.sql
@@ -22,7 +22,8 @@ with ordered as (
     from {{ source("lana", "public_cala_balance_history_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
@@ -21,7 +21,8 @@ with ordered as (
         {{ source("lana", "public_cala_account_set_member_account_sets_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_set_member_accounts.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_accounts.sql
@@ -21,7 +21,8 @@ with ordered as (
     from {{ source("lana", "public_cala_account_set_member_accounts_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_sets.sql
@@ -21,7 +21,8 @@ with ordered as (
     from {{ source("lana", "public_cala_account_sets_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_accounts.sql
+++ b/meltano/transform/models/staging/stg_accounts.sql
@@ -23,7 +23,8 @@ with ordered as (
     from {{ source("lana", "public_cala_accounts_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_bitfinex_order_book.sql
+++ b/meltano/transform/models/staging/stg_bitfinex_order_book.sql
@@ -7,18 +7,10 @@
 
 select
     requested_at,
-    bid,
-    bid_size,
-    ask,
-    daily_change,
-    daily_change_relative,
-    last_price as last_price_usd,
-    volume,
-    high,
-    low,
+    orders,
     _sdc_batched_at
 
-from {{ source("lana", "bitfinex_ticker_view") }}
+from {{ source("lana", "bitfinex_order_book_view") }}
 
 {% if is_incremental() %}
 where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )

--- a/meltano/transform/models/staging/stg_bitfinex_trades.sql
+++ b/meltano/transform/models/staging/stg_bitfinex_trades.sql
@@ -1,24 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key ='requested_at',
+    unique_key ='ID',
     full_refresh = true,
 ) }}
 -- TODO: turn off full_refresh after rollout
 
 select
-    requested_at,
-    bid,
-    bid_size,
-    ask,
-    daily_change,
-    daily_change_relative,
-    last_price as last_price_usd,
-    volume,
-    high,
-    low,
+    id,
+    mts,
+    amount,
+    price,
     _sdc_batched_at
 
-from {{ source("lana", "bitfinex_ticker_view") }}
+from {{ source("lana", "bitfinex_trades_view") }}
 
 {% if is_incremental() %}
 where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )

--- a/meltano/transform/models/staging/stg_credit_facility_events.sql
+++ b/meltano/transform/models/staging/stg_credit_facility_events.sql
@@ -22,7 +22,8 @@ with ordered as (
     from {{ source("lana", "public_credit_facility_events_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )

--- a/meltano/transform/models/staging/stg_customer_events.sql
+++ b/meltano/transform/models/staging/stg_customer_events.sql
@@ -22,7 +22,8 @@ with ordered as (
     from {{ source("lana", "public_customer_events_view") }}
 
     {% if is_incremental() %}
-    where _sdc_batched_at >= (select coalesce(max(_sdc_batched_at),'1900-01-01') from {{ this }} )
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
     {% endif %}
 
 )


### PR DESCRIPTION
A merged PR will reset the data warehouse so its state is synced with the application: https://github.com/GaloyMoney/galoy-deployments/pull/148

This PR caches the price as well as trades and order book data so that we can keep historical values through the reset.
