### PR TITLE
chore(reporting): sync sumsub data every two minutes

### DIFF
--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -40,8 +40,8 @@ schedules:
 - name: poll-bitfinex-on-minute
   interval: '* * * * *'
   job: poll-bitfinex
-- name: sync-sumsub-hourly
-  interval: '@hourly'
+- name: sync-sumsub-on-minute
+  interval: '*/2 * * * *'
   job: sync-sumsub
 - name: test-dbt-daily
   interval: '@daily'


### PR DESCRIPTION
Since we're using incremental loading for sumsub (only make an api call when there are new rows in the sumsub_callbacks table) this should not cause issues with the API limits.