### PR TITLE
feat(reporting): data tests for alternative credit facility tables

### DIFF
--- a/meltano/transform/models/intermediate/credit_facilities_alt/int_credit_facilities_alt.yml
+++ b/meltano/transform/models/intermediate/credit_facilities_alt/int_credit_facilities_alt.yml
@@ -1,0 +1,35 @@
+version: 2
+
+models:
+  - name: int_days
+    columns:
+    - name: day
+      data_tests:
+      - unique
+      - not_null
+    - name: close_price_usd_per_btc
+      data_tests:
+      - not_null
+  - name: int_credit_facility_disbursals
+    columns:
+    - name: credit_facility_id
+      data_tests:
+      - not_null
+      - relationships:
+          to: ref('credit_facilities')
+          field: credit_facility_id
+    - name: day
+      data_tests:
+      - not_null
+  - name: int_credit_facility_collateral
+    columns:
+    - name: credit_facility_id
+      data_tests:
+      - not_null
+      - relationships:
+          to: ref('credit_facilities')
+          field: credit_facility_id
+    - name: day
+      data_tests:
+      - not_null
+

--- a/meltano/transform/models/outputs/credit_facilities_alt/credit_facilities.sql
+++ b/meltano/transform/models/outputs/credit_facilities_alt/credit_facilities.sql
@@ -6,14 +6,14 @@ select
     json_value(parsed_event.customer_id) as customer_id,
     lax_int64(parsed_event.facility) / 100 as facility_usd,
     json_value(parsed_event.terms.accrual_interval.type) as terms_accrual_interval_type,
-    lax_int64(parsed_event.terms.annual_rate) as terms_annual_rate,
+    lax_int64(parsed_event.terms.annual_rate)/100 as terms_annual_rate,
     json_value(parsed_event.terms.duration.type) as terms_duration_type,
     lax_int64(parsed_event.terms.duration.value) as terms_duration_value,
     json_value(parsed_event.terms.incurrence_interval.type) as terms_incurrence_interval_type,
-    lax_int64(parsed_event.terms.initial_cvl) as terms_initial_cvl,
-    lax_int64(parsed_event.terms.liquidation_cvl) as terms_liquidation_cvl,
-    lax_int64(parsed_event.terms.margin_call_cvl) as terms_margin_call_cvl,
-    lax_int64(parsed_event.terms.one_time_fee_rate) as terms_one_time_fee_rate
+    lax_int64(parsed_event.terms.initial_cvl)/100 as terms_initial_cvl,
+    lax_int64(parsed_event.terms.liquidation_cvl)/100 as terms_liquidation_cvl,
+    lax_int64(parsed_event.terms.margin_call_cvl)/100 as terms_margin_call_cvl,
+    lax_int64(parsed_event.terms.one_time_fee_rate)/100 as terms_one_time_fee_rate
 
 from {{ ref('stg_credit_facility_events') }}
 

--- a/meltano/transform/models/outputs/credit_facilities_alt/credit_facilities_alt.yml
+++ b/meltano/transform/models/outputs/credit_facilities_alt/credit_facilities_alt.yml
@@ -1,0 +1,56 @@
+version: 2
+
+models:
+  - name: credit_facilities
+    columns:
+    - name: credit_facility_id
+      data_tests:
+      - unique
+      - not_null
+    - name: created_at
+      data_tests:
+      - not_null
+    - name: customer_id
+      data_tests:
+      - not_null
+      - relationships:
+          to: ref('customers')
+          field: customers_id
+    - name: facility_usd
+      data_tests:
+      - not_null
+    - name: terms_annual_rate
+      data_tests:
+      - not_null
+    - name: terms_duration_value
+      data_tests:
+      - not_null
+    - name: terms_incurrence_interval_type
+      data_tests:
+      - not_null
+    - name: terms_liquidation_cvl
+      data_tests:
+      - not_null
+    - name: terms_margin_call_cvl
+      data_tests:
+      - not_null
+    - name: terms_one_time_fee_rate
+      data_tests:
+      - not_null
+  - name: customers
+    columns:
+    - name: customer_id
+      data_tests:
+      - unique
+      - not_null
+  - name: daily_credit_facility_states
+    columns:
+    - name: day
+      data_tests:
+      - not_null
+    - name: credit_facility_id
+      data_tests:
+      - not_null
+      - relationships:
+          to: ref('credit_facilities')
+          field: credit_facility_id

--- a/meltano/transform/models/staging/stg_accounts.yml
+++ b/meltano/transform/models/staging/stg_accounts.yml
@@ -4,23 +4,23 @@ models:
   - name: stg_accounts
     columns:
     - name: id
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: created_at
       tests:
       - not_null
     - name: normal_balance_type
-      tests:
+      data_tests:
       - not_null
       - accepted_values:
           values: ['credit', 'debit']
     - name: latest_values
-      tests:
+      data_tests:
       - not_null
     - name: name
-      tests:
+      data_tests:
       - not_null
     - name: code
-      tests:
+      data_tests:
       - not_null

--- a/meltano/transform/tests/credit_facilities_alt/assert_disbursals_less_than_facility.sql
+++ b/meltano/transform/tests/credit_facilities_alt/assert_disbursals_less_than_facility.sql
@@ -1,0 +1,10 @@
+select
+    day,
+    credit_facility_id,
+    total_disbursed_usd,
+    facility_usd
+
+from {{ ref('daily_credit_facility_states') }}
+left join {{ ref('credit_facilities') }} using (credit_facility_id)
+
+where total_disbursed_usd > facility_usd

--- a/meltano/transform/tests/credit_facilities_alt/assert_liquidation_cvl.sql
+++ b/meltano/transform/tests/credit_facilities_alt/assert_liquidation_cvl.sql
@@ -1,0 +1,16 @@
+select
+    credit_facility_id,
+    day,
+    terms_initial_cvl,
+    terms_liquidation_cvl,
+    terms_margin_call_cvl,
+    total_collateral_value_usd,
+    facility_usd,
+    total_disbursed_usd
+
+from {{ ref('daily_credit_facility_states') }}
+left join {{ ref('credit_facilities') }} using (credit_facility_id)
+
+where
+    total_disbursed_usd > 0
+    and total_collateral_value_usd < facility_usd * terms_liquidation_cvl


### PR DESCRIPTION
Since the schema for events is still evolving, assumptions used in the data warehouse can break down.  Adding data tests is a good way to make sure that the assumptions our data models depend on hold or (once https://github.com/GaloyMoney/lana-bank/pull/1449 is merged) know when they don't.