### PR TITLE
feat(reporting): enable live views for holistics

### DIFF
--- a/tf/bq-setup/bq.tf
+++ b/tf/bq-setup/bq.tf
@@ -90,3 +90,14 @@ resource "google_bigquery_dataset_iam_member" "dbt_additional_owners" {
   role       = "roles/bigquery.dataOwner"
   member     = "user:${each.value}"
 }
+
+resource "google_bigquery_dataset_access" "view_access" {
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  dataset {
+    dataset {
+      project_id = local.project
+      dataset_id = google_bigquery_dataset.dbt.dataset_id
+    }
+    target_types = ["VIEWS"]
+  }
+}


### PR DESCRIPTION
This PR configures the dbt dataset as an authorized dataset to our raw dataset.  This means that, though the holistics service account can't query the raw dataset, any views we create in the dbt dataset which point to the raw dataset can be queried by holistics.  This means we can get live prices and other nice things.