### PR TITLE
chore(reporting): configure dbt data tests to run daily and store results

### DIFF
--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -24,6 +24,9 @@ jobs:
 - name: tap-postgres-to-target-bigquery-run-dbt
   tasks:
   - tap-postgres target-bigquery dbt-bigquery:run
+- name: test-dbt
+  tasks:
+  - dbt-bigquery:test
 - name: poll-bitfinex
   tasks:
   - tap-bitfinexapi target-bigquery
@@ -40,6 +43,9 @@ schedules:
 - name: sync-sumsub-hourly
   interval: '@hourly'
   job: sync-sumsub
+- name: test-dbt-daily
+  interval: '@daily'
+  job: test-dbt
 plugins:
   extractors:
   - name: tap-postgres

--- a/meltano/transform/dbt_project.yml
+++ b/meltano/transform/dbt_project.yml
@@ -24,6 +24,9 @@ clean-targets:
 - logs
 models:
   my_meltano_project: null
+tests:
+  schema: null
+  store_failures: true
 on-run-start:
 - '{{create_udfs()}}'
 vars:


### PR DESCRIPTION
We could configure test results to go to their own dataset but I don't think there is any benefits from the additional complexity in the terraform configuration.