### PR TITLE
fix(reporting): average open price should not be zero

### DIFF
--- a/meltano/transform/models/outputs/credit_facilities_alt/daily_credit_facility_states.sql
+++ b/meltano/transform/models/outputs/credit_facilities_alt/daily_credit_facility_states.sql
@@ -151,7 +151,7 @@ avg_open_price as (
     select
         credit_facility_id,
         day,
-        avg_open_prices[o] as collateral_avg_open_price
+        nullif(avg_open_prices[o], 0) as collateral_avg_open_price
 
     from (
 


### PR DESCRIPTION
When the collateral change is 0 the average open price UDF returns 0 this caused the alt collateral dashboard to show a price below the lowest price seen for the average open price when taking the average over credit facilities (since some were set to 0 instead of NULL)