### PR TITLE
refactor: make charts gql type into an entity

### DIFF
--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -271,6 +271,7 @@ export type ChartControlSubAccount = {
 export type ChartOfAccounts = {
   __typename?: 'ChartOfAccounts';
   categories: ChartCategories;
+  id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
 };
 

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -355,6 +355,7 @@ export const mockChartOfAccounts = (overrides?: Partial<ChartOfAccounts>, _relat
     return {
         __typename: 'ChartOfAccounts',
         categories: overrides && overrides.hasOwnProperty('categories') ? overrides.categories! : relationshipsToOmit.has('ChartCategories') ? {} as ChartCategories : mockChartCategories({}, relationshipsToOmit),
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.string.uuid(),
         name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : generateMockValue.name(),
     };
 };

--- a/core/chart-of-accounts/src/chart_of_accounts/entity.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/entity.rs
@@ -47,6 +47,7 @@ pub enum ChartEvent {
 pub struct Chart {
     pub id: ChartId,
     pub reference: String,
+    pub name: String,
     pub(super) events: EntityEvents<ChartEvent>,
 }
 
@@ -208,8 +209,16 @@ impl TryFromEvents<ChartEvent> for Chart {
         let mut builder = ChartBuilder::default();
         for event in events.iter_all() {
             match event {
-                ChartEvent::Initialized { id, reference, .. } => {
-                    builder = builder.id(*id).reference(reference.to_string())
+                ChartEvent::Initialized {
+                    id,
+                    reference,
+                    name,
+                    ..
+                } => {
+                    builder = builder
+                        .id(*id)
+                        .reference(reference.to_string())
+                        .name(name.to_string())
                 }
                 ChartEvent::ControlAccountAdded { .. } => (),
                 ChartEvent::ControlSubAccountAdded { .. } => (),

--- a/core/chart-of-accounts/src/chart_of_accounts/mod.rs
+++ b/core/chart-of-accounts/src/chart_of_accounts/mod.rs
@@ -3,5 +3,6 @@ pub mod error;
 mod repo;
 pub mod tree;
 
+pub use entity::Chart;
 pub(super) use entity::*;
 pub(super) use repo::*;

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -110,6 +110,14 @@ where
         Ok(chart)
     }
 
+    #[instrument(name = "chart_of_accounts.find_all", skip(self), err)]
+    pub async fn find_all<T: From<Chart>>(
+        &self,
+        ids: &[ChartId],
+    ) -> Result<std::collections::HashMap<ChartId, T>, CoreChartOfAccountsError> {
+        Ok(self.repo.find_all(ids).await?)
+    }
+
     #[instrument(name = "chart_of_accounts.find_by_reference", skip(self))]
     pub async fn find_by_reference(
         &self,

--- a/core/chart-of-accounts/src/lib.rs
+++ b/core/chart-of-accounts/src/lib.rs
@@ -13,8 +13,8 @@ use tracing::instrument;
 use audit::AuditSvc;
 use authz::PermissionCheck;
 
-pub use chart_of_accounts::tree;
 use chart_of_accounts::*;
+pub use chart_of_accounts::{tree, Chart};
 use error::*;
 pub use path::ControlSubAccountPath;
 pub use primitives::*;

--- a/lana/admin-server/src/graphql/chart_of_accounts.rs
+++ b/lana/admin-server/src/graphql/chart_of_accounts.rs
@@ -1,68 +1,84 @@
 use async_graphql::*;
 
-use lana_app::chart_of_accounts::tree::*;
+use crate::primitives::*;
 
-#[derive(SimpleObject)]
+use lana_app::chart_of_accounts::Chart as DomainChart;
+
+#[derive(SimpleObject, Clone)]
+#[graphql(complex)]
 pub struct ChartOfAccounts {
+    id: ID,
     name: String,
-    categories: ChartCategories,
+
+    #[graphql(skip)]
+    pub(super) entity: Arc<DomainChart>,
 }
 
-impl From<ChartTree> for ChartOfAccounts {
-    fn from(tree: ChartTree) -> Self {
+impl From<DomainChart> for ChartOfAccounts {
+    fn from(chart: DomainChart) -> Self {
         ChartOfAccounts {
-            name: tree.name,
-            categories: ChartCategories {
-                assets: ChartCategory {
-                    name: tree.assets.name,
-                    account_code: tree.assets.encoded_path,
-                    control_accounts: tree
-                        .assets
-                        .children
-                        .into_iter()
-                        .map(ChartControlAccount::from)
-                        .collect(),
-                },
-                liabilities: ChartCategory {
-                    name: tree.liabilities.name,
-                    account_code: tree.liabilities.encoded_path,
-                    control_accounts: tree
-                        .liabilities
-                        .children
-                        .into_iter()
-                        .map(ChartControlAccount::from)
-                        .collect(),
-                },
-                equity: ChartCategory {
-                    name: tree.equity.name,
-                    account_code: tree.equity.encoded_path,
-                    control_accounts: tree
-                        .equity
-                        .children
-                        .into_iter()
-                        .map(ChartControlAccount::from)
-                        .collect(),
-                },
-                revenues: ChartCategory {
-                    name: tree.revenues.name,
-                    account_code: tree.revenues.encoded_path,
-                    control_accounts: tree
-                        .revenues
-                        .children
-                        .into_iter()
-                        .map(ChartControlAccount::from)
-                        .collect(),
-                },
-                expenses: ChartCategory {
-                    name: tree.expenses.name,
-                    account_code: tree.expenses.encoded_path,
-                    control_accounts: tree
-                        .expenses
-                        .children
-                        .into_iter()
-                        .map(ChartControlAccount::from)
-                        .collect(),
-                },
+            id: chart.id.to_global_id(),
+            name: chart.name.to_string(),
+
+            entity: Arc::new(chart),
+        }
+    }
+}
+
+#[ComplexObject]
+impl ChartOfAccounts {
+    async fn categories(&self) -> ChartCategories {
+        let tree = self.entity.chart();
+        ChartCategories {
+            assets: ChartCategory {
+                name: tree.assets.name,
+                account_code: tree.assets.encoded_path,
+                control_accounts: tree
+                    .assets
+                    .children
+                    .into_iter()
+                    .map(ChartControlAccount::from)
+                    .collect(),
+            },
+            liabilities: ChartCategory {
+                name: tree.liabilities.name,
+                account_code: tree.liabilities.encoded_path,
+                control_accounts: tree
+                    .liabilities
+                    .children
+                    .into_iter()
+                    .map(ChartControlAccount::from)
+                    .collect(),
+            },
+            equity: ChartCategory {
+                name: tree.equity.name,
+                account_code: tree.equity.encoded_path,
+                control_accounts: tree
+                    .equity
+                    .children
+                    .into_iter()
+                    .map(ChartControlAccount::from)
+                    .collect(),
+            },
+            revenues: ChartCategory {
+                name: tree.revenues.name,
+                account_code: tree.revenues.encoded_path,
+                control_accounts: tree
+                    .revenues
+                    .children
+                    .into_iter()
+                    .map(ChartControlAccount::from)
+                    .collect(),
+            },
+            expenses: ChartCategory {
+                name: tree.expenses.name,
+                account_code: tree.expenses.encoded_path,
+                control_accounts: tree
+                    .expenses
+                    .children
+                    .into_iter()
+                    .map(ChartControlAccount::from)
+                    .collect(),
             },
         }
     }
@@ -85,14 +101,29 @@ pub struct ChartCategory {
 }
 
 #[derive(SimpleObject)]
+pub struct ChartControlAccountDetails {
+    name: String,
+    account_code: String,
+}
+
+impl From<lana_app::chart_of_accounts::ControlAccountDetails> for ChartControlAccountDetails {
+    fn from(details: lana_app::chart_of_accounts::ControlAccountDetails) -> Self {
+        Self {
+            name: details.name,
+            account_code: details.path.to_string(),
+        }
+    }
+}
+
+#[derive(SimpleObject)]
 pub struct ChartControlAccount {
     name: String,
     account_code: String,
     control_sub_accounts: Vec<ChartControlSubAccount>,
 }
 
-impl From<ChartTreeControlAccount> for ChartControlAccount {
-    fn from(tree: ChartTreeControlAccount) -> Self {
+impl From<lana_app::chart_of_accounts::tree::ChartTreeControlAccount> for ChartControlAccount {
+    fn from(tree: lana_app::chart_of_accounts::tree::ChartTreeControlAccount) -> Self {
         ChartControlAccount {
             name: tree.name,
             account_code: tree.encoded_path,
@@ -111,8 +142,10 @@ pub struct ChartControlSubAccount {
     account_code: String,
 }
 
-impl From<ChartTreeControlSubAccount> for ChartControlSubAccount {
-    fn from(tree: ChartTreeControlSubAccount) -> Self {
+impl From<lana_app::chart_of_accounts::tree::ChartTreeControlSubAccount>
+    for ChartControlSubAccount
+{
+    fn from(tree: lana_app::chart_of_accounts::tree::ChartTreeControlSubAccount) -> Self {
         ChartControlSubAccount {
             name: tree.name,
             account_code: tree.encoded_path,

--- a/lana/admin-server/src/graphql/loader.rs
+++ b/lana/admin-server/src/graphql/loader.rs
@@ -2,13 +2,17 @@ use async_graphql::dataloader::{DataLoader, Loader};
 
 use std::collections::HashMap;
 
-use lana_app::{app::LanaApp, deposit::error::CoreDepositError, user::error::UserError};
+use lana_app::{
+    app::LanaApp, chart_of_accounts::error::CoreChartOfAccountsError,
+    deposit::error::CoreDepositError, user::error::UserError,
+};
 
 use crate::primitives::*;
 
 use super::{
-    approval_process::*, committee::*, credit_facility::*, customer::*, deposit::*,
-    deposit_account::*, document::*, policy::*, terms_template::*, user::*, withdrawal::*,
+    approval_process::*, chart_of_accounts::*, committee::*, credit_facility::*, customer::*,
+    deposit::*, deposit_account::*, document::*, policy::*, terms_template::*, user::*,
+    withdrawal::*,
 };
 
 pub type LanaDataLoader = DataLoader<LanaLoader>;
@@ -99,6 +103,22 @@ impl Loader<CustomerId> for LanaLoader {
         keys: &[CustomerId],
     ) -> Result<HashMap<CustomerId, Customer>, Self::Error> {
         self.app.customers().find_all(keys).await.map_err(Arc::new)
+    }
+}
+
+impl Loader<ChartId> for LanaLoader {
+    type Value = ChartOfAccounts;
+    type Error = Arc<CoreChartOfAccountsError>;
+
+    async fn load(
+        &self,
+        keys: &[ChartId],
+    ) -> Result<HashMap<ChartId, ChartOfAccounts>, Self::Error> {
+        self.app
+            .chart_of_accounts()
+            .find_all(keys)
+            .await
+            .map_err(Arc::new)
     }
 }
 

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -244,6 +244,7 @@ type ChartControlSubAccount {
 }
 
 type ChartOfAccounts {
+	id: ID!
 	name: String!
 	categories: ChartCategories!
 }

--- a/lana/admin-server/src/graphql/schema.rs
+++ b/lana/admin-server/src/graphql/schema.rs
@@ -438,15 +438,14 @@ impl Query {
         let reference = CHART_REF.to_string();
 
         let (app, sub) = app_and_sub_from_ctx!(ctx);
-        let chart_projection = app
+        let chart = app
             .chart_of_accounts()
             .list_charts(sub)
             .await?
             .into_iter()
             .find(|p| p.reference == reference)
-            .unwrap_or_else(|| panic!("Chart of accounts not found for ref {}", reference))
-            .chart();
-        Ok(ChartOfAccounts::from(chart_projection))
+            .unwrap_or_else(|| panic!("Chart of accounts not found for ref {}", reference));
+        Ok(ChartOfAccounts::from(chart))
     }
 
     async fn off_balance_sheet_chart_of_accounts(
@@ -456,15 +455,14 @@ impl Query {
         let reference = OBS_CHART_REF.to_string();
 
         let (app, sub) = app_and_sub_from_ctx!(ctx);
-        let chart_projection = app
+        let chart = app
             .chart_of_accounts()
             .list_charts(sub)
             .await?
             .into_iter()
             .find(|p| p.reference == reference)
-            .unwrap_or_else(|| panic!("Chart of accounts not found for ref {}", reference))
-            .chart();
-        Ok(ChartOfAccounts::from(chart_projection))
+            .unwrap_or_else(|| panic!("Chart of accounts not found for ref {}", reference));
+        Ok(ChartOfAccounts::from(chart))
     }
 
     // TODO: remove Option from return type

--- a/lana/admin-server/src/primitives.rs
+++ b/lana/admin-server/src/primitives.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 
 pub use lana_app::{
     primitives::{
-        ApprovalProcessId, CommitteeId, CreditFacilityId, CustomerId, DepositAccountId, DepositId,
-        DisbursalId, DisbursalIdx, DisbursalStatus, DocumentId, LanaRole, PaymentId, PolicyId,
-        ReportId, ReportProgress, Satoshis, SignedSatoshis, SignedUsdCents, Subject,
+        ApprovalProcessId, ChartId, CommitteeId, CreditFacilityId, CustomerId, DepositAccountId,
+        DepositId, DisbursalId, DisbursalIdx, DisbursalStatus, DocumentId, LanaRole, PaymentId,
+        PolicyId, ReportId, ReportProgress, Satoshis, SignedSatoshis, SignedUsdCents, Subject,
         TermsTemplateId, UsdCents, UserId, WithdrawalId,
     },
     terms::CollateralizationState,
@@ -76,6 +76,7 @@ macro_rules! impl_to_global_id {
 impl_to_global_id! {
     UserId,
     CustomerId,
+    ChartId,
     TermsTemplateId,
     CreditFacilityId,
     DisbursalId,

--- a/lana/app/src/lib.rs
+++ b/lana/app/src/lib.rs
@@ -94,7 +94,7 @@ pub mod deposit {
 }
 
 pub mod chart_of_accounts {
-    pub use chart_of_accounts::tree;
+    pub use chart_of_accounts::{tree, Chart, ControlAccountDetails};
 
     pub type ChartOfAccounts =
         chart_of_accounts::CoreChartOfAccounts<crate::authorization::Authorization>;

--- a/lana/app/src/lib.rs
+++ b/lana/app/src/lib.rs
@@ -94,7 +94,7 @@ pub mod deposit {
 }
 
 pub mod chart_of_accounts {
-    pub use chart_of_accounts::{tree, Chart, ControlAccountDetails};
+    pub use chart_of_accounts::{error, tree, Chart, ControlAccountDetails};
 
     pub type ChartOfAccounts =
         chart_of_accounts::CoreChartOfAccounts<crate::authorization::Authorization>;

--- a/lana/app/src/primitives.rs
+++ b/lana/app/src/primitives.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 
+pub use chart_of_accounts::ChartId;
 pub use core_customer::CustomerId;
 pub use core_money::*;
 pub use core_user::UserId;


### PR DESCRIPTION
## Description

This is to add the missing elements to the `ChartOfAccounts` gql type in prep for using it with the `exec_mutation!` macro