### PR TITLE
refactor: genericize new charts structure

### DIFF
--- a/core/chart-of-accounts/src/new/csv.rs
+++ b/core/chart-of-accounts/src/new/csv.rs
@@ -2,7 +2,7 @@ use csv::{ReaderBuilder, Trim};
 use std::io::Cursor;
 
 use super::primitives::{
-    AccountCategory, AccountCodeSection, AccountCodeSectionParseError, AccountSpec,
+    AccountCodeSection, AccountCodeSectionParseError, AccountName, AccountSpec,
 };
 
 use thiserror::Error;
@@ -37,7 +37,7 @@ impl CsvParser {
                     }
 
                     for (idx, field) in record.iter().enumerate() {
-                        if let Ok(category) = field.parse::<AccountCategory>() {
+                        if let Ok(category) = field.parse::<AccountName>() {
                             if let Some(s) = specs.last() {
                                 if s.code.is_parent(&sections) {
                                     specs.push(AccountSpec::new(

--- a/core/chart-of-accounts/src/new/entity.rs
+++ b/core/chart-of-accounts/src/new/entity.rs
@@ -19,12 +19,7 @@ pub enum ChartEvent {
         reference: String,
         audit_info: AuditInfo,
     },
-    ControlAccountAdded {
-        spec: AccountSpec,
-        ledger_account_set_id: LedgerAccountSetId,
-        audit_info: AuditInfo,
-    },
-    ControlSubAccountAdded {
+    NodeAdded {
         spec: AccountSpec,
         ledger_account_set_id: LedgerAccountSetId,
         audit_info: AuditInfo,
@@ -42,24 +37,7 @@ pub struct Chart {
 }
 
 impl Chart {
-    pub fn create_control_account(
-        &mut self,
-        spec: &AccountSpec,
-        audit_info: AuditInfo,
-    ) -> Idempotent<LedgerAccountSetId> {
-        if self.all_accounts.contains_key(&spec.code) {
-            return Idempotent::AlreadyApplied;
-        }
-        let ledger_account_set_id = LedgerAccountSetId::new();
-        self.events.push(ChartEvent::ControlAccountAdded {
-            spec: spec.clone(),
-            ledger_account_set_id,
-            audit_info,
-        });
-        Idempotent::Executed(ledger_account_set_id)
-    }
-
-    pub fn create_control_sub_account(
+    pub fn create_node(
         &mut self,
         spec: &AccountSpec,
         audit_info: AuditInfo,
@@ -68,7 +46,7 @@ impl Chart {
             return Idempotent::AlreadyApplied;
         }
         let ledger_account_set_id = LedgerAccountSetId::new();
-        self.events.push(ChartEvent::ControlSubAccountAdded {
+        self.events.push(ChartEvent::NodeAdded {
             spec: spec.clone(),
             ledger_account_set_id,
             audit_info,
@@ -99,14 +77,7 @@ impl TryFromEvents<ChartEvent> for Chart {
                         .reference(reference.to_string())
                         .name(name.to_string())
                 }
-                ChartEvent::ControlAccountAdded {
-                    spec,
-                    ledger_account_set_id,
-                    ..
-                } => {
-                    all_accounts.insert(spec.code.clone(), (spec.clone(), *ledger_account_set_id));
-                }
-                ChartEvent::ControlSubAccountAdded {
+                ChartEvent::NodeAdded {
                     spec,
                     ledger_account_set_id,
                     ..

--- a/core/chart-of-accounts/src/new/entity.rs
+++ b/core/chart-of-accounts/src/new/entity.rs
@@ -8,6 +8,7 @@ use audit::AuditInfo;
 use es_entity::*;
 
 use super::primitives::*;
+use super::tree;
 
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -57,6 +58,10 @@ impl Chart {
             None
         };
         Idempotent::Executed((parent, ledger_account_set_id))
+    }
+
+    pub fn chart(&self) -> tree::ChartTree {
+        tree::project(self.events.iter_all())
     }
 }
 

--- a/core/chart-of-accounts/src/new/mod.rs
+++ b/core/chart-of-accounts/src/new/mod.rs
@@ -2,6 +2,7 @@ mod csv;
 mod entity;
 mod primitives;
 mod repo;
+pub mod tree;
 
 use audit::AuditSvc;
 use authz::PermissionCheck;

--- a/core/chart-of-accounts/src/new/mod.rs
+++ b/core/chart-of-accounts/src/new/mod.rs
@@ -118,35 +118,22 @@ where
         let mut new_account_sets = Vec::new();
         let mut new_connections = Vec::new();
         for spec in account_specs {
-            if !spec.has_parent() {
-                if let es_entity::Idempotent::Executed(set_id) =
-                    chart.create_control_account(&spec, audit_info.clone())
-                {
-                    let new_account_set = NewAccountSet::builder()
-                        .id(set_id)
-                        .journal_id(self.journal_id)
-                        .name(spec.category.to_string())
-                        .description(spec.category.to_string())
-                        .external_id(spec.account_set_external_id(id))
-                        // .normal_balance_type()
-                        .build()
-                        .expect("Could not build new account set");
-                    new_account_sets.push(new_account_set);
-                }
-            } else if let es_entity::Idempotent::Executed((parent, set_id)) =
-                chart.create_control_sub_account(&spec, audit_info.clone())
+            if let es_entity::Idempotent::Executed((parent, set_id)) =
+                chart.create_node(&spec, audit_info.clone())
             {
                 let new_account_set = NewAccountSet::builder()
                     .id(set_id)
                     .journal_id(self.journal_id)
-                    .name(spec.category.to_string())
-                    .description(spec.category.to_string())
+                    .name(spec.name.to_string())
+                    .description(spec.name.to_string())
                     .external_id(spec.account_set_external_id(id))
                     // .normal_balance_type()
                     .build()
                     .expect("Could not build new account set");
                 new_account_sets.push(new_account_set);
-                new_connections.push((parent, set_id));
+                if let Some(parent) = parent {
+                    new_connections.push((parent, set_id));
+                }
             }
         }
         let mut op = self.repo.begin_op().await?;
@@ -159,12 +146,10 @@ where
             .await?;
 
         for (parent, child) in new_connections {
-            if let Some(parent) = parent {
-                self.cala
-                    .account_sets()
-                    .add_member_in_op(&mut op, parent, child)
-                    .await?;
-            }
+            self.cala
+                .account_sets()
+                .add_member_in_op(&mut op, parent, child)
+                .await?;
         }
         op.commit().await?;
         Ok(())

--- a/core/chart-of-accounts/src/new/primitives.rs
+++ b/core/chart-of-accounts/src/new/primitives.rs
@@ -56,7 +56,7 @@ pub enum AccountCodeSectionParseError {
     NonDigit,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AccountCodeSection {
     code: String,
 }
@@ -84,7 +84,7 @@ impl std::fmt::Display for AccountCodeSection {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AccountCode {
     section: Vec<AccountCodeSection>,
 }

--- a/core/chart-of-accounts/src/new/primitives.rs
+++ b/core/chart-of-accounts/src/new/primitives.rs
@@ -13,7 +13,7 @@ pub use crate::primitives::ChartId;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum AccountCategoryParseError {
+pub enum AccountNameParseError {
     #[error("empty")]
     Empty,
     #[error("starts-with-digit")]
@@ -21,28 +21,28 @@ pub enum AccountCategoryParseError {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct AccountCategory {
+pub struct AccountName {
     name: String,
 }
 
-impl std::fmt::Display for AccountCategory {
+impl std::fmt::Display for AccountName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
     }
 }
 
-impl FromStr for AccountCategory {
-    type Err = AccountCategoryParseError;
+impl FromStr for AccountName {
+    type Err = AccountNameParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let trimmed = s.trim();
         if trimmed.is_empty() {
-            return Err(AccountCategoryParseError::Empty);
+            return Err(AccountNameParseError::Empty);
         }
         if trimmed.chars().next().unwrap().is_ascii_digit() {
-            return Err(AccountCategoryParseError::StartsWithDigit);
+            return Err(AccountNameParseError::StartsWithDigit);
         }
-        Ok(AccountCategory {
+        Ok(AccountName {
             name: trimmed.to_string(),
         })
     }
@@ -148,21 +148,17 @@ impl std::fmt::Display for AccountCode {
 pub struct AccountSpec {
     pub parent: Option<AccountCode>,
     pub code: AccountCode,
-    pub category: AccountCategory,
+    pub name: AccountName,
 }
 
 impl AccountSpec {
     pub(super) fn new(
         parent: Option<AccountCode>,
         sections: Vec<AccountCodeSection>,
-        category: AccountCategory,
+        name: AccountName,
     ) -> Self {
         let code = AccountCode { section: sections };
-        AccountSpec {
-            parent,
-            code,
-            category,
-        }
+        AccountSpec { parent, code, name }
     }
 
     pub(super) fn account_set_external_id(&self, chart_id: ChartId) -> String {

--- a/core/chart-of-accounts/src/new/tree.rs
+++ b/core/chart-of-accounts/src/new/tree.rs
@@ -1,0 +1,256 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    rc::{Rc, Weak},
+};
+
+use crate::{primitives::LedgerAccountSetId, ChartId};
+
+use super::{AccountCode, AccountName, AccountSpec, ChartEvent};
+
+#[derive(Debug)]
+pub struct ChartTree {
+    pub id: ChartId,
+    pub name: String,
+    pub children: Vec<TreeNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TreeNode {
+    pub id: LedgerAccountSetId,
+    pub code: AccountCode,
+    pub name: AccountName,
+    pub parent: Option<AccountCode>,
+    pub children: Vec<TreeNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TreeNodeWithRef {
+    id: LedgerAccountSetId,
+    code: AccountCode,
+    name: AccountName,
+    parent: Option<AccountCode>,
+    children: Vec<Rc<RefCell<TreeNodeWithRef>>>,
+}
+
+impl TreeNodeWithRef {
+    fn into_node(self) -> TreeNode {
+        TreeNode {
+            id: self.id,
+            code: self.code,
+            name: self.name,
+            parent: self.parent,
+            children: self
+                .children
+                .into_iter()
+                .map(|child_rc| {
+                    let child = Rc::try_unwrap(child_rc)
+                        .expect("Child has multiple owners")
+                        .into_inner();
+                    child.into_node()
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EntityNode {
+    pub id: LedgerAccountSetId,
+    pub spec: AccountSpec,
+}
+
+pub(super) fn project<'a>(events: impl DoubleEndedIterator<Item = &'a ChartEvent>) -> ChartTree {
+    let mut id: Option<ChartId> = None;
+    let mut name: Option<String> = None;
+    let mut entity_nodes: Vec<EntityNode> = vec![];
+
+    for event in events {
+        match event {
+            ChartEvent::Initialized {
+                id: chart_id,
+                name: chart_name,
+                ..
+            } => {
+                id = Some(*chart_id);
+                name = Some(chart_name.to_string());
+            }
+            ChartEvent::NodeAdded {
+                ledger_account_set_id: id,
+                spec,
+                ..
+            } => entity_nodes.push(EntityNode {
+                id: *id,
+                spec: spec.clone(),
+            }),
+        }
+    }
+
+    let mut chart_children: Vec<Rc<RefCell<TreeNodeWithRef>>> = vec![];
+    let mut tree_nodes_by_code: HashMap<AccountCode, Weak<RefCell<TreeNodeWithRef>>> =
+        HashMap::new();
+
+    entity_nodes.sort_by_key(|l| l.spec.code.clone());
+    for node in entity_nodes {
+        let node_rc = Rc::new(RefCell::new(TreeNodeWithRef {
+            id: node.id,
+            code: node.spec.code.clone(),
+            name: node.spec.name.clone(),
+            parent: node.spec.parent.clone(),
+            children: vec![],
+        }));
+        if let Some(parent) = node.spec.parent {
+            tree_nodes_by_code
+                .get_mut(&parent)
+                .expect("Parent missing in tree_nodes_by_code for code")
+                .upgrade()
+                .expect("Parent node for code was dropped")
+                .borrow_mut()
+                .children
+                .push(Rc::clone(&node_rc));
+        } else {
+            chart_children.push(Rc::clone(&node_rc));
+        }
+
+        tree_nodes_by_code
+            .entry(node.spec.code)
+            .or_insert_with(|| Rc::downgrade(&node_rc));
+    }
+
+    ChartTree {
+        id: id.expect("chart id is missing"),
+        name: name.expect("chart name is missing"),
+        children: chart_children
+            .into_iter()
+            .map(|child_rc| {
+                let child_refcell = Rc::try_unwrap(child_rc)
+                    .expect("Child has multiple owners")
+                    .into_inner();
+                child_refcell.into_node()
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use es_entity::*;
+
+    use crate::new::{Chart, NewChart};
+
+    use super::*;
+
+    use audit::{AuditEntryId, AuditInfo};
+
+    fn dummy_audit_info() -> AuditInfo {
+        AuditInfo {
+            audit_entry_id: AuditEntryId::from(1),
+            sub: "sub".to_string(),
+        }
+    }
+
+    fn init_chart_of_events() -> Chart {
+        let id = ChartId::new();
+        let audit_info = dummy_audit_info();
+
+        let new_chart = NewChart::builder()
+            .id(id)
+            .name("Test Chart".to_string())
+            .reference("ref-01".to_string())
+            .audit_info(audit_info)
+            .build()
+            .unwrap();
+
+        let events = new_chart.into_events();
+        Chart::try_from_events(events).unwrap()
+    }
+
+    #[test]
+    fn test_project_chart_structure() {
+        let mut chart = init_chart_of_events();
+
+        {
+            chart
+                .create_node(
+                    &AccountSpec {
+                        parent: None,
+                        code: AccountCode::new(vec!["1".parse().unwrap()]),
+                        name: "Assets".parse().unwrap(),
+                    },
+                    dummy_audit_info(),
+                )
+                .unwrap();
+            chart
+                .create_node(
+                    &AccountSpec {
+                        parent: Some(AccountCode::new(vec!["1".parse().unwrap()])),
+                        code: AccountCode::new(vec!["11".parse().unwrap()]),
+                        name: "Assets".parse().unwrap(),
+                    },
+                    dummy_audit_info(),
+                )
+                .unwrap();
+            chart
+                .create_node(
+                    &AccountSpec {
+                        parent: Some(AccountCode::new(vec!["11".parse().unwrap()])),
+                        code: AccountCode::new(
+                            vec!["11", "01"]
+                                .iter()
+                                .map(|c| c.parse().unwrap())
+                                .collect(),
+                        ),
+                        name: "Cash".parse().unwrap(),
+                    },
+                    dummy_audit_info(),
+                )
+                .unwrap();
+            chart
+                .create_node(
+                    &AccountSpec {
+                        parent: Some(AccountCode::new(
+                            vec!["11", "01"]
+                                .iter()
+                                .map(|c| c.parse().unwrap())
+                                .collect(),
+                        )),
+                        code: AccountCode::new(
+                            vec!["11", "01", "0101"]
+                                .iter()
+                                .map(|c| c.parse().unwrap())
+                                .collect(),
+                        ),
+                        name: "Central Office".parse().unwrap(),
+                    },
+                    dummy_audit_info(),
+                )
+                .unwrap();
+        }
+        let tree = chart.chart();
+        let assets = &tree.children[0];
+        assert_eq!(assets.code, AccountCode::new(vec!["1".parse().unwrap()]));
+        let assets_2 = &assets.children[0];
+        assert_eq!(assets_2.code, AccountCode::new(vec!["11".parse().unwrap()]));
+        let cash = &assets_2.children[0];
+        assert_eq!(
+            cash.code,
+            AccountCode::new(
+                vec!["11", "01"]
+                    .iter()
+                    .map(|c| c.parse().unwrap())
+                    .collect(),
+            )
+        );
+        let central_office = &cash.children[0];
+        assert_eq!(
+            central_office.code,
+            AccountCode::new(
+                vec!["11", "01", "0101"]
+                    .iter()
+                    .map(|c| c.parse().unwrap())
+                    .collect(),
+            )
+        );
+        assert!(central_office.children.is_empty());
+    }
+}


### PR DESCRIPTION
## Description

This PR is to remove the opinionated `Category`/`ControlAccount`/`ControlSubAccount` hierarchy and to instead use a more generic `Node` element to represent nodes and levels in the chart