### PR TITLE
feat: expand credit internal account sets

### DIFF
--- a/apps/admin-panel/app/modules/credit-config-update.tsx
+++ b/apps/admin-panel/app/modules/credit-config-update.tsx
@@ -30,10 +30,16 @@ gql`
         chartOfAccountCollateralOmnibusParentCode
         chartOfAccountFacilityParentCode
         chartOfAccountCollateralParentCode
-        chartOfAccountDisbursedReceivableParentCode
         chartOfAccountInterestReceivableParentCode
         chartOfAccountInterestIncomeParentCode
         chartOfAccountFeeIncomeParentCode
+        chartOfAccountIndividualDisbursedReceivableParentCode
+        chartOfAccountGovernmentEntityDisbursedReceivableParentCode
+        chartOfAccountPrivateCompanyDisbursedReceivableParentCode
+        chartOfAccountBankDisbursedReceivableParentCode
+        chartOfAccountFinancialInstitutionDisbursedReceivableParentCode
+        chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode
+        chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode
       }
     }
   }
@@ -50,10 +56,16 @@ const initialFormData = {
   chartOfAccountCollateralOmnibusParentCode: "",
   chartOfAccountFacilityParentCode: "",
   chartOfAccountCollateralParentCode: "",
-  chartOfAccountDisbursedReceivableParentCode: "",
   chartOfAccountInterestReceivableParentCode: "",
   chartOfAccountInterestIncomeParentCode: "",
   chartOfAccountFeeIncomeParentCode: "",
+  chartOfAccountIndividualDisbursedReceivableParentCode: "",
+  chartOfAccountGovernmentEntityDisbursedReceivableParentCode: "",
+  chartOfAccountPrivateCompanyDisbursedReceivableParentCode: "",
+  chartOfAccountBankDisbursedReceivableParentCode: "",
+  chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: "",
+  chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: "",
+  chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: "",
 }
 
 export const CreditConfigUpdateDialog: React.FC<CreditConfigUpdateDialogProps> = ({
@@ -83,10 +95,16 @@ export const CreditConfigUpdateDialog: React.FC<CreditConfigUpdateDialogProps> =
       creditModuleConfig.chartOfAccountCollateralOmnibusParentCode &&
       creditModuleConfig.chartOfAccountFacilityParentCode &&
       creditModuleConfig.chartOfAccountCollateralParentCode &&
-      creditModuleConfig.chartOfAccountDisbursedReceivableParentCode &&
       creditModuleConfig.chartOfAccountInterestReceivableParentCode &&
       creditModuleConfig.chartOfAccountInterestIncomeParentCode &&
-      creditModuleConfig.chartOfAccountFeeIncomeParentCode
+      creditModuleConfig.chartOfAccountFeeIncomeParentCode &&
+      creditModuleConfig.chartOfAccountIndividualDisbursedReceivableParentCode &&
+      creditModuleConfig.chartOfAccountGovernmentEntityDisbursedReceivableParentCode &&
+      creditModuleConfig.chartOfAccountPrivateCompanyDisbursedReceivableParentCode &&
+      creditModuleConfig.chartOfAccountBankDisbursedReceivableParentCode &&
+      creditModuleConfig.chartOfAccountFinancialInstitutionDisbursedReceivableParentCode &&
+      creditModuleConfig.chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode &&
+      creditModuleConfig.chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode
     ) {
       setFormData({
         chartOfAccountFacilityOmnibusParentCode:
@@ -97,14 +115,26 @@ export const CreditConfigUpdateDialog: React.FC<CreditConfigUpdateDialogProps> =
           creditModuleConfig.chartOfAccountFacilityParentCode,
         chartOfAccountCollateralParentCode:
           creditModuleConfig.chartOfAccountCollateralParentCode,
-        chartOfAccountDisbursedReceivableParentCode:
-          creditModuleConfig.chartOfAccountDisbursedReceivableParentCode,
         chartOfAccountInterestReceivableParentCode:
           creditModuleConfig.chartOfAccountInterestReceivableParentCode,
         chartOfAccountInterestIncomeParentCode:
           creditModuleConfig.chartOfAccountInterestIncomeParentCode,
         chartOfAccountFeeIncomeParentCode:
           creditModuleConfig.chartOfAccountFeeIncomeParentCode,
+        chartOfAccountIndividualDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountIndividualDisbursedReceivableParentCode,
+        chartOfAccountGovernmentEntityDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountGovernmentEntityDisbursedReceivableParentCode,
+        chartOfAccountPrivateCompanyDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountPrivateCompanyDisbursedReceivableParentCode,
+        chartOfAccountBankDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountBankDisbursedReceivableParentCode,
+        chartOfAccountFinancialInstitutionDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountFinancialInstitutionDisbursedReceivableParentCode,
+        chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode,
+        chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode:
+          creditModuleConfig.chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode,
       })
     }
   }, [creditModuleConfig])

--- a/apps/admin-panel/app/modules/page.tsx
+++ b/apps/admin-panel/app/modules/page.tsx
@@ -39,10 +39,16 @@ gql`
       chartOfAccountCollateralOmnibusParentCode
       chartOfAccountFacilityParentCode
       chartOfAccountCollateralParentCode
-      chartOfAccountDisbursedReceivableParentCode
       chartOfAccountInterestReceivableParentCode
       chartOfAccountInterestIncomeParentCode
       chartOfAccountFeeIncomeParentCode
+      chartOfAccountIndividualDisbursedReceivableParentCode
+      chartOfAccountGovernmentEntityDisbursedReceivableParentCode
+      chartOfAccountPrivateCompanyDisbursedReceivableParentCode
+      chartOfAccountBankDisbursedReceivableParentCode
+      chartOfAccountFinancialInstitutionDisbursedReceivableParentCode
+      chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode
+      chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode
     }
   }
 `

--- a/apps/admin-panel/i18n.lock
+++ b/apps/admin-panel/i18n.lock
@@ -742,10 +742,16 @@ checksums:
     Modules/credit/chartOfAccountCollateralOmnibusParentCode: 1ef5f1593be70bd9c306b0dc7144cf69
     Modules/credit/chartOfAccountFacilityParentCode: 2f989fd7b573d6c58697bc7f3584bd6c
     Modules/credit/chartOfAccountCollateralParentCode: 0369fcbe2714bbef2ad97d2dcb74d021
-    Modules/credit/chartOfAccountDisbursedReceivableParentCode: c847cdf7a4ae05d52c73fcb218b9ea71
     Modules/credit/chartOfAccountInterestReceivableParentCode: e3582dd5597fda4cd2eb142eb9a04293
     Modules/credit/chartOfAccountInterestIncomeParentCode: 6f7bc91587039fec7e07edc8214be0b1
     Modules/credit/chartOfAccountFeeIncomeParentCode: 41eb6f093aee01175ddc0a61cb612efd
+    Modules/credit/chartOfAccountIndividualDisbursedReceivableParentCode: 6334b976cbbbacf0857c41db46b11905
+    Modules/credit/chartOfAccountGovernmentEntityDisbursedReceivableParentCode: a93ecb33842432d702359f4f1ca87a9d
+    Modules/credit/chartOfAccountPrivateCompanyDisbursedReceivableParentCode: 255e30c0d0e7d8785bca905a7007bb8f
+    Modules/credit/chartOfAccountBankDisbursedReceivableParentCode: 8522ba23c486112756c71a643ab0e083
+    Modules/credit/chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: 79ea826786bd3cb45d4fbae8f55fc085
+    Modules/credit/chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: b485904fa834748bad3c12abace20914
+    Modules/credit/chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: 3964f5670235daf95cf72c8266733182
     ChartOfAccountsLedgerAccount/title: b156c85b7cdaac35654dfa3b8bcc6cf2
     ChartOfAccountsLedgerAccount/description: cd8f9f4d52de7097bb3bf5df68df82f8
     ChartOfAccountsLedgerAccount/details/code: 9218742c297d337fdc0f5f5dd985294d

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -616,26 +616,38 @@ export enum CreditFacilityStatus {
 
 export type CreditModuleConfig = {
   __typename?: 'CreditModuleConfig';
+  chartOfAccountBankDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountCollateralOmnibusParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountCollateralParentCode?: Maybe<Scalars['String']['output']>;
-  chartOfAccountDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountFacilityOmnibusParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountFacilityParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountFeeIncomeParentCode?: Maybe<Scalars['String']['output']>;
+  chartOfAccountFinancialInstitutionDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
+  chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
+  chartOfAccountGovernmentEntityDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
+  chartOfAccountIndividualDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountInterestIncomeParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountInterestReceivableParentCode?: Maybe<Scalars['String']['output']>;
+  chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
+  chartOfAccountPrivateCompanyDisbursedReceivableParentCode?: Maybe<Scalars['String']['output']>;
   chartOfAccountsId?: Maybe<Scalars['UUID']['output']>;
 };
 
 export type CreditModuleConfigureInput = {
+  chartOfAccountBankDisbursedReceivableParentCode: Scalars['String']['input'];
   chartOfAccountCollateralOmnibusParentCode: Scalars['String']['input'];
   chartOfAccountCollateralParentCode: Scalars['String']['input'];
-  chartOfAccountDisbursedReceivableParentCode: Scalars['String']['input'];
   chartOfAccountFacilityOmnibusParentCode: Scalars['String']['input'];
   chartOfAccountFacilityParentCode: Scalars['String']['input'];
   chartOfAccountFeeIncomeParentCode: Scalars['String']['input'];
+  chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: Scalars['String']['input'];
+  chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: Scalars['String']['input'];
+  chartOfAccountGovernmentEntityDisbursedReceivableParentCode: Scalars['String']['input'];
+  chartOfAccountIndividualDisbursedReceivableParentCode: Scalars['String']['input'];
   chartOfAccountInterestIncomeParentCode: Scalars['String']['input'];
   chartOfAccountInterestReceivableParentCode: Scalars['String']['input'];
+  chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: Scalars['String']['input'];
+  chartOfAccountPrivateCompanyDisbursedReceivableParentCode: Scalars['String']['input'];
 };
 
 export type CreditModuleConfigurePayload = {
@@ -2192,7 +2204,7 @@ export type CreditModuleConfigureMutationVariables = Exact<{
 }>;
 
 
-export type CreditModuleConfigureMutation = { __typename?: 'Mutation', creditModuleConfigure: { __typename?: 'CreditModuleConfigurePayload', creditConfig: { __typename?: 'CreditModuleConfig', chartOfAccountsId?: string | null, chartOfAccountFacilityOmnibusParentCode?: string | null, chartOfAccountCollateralOmnibusParentCode?: string | null, chartOfAccountFacilityParentCode?: string | null, chartOfAccountCollateralParentCode?: string | null, chartOfAccountDisbursedReceivableParentCode?: string | null, chartOfAccountInterestReceivableParentCode?: string | null, chartOfAccountInterestIncomeParentCode?: string | null, chartOfAccountFeeIncomeParentCode?: string | null } } };
+export type CreditModuleConfigureMutation = { __typename?: 'Mutation', creditModuleConfigure: { __typename?: 'CreditModuleConfigurePayload', creditConfig: { __typename?: 'CreditModuleConfig', chartOfAccountsId?: string | null, chartOfAccountFacilityOmnibusParentCode?: string | null, chartOfAccountCollateralOmnibusParentCode?: string | null, chartOfAccountFacilityParentCode?: string | null, chartOfAccountCollateralParentCode?: string | null, chartOfAccountInterestReceivableParentCode?: string | null, chartOfAccountInterestIncomeParentCode?: string | null, chartOfAccountFeeIncomeParentCode?: string | null, chartOfAccountIndividualDisbursedReceivableParentCode?: string | null, chartOfAccountGovernmentEntityDisbursedReceivableParentCode?: string | null, chartOfAccountPrivateCompanyDisbursedReceivableParentCode?: string | null, chartOfAccountBankDisbursedReceivableParentCode?: string | null, chartOfAccountFinancialInstitutionDisbursedReceivableParentCode?: string | null, chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode?: string | null, chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode?: string | null } } };
 
 export type DepositModuleConfigureMutationVariables = Exact<{
   input: DepositModuleConfigureInput;
@@ -2209,7 +2221,7 @@ export type DepositConfigQuery = { __typename?: 'Query', depositConfig?: { __typ
 export type CreditConfigQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type CreditConfigQuery = { __typename?: 'Query', creditConfig?: { __typename?: 'CreditModuleConfig', chartOfAccountFacilityOmnibusParentCode?: string | null, chartOfAccountCollateralOmnibusParentCode?: string | null, chartOfAccountFacilityParentCode?: string | null, chartOfAccountCollateralParentCode?: string | null, chartOfAccountDisbursedReceivableParentCode?: string | null, chartOfAccountInterestReceivableParentCode?: string | null, chartOfAccountInterestIncomeParentCode?: string | null, chartOfAccountFeeIncomeParentCode?: string | null } | null };
+export type CreditConfigQuery = { __typename?: 'Query', creditConfig?: { __typename?: 'CreditModuleConfig', chartOfAccountFacilityOmnibusParentCode?: string | null, chartOfAccountCollateralOmnibusParentCode?: string | null, chartOfAccountFacilityParentCode?: string | null, chartOfAccountCollateralParentCode?: string | null, chartOfAccountInterestReceivableParentCode?: string | null, chartOfAccountInterestIncomeParentCode?: string | null, chartOfAccountFeeIncomeParentCode?: string | null, chartOfAccountIndividualDisbursedReceivableParentCode?: string | null, chartOfAccountGovernmentEntityDisbursedReceivableParentCode?: string | null, chartOfAccountPrivateCompanyDisbursedReceivableParentCode?: string | null, chartOfAccountBankDisbursedReceivableParentCode?: string | null, chartOfAccountFinancialInstitutionDisbursedReceivableParentCode?: string | null, chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode?: string | null, chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode?: string | null } | null };
 
 export type PolicyAssignCommitteeMutationVariables = Exact<{
   input: PolicyAssignCommitteeInput;
@@ -4776,10 +4788,16 @@ export const CreditModuleConfigureDocument = gql`
       chartOfAccountCollateralOmnibusParentCode
       chartOfAccountFacilityParentCode
       chartOfAccountCollateralParentCode
-      chartOfAccountDisbursedReceivableParentCode
       chartOfAccountInterestReceivableParentCode
       chartOfAccountInterestIncomeParentCode
       chartOfAccountFeeIncomeParentCode
+      chartOfAccountIndividualDisbursedReceivableParentCode
+      chartOfAccountGovernmentEntityDisbursedReceivableParentCode
+      chartOfAccountPrivateCompanyDisbursedReceivableParentCode
+      chartOfAccountBankDisbursedReceivableParentCode
+      chartOfAccountFinancialInstitutionDisbursedReceivableParentCode
+      chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode
+      chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode
     }
   }
 }
@@ -4889,10 +4907,16 @@ export const CreditConfigDocument = gql`
     chartOfAccountCollateralOmnibusParentCode
     chartOfAccountFacilityParentCode
     chartOfAccountCollateralParentCode
-    chartOfAccountDisbursedReceivableParentCode
     chartOfAccountInterestReceivableParentCode
     chartOfAccountInterestIncomeParentCode
     chartOfAccountFeeIncomeParentCode
+    chartOfAccountIndividualDisbursedReceivableParentCode
+    chartOfAccountGovernmentEntityDisbursedReceivableParentCode
+    chartOfAccountPrivateCompanyDisbursedReceivableParentCode
+    chartOfAccountBankDisbursedReceivableParentCode
+    chartOfAccountFinancialInstitutionDisbursedReceivableParentCode
+    chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode
+    chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode
   }
 }
     `;

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -801,14 +801,20 @@ export const mockCreditModuleConfig = (overrides?: Partial<CreditModuleConfig>, 
     relationshipsToOmit.add('CreditModuleConfig');
     return {
         __typename: 'CreditModuleConfig',
+        chartOfAccountBankDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountBankDisbursedReceivableParentCode') ? overrides.chartOfAccountBankDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountCollateralOmnibusParentCode: overrides && overrides.hasOwnProperty('chartOfAccountCollateralOmnibusParentCode') ? overrides.chartOfAccountCollateralOmnibusParentCode! : faker.lorem.word(),
         chartOfAccountCollateralParentCode: overrides && overrides.hasOwnProperty('chartOfAccountCollateralParentCode') ? overrides.chartOfAccountCollateralParentCode! : faker.lorem.word(),
-        chartOfAccountDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountDisbursedReceivableParentCode') ? overrides.chartOfAccountDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountFacilityOmnibusParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFacilityOmnibusParentCode') ? overrides.chartOfAccountFacilityOmnibusParentCode! : faker.lorem.word(),
         chartOfAccountFacilityParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFacilityParentCode') ? overrides.chartOfAccountFacilityParentCode! : faker.lorem.word(),
         chartOfAccountFeeIncomeParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFeeIncomeParentCode') ? overrides.chartOfAccountFeeIncomeParentCode! : faker.lorem.word(),
+        chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFinancialInstitutionDisbursedReceivableParentCode') ? overrides.chartOfAccountFinancialInstitutionDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode') ? overrides.chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountGovernmentEntityDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountGovernmentEntityDisbursedReceivableParentCode') ? overrides.chartOfAccountGovernmentEntityDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountIndividualDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountIndividualDisbursedReceivableParentCode') ? overrides.chartOfAccountIndividualDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountInterestIncomeParentCode: overrides && overrides.hasOwnProperty('chartOfAccountInterestIncomeParentCode') ? overrides.chartOfAccountInterestIncomeParentCode! : faker.lorem.word(),
         chartOfAccountInterestReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountInterestReceivableParentCode') ? overrides.chartOfAccountInterestReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode') ? overrides.chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountPrivateCompanyDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountPrivateCompanyDisbursedReceivableParentCode') ? overrides.chartOfAccountPrivateCompanyDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountsId: overrides && overrides.hasOwnProperty('chartOfAccountsId') ? overrides.chartOfAccountsId! : generateMockValue.uuid(),
     };
 };
@@ -817,14 +823,20 @@ export const mockCreditModuleConfigureInput = (overrides?: Partial<CreditModuleC
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('CreditModuleConfigureInput');
     return {
+        chartOfAccountBankDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountBankDisbursedReceivableParentCode') ? overrides.chartOfAccountBankDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountCollateralOmnibusParentCode: overrides && overrides.hasOwnProperty('chartOfAccountCollateralOmnibusParentCode') ? overrides.chartOfAccountCollateralOmnibusParentCode! : faker.lorem.word(),
         chartOfAccountCollateralParentCode: overrides && overrides.hasOwnProperty('chartOfAccountCollateralParentCode') ? overrides.chartOfAccountCollateralParentCode! : faker.lorem.word(),
-        chartOfAccountDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountDisbursedReceivableParentCode') ? overrides.chartOfAccountDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountFacilityOmnibusParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFacilityOmnibusParentCode') ? overrides.chartOfAccountFacilityOmnibusParentCode! : faker.lorem.word(),
         chartOfAccountFacilityParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFacilityParentCode') ? overrides.chartOfAccountFacilityParentCode! : faker.lorem.word(),
         chartOfAccountFeeIncomeParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFeeIncomeParentCode') ? overrides.chartOfAccountFeeIncomeParentCode! : faker.lorem.word(),
+        chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountFinancialInstitutionDisbursedReceivableParentCode') ? overrides.chartOfAccountFinancialInstitutionDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode') ? overrides.chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountGovernmentEntityDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountGovernmentEntityDisbursedReceivableParentCode') ? overrides.chartOfAccountGovernmentEntityDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountIndividualDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountIndividualDisbursedReceivableParentCode') ? overrides.chartOfAccountIndividualDisbursedReceivableParentCode! : faker.lorem.word(),
         chartOfAccountInterestIncomeParentCode: overrides && overrides.hasOwnProperty('chartOfAccountInterestIncomeParentCode') ? overrides.chartOfAccountInterestIncomeParentCode! : faker.lorem.word(),
         chartOfAccountInterestReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountInterestReceivableParentCode') ? overrides.chartOfAccountInterestReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode') ? overrides.chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode! : faker.lorem.word(),
+        chartOfAccountPrivateCompanyDisbursedReceivableParentCode: overrides && overrides.hasOwnProperty('chartOfAccountPrivateCompanyDisbursedReceivableParentCode') ? overrides.chartOfAccountPrivateCompanyDisbursedReceivableParentCode! : faker.lorem.word(),
     };
 };
 

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -1298,10 +1298,16 @@
       "chartOfAccountCollateralOmnibusParentCode": "Collateral Omnibus Parent Code",
       "chartOfAccountFacilityParentCode": "Facility Parent Code",
       "chartOfAccountCollateralParentCode": "Collateral Parent Code",
-      "chartOfAccountDisbursedReceivableParentCode": "Disbursed Receivable Parent Code",
       "chartOfAccountInterestReceivableParentCode": "Interest Receivable Parent Code",
       "chartOfAccountInterestIncomeParentCode": "Interest Income Parent Code",
-      "chartOfAccountFeeIncomeParentCode": "Fee Income Parent Code"
+      "chartOfAccountFeeIncomeParentCode": "Fee Income Parent Code",
+      "chartOfAccountIndividualDisbursedReceivableParentCode": "Disbursed Individual Parent Code",
+      "chartOfAccountGovernmentEntityDisbursedReceivableParentCode": "Disbursed Government Entity Receivable Parent Code",
+      "chartOfAccountPrivateCompanyDisbursedReceivableParentCode": "Disbursed Private Company Receivable Parent Code",
+      "chartOfAccountBankDisbursedReceivableParentCode": "Disbursed Bank Receivable Parent Code",
+      "chartOfAccountFinancialInstitutionDisbursedReceivableParentCode": "Disbursed Financial Institution Receivable Parent Code",
+      "chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode": "Disbursed Foreign Agency Or Subsidiary Receivable Parent Code",
+      "chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode": "Disbursed Non-Domiciled Company Receivable Parent Code"
     }
   },
   "ChartOfAccountsLedgerAccount": {

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -1298,10 +1298,17 @@
       "chartOfAccountCollateralOmnibusParentCode": "Código padre ómnibus de garantía",
       "chartOfAccountFacilityParentCode": "Código padre de facilidad",
       "chartOfAccountCollateralParentCode": "Código padre de garantía",
-      "chartOfAccountDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas",
       "chartOfAccountInterestReceivableParentCode": "Código padre de intereses por cobrar",
       "chartOfAccountInterestIncomeParentCode": "Código padre de ingresos por intereses",
-      "chartOfAccountFeeIncomeParentCode": "Código padre de ingresos por comisiones"
+      "chartOfAccountFeeIncomeParentCode": "Código padre de ingresos por comisiones",
+      "chartOfAccountDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas",
+      "chartOfAccountIndividualDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos individuales",
+      "chartOfAccountGovernmentEntityDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a entidades gubernamentales",
+      "chartOfAccountPrivateCompanyDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a empresas privadas",
+      "chartOfAccountBankDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a bancos",
+      "chartOfAccountFinancialInstitutionDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a instituciones financieras",
+      "chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a agencias o filiales extranjeras",
+      "chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a empresas no domiciliadas"
     }
   },
   "ChartOfAccountsLedgerAccount": {

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -1301,14 +1301,13 @@
       "chartOfAccountInterestReceivableParentCode": "Código padre de intereses por cobrar",
       "chartOfAccountInterestIncomeParentCode": "Código padre de ingresos por intereses",
       "chartOfAccountFeeIncomeParentCode": "Código padre de ingresos por comisiones",
-      "chartOfAccountDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas",
-      "chartOfAccountIndividualDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos individuales",
-      "chartOfAccountGovernmentEntityDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a entidades gubernamentales",
-      "chartOfAccountPrivateCompanyDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a empresas privadas",
-      "chartOfAccountBankDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a bancos",
-      "chartOfAccountFinancialInstitutionDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a instituciones financieras",
-      "chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a agencias o filiales extranjeras",
-      "chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode": "Código padre de cuenta matriz de desembolsos a empresas no domiciliadas"
+      "chartOfAccountIndividualDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a individuos",
+      "chartOfAccountGovernmentEntityDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a entidades gubernamentales",
+      "chartOfAccountPrivateCompanyDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a empresas privadas",
+      "chartOfAccountBankDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a bancos",
+      "chartOfAccountFinancialInstitutionDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a instituciones financieras",
+      "chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a agencias extranjeras o subsidiarias",
+      "chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode": "Código padre de cuentas por cobrar desembolsadas a empresas no domiciliadas"
     }
   },
   "ChartOfAccountsLedgerAccount": {

--- a/core/credit/src/chart_of_accounts_integration.rs
+++ b/core/credit/src/chart_of_accounts_integration.rs
@@ -11,10 +11,17 @@ pub struct ChartOfAccountsIntegrationConfig {
     pub chart_of_account_collateral_omnibus_parent_code: AccountCode,
     pub chart_of_account_facility_parent_code: AccountCode,
     pub chart_of_account_collateral_parent_code: AccountCode,
-    pub chart_of_account_disbursed_receivable_parent_code: AccountCode,
     pub chart_of_account_interest_receivable_parent_code: AccountCode,
     pub chart_of_account_interest_income_parent_code: AccountCode,
     pub chart_of_account_fee_income_parent_code: AccountCode,
+
+    pub chart_of_account_individual_disbursed_receivable_parent_code: AccountCode,
+    pub chart_of_account_government_entity_disbursed_receivable_parent_code: AccountCode,
+    pub chart_of_account_private_company_disbursed_receivable_parent_code: AccountCode,
+    pub chart_of_account_bank_disbursed_receivable_parent_code: AccountCode,
+    pub chart_of_account_financial_institution_disbursed_receivable_parent_code: AccountCode,
+    pub chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code: AccountCode,
+    pub chart_of_account_non_domiciled_company_disbursed_receivable_parent_code: AccountCode,
 }
 
 impl ChartOfAccountsIntegrationConfig {

--- a/core/credit/src/ledger/constants.rs
+++ b/core/credit/src/ledger/constants.rs
@@ -16,10 +16,34 @@ pub const CREDIT_FACILITY_REMAINING_ACCOUNT_SET_REF: &str = "credit-facility-rem
 pub const CREDIT_COLLATERAL_ACCOUNT_SET_NAME: &str = "Credit Collateral Account Set";
 pub const CREDIT_COLLATERAL_ACCOUNT_SET_REF: &str = "credit-collateral-account-set";
 
-pub const CREDIT_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
-    "Credit Disbursed Receivable Account Set";
-pub const CREDIT_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
-    "credit-disbursed-receivable-account-set";
+pub const CREDIT_INDIVIDUAL_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Individual Disbursed Receivable Account Set";
+pub const CREDIT_INDIVIDUAL_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-individual-disbursed-receivable-account-set";
+pub const CREDIT_GOVERNMENT_ENTITY_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Government Entity Disbursed Receivable Account Set";
+pub const CREDIT_GOVERNMENT_ENTITY_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-government-entity-disbursed-receivable-account-set";
+pub const CREDIT_PRIVATE_COMPANY_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Private Company Disbursed Receivable Account Set";
+pub const CREDIT_PRIVATE_COMPANY_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-private-company-disbursed-receivable-account-set";
+pub const CREDIT_BANK_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Bank Disbursed Receivable Account Set";
+pub const CREDIT_BANK_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-bank-disbursed-receivable-account-set";
+pub const CREDIT_FINANCIAL_INSTITUTION_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Financial Institution Disbursed Receivable Account Set";
+pub const CREDIT_FINANCIAL_INSTITUTION_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-financial-institution-disbursed-receivable-account-set";
+pub const CREDIT_FOREIGN_AGENCY_OR_SUBSIDIARY_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Foreign Agency Or Subsidiary Disbursed Receivable Account Set";
+pub const CREDIT_FOREIGN_AGENCY_OR_SUBSIDIARY_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-foreign-agency-or-subsidiary-disbursed-receivable-account-set";
+pub const CREDIT_NON_DOMICILED_COMPANY_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
+    "Credit Non-Domiciled Company Disbursed Receivable Account Set";
+pub const CREDIT_NON_DOMICILED_COMPANY_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =
+    "credit-non-domiciled-company-disbursed-receivable-account-set";
 
 pub const CREDIT_INTEREST_RECEIVABLE_ACCOUNT_SET_NAME: &str =
     "Credit Interest Receivable Account Set";

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -1083,28 +1083,9 @@ impl CreditLedger {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn attach_chart_of_accounts_account_sets(
         &self,
-        audit_info: AuditInfo,
-        config: &ChartOfAccountsIntegrationConfig,
-        facility_omnibus_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        collateral_omnibus_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        facility_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        collateral_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        interest_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        interest_income_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        fee_income_parent_account_set_id: impl Into<LedgerAccountSetId>,
-
-        individual_disbursed_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        government_entity_disbursed_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        private_company_disbursed_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        bank_disbursed_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        financial_institution_disbursed_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
-        foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id: impl Into<
-            LedgerAccountSetId,
-        >,
-        non_domiciled_company_disbursed_receivable_parent_account_set_id: impl Into<LedgerAccountSetId>,
+        charts_integration_meta: ChartOfAccountsIntegrationMeta,
     ) -> Result<(), CreditLedgerError> {
         let mut op = self.cala.begin_operation().await?;
 
@@ -1119,70 +1100,33 @@ impl CreditLedger {
             .find_all_in_op::<AccountSet>(&mut op, &account_set_ids)
             .await?;
 
-        let new_meta = ChartOfAccountsIntegrationMeta {
-            config: config.clone(),
-            facility_omnibus_parent_account_set_id: facility_omnibus_parent_account_set_id.into(),
-            collateral_omnibus_parent_account_set_id: collateral_omnibus_parent_account_set_id
-                .into(),
-            facility_parent_account_set_id: facility_parent_account_set_id.into(),
-            collateral_parent_account_set_id: collateral_parent_account_set_id.into(),
-            interest_receivable_parent_account_set_id: interest_receivable_parent_account_set_id
-                .into(),
-            interest_income_parent_account_set_id: interest_income_parent_account_set_id.into(),
-            fee_income_parent_account_set_id: fee_income_parent_account_set_id.into(),
-
-            individual_disbursed_receivable_parent_account_set_id:
-                individual_disbursed_receivable_parent_account_set_id.into(),
-            government_entity_disbursed_receivable_parent_account_set_id:
-                government_entity_disbursed_receivable_parent_account_set_id.into(),
-            private_company_disbursed_receivable_parent_account_set_id:
-                private_company_disbursed_receivable_parent_account_set_id.into(),
-            bank_disbursed_receivable_parent_account_set_id:
-                bank_disbursed_receivable_parent_account_set_id.into(),
-            financial_institution_disbursed_receivable_parent_account_set_id:
-                financial_institution_disbursed_receivable_parent_account_set_id.into(),
-            foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id:
-                foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id.into(),
-            non_domiciled_company_disbursed_receivable_parent_account_set_id:
-                non_domiciled_company_disbursed_receivable_parent_account_set_id.into(),
-
-            audit_info,
-        };
-
         let ChartOfAccountsIntegrationMeta {
             config: _,
             audit_info: _,
 
-            facility_omnibus_parent_account_set_id: facility_omnibus_parent_id_for_attach,
-            collateral_omnibus_parent_account_set_id: collateral_omnibus_parent_id_for_attach,
-            facility_parent_account_set_id: facility_parent_id_for_attach,
-            collateral_parent_account_set_id: collateral_parent_id_for_attach,
-            interest_receivable_parent_account_set_id: interest_receivable_parent_id_for_attach,
-            interest_income_parent_account_set_id: interest_income_parent_id_for_attach,
-            fee_income_parent_account_set_id: fee_income_parent_id_for_attach,
+            facility_omnibus_parent_account_set_id,
+            collateral_omnibus_parent_account_set_id,
+            facility_parent_account_set_id,
+            collateral_parent_account_set_id,
+            interest_receivable_parent_account_set_id,
+            interest_income_parent_account_set_id,
+            fee_income_parent_account_set_id,
 
-            individual_disbursed_receivable_parent_account_set_id:
-                individual_disbursed_receivable_parent_id_for_attach,
-            government_entity_disbursed_receivable_parent_account_set_id:
-                government_entity_disbursed_receivable_parent_id_for_attach,
-            private_company_disbursed_receivable_parent_account_set_id:
-                private_company_disbursed_receivable_parent_id_for_attach,
-            bank_disbursed_receivable_parent_account_set_id:
-                bank_disbursed_receivable_parent_id_for_attach,
-            financial_institution_disbursed_receivable_parent_account_set_id:
-                financial_institution_disbursed_receivable_parent_id_for_attach,
-            foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id:
-                foreign_agency_or_subsidiary_disbursed_receivable_parent_id_for_attach,
-            non_domiciled_company_disbursed_receivable_parent_account_set_id:
-                non_domiciled_company_disbursed_receivable_parent_id_for_attach,
-        } = &new_meta;
+            individual_disbursed_receivable_parent_account_set_id,
+            government_entity_disbursed_receivable_parent_account_set_id,
+            private_company_disbursed_receivable_parent_account_set_id,
+            bank_disbursed_receivable_parent_account_set_id,
+            financial_institution_disbursed_receivable_parent_account_set_id,
+            foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id,
+            non_domiciled_company_disbursed_receivable_parent_account_set_id,
+        } = &charts_integration_meta;
 
         self.attach_charts_account_set(
             &mut op,
             &mut account_sets,
             self.facility_omnibus_account_ids.account_set_id,
-            *facility_omnibus_parent_id_for_attach,
-            &new_meta,
+            *facility_omnibus_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.facility_omnibus_parent_account_set_id,
         )
         .await?;
@@ -1190,8 +1134,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.collateral_omnibus_account_ids.account_set_id,
-            *collateral_omnibus_parent_id_for_attach,
-            &new_meta,
+            *collateral_omnibus_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.collateral_omnibus_parent_account_set_id,
         )
         .await?;
@@ -1200,8 +1144,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.internal_account_sets.facility.id,
-            *facility_parent_id_for_attach,
-            &new_meta,
+            *facility_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.facility_parent_account_set_id,
         )
         .await?;
@@ -1209,8 +1153,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.internal_account_sets.collateral.id,
-            *collateral_parent_id_for_attach,
-            &new_meta,
+            *collateral_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.collateral_parent_account_set_id,
         )
         .await?;
@@ -1218,8 +1162,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.internal_account_sets.interest_receivable.id,
-            *interest_receivable_parent_id_for_attach,
-            &new_meta,
+            *interest_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.interest_receivable_parent_account_set_id,
         )
         .await?;
@@ -1227,8 +1171,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.internal_account_sets.interest_income.id,
-            *interest_income_parent_id_for_attach,
-            &new_meta,
+            *interest_income_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.interest_income_parent_account_set_id,
         )
         .await?;
@@ -1236,8 +1180,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.internal_account_sets.fee_income.id,
-            *fee_income_parent_id_for_attach,
-            &new_meta,
+            *fee_income_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.fee_income_parent_account_set_id,
         )
         .await?;
@@ -1249,8 +1193,8 @@ impl CreditLedger {
                 .disbursed_receivable
                 .individual
                 .id,
-            *individual_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *individual_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.individual_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1261,8 +1205,8 @@ impl CreditLedger {
                 .disbursed_receivable
                 .government_entity
                 .id,
-            *government_entity_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *government_entity_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.government_entity_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1273,8 +1217,8 @@ impl CreditLedger {
                 .disbursed_receivable
                 .private_company
                 .id,
-            *private_company_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *private_company_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.private_company_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1282,8 +1226,8 @@ impl CreditLedger {
             &mut op,
             &mut account_sets,
             self.internal_account_sets.disbursed_receivable.bank.id,
-            *bank_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *bank_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.bank_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1294,8 +1238,8 @@ impl CreditLedger {
                 .disbursed_receivable
                 .financial_institution
                 .id,
-            *financial_institution_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *financial_institution_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.financial_institution_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1306,8 +1250,8 @@ impl CreditLedger {
                 .disbursed_receivable
                 .foreign_agency_or_subsidiary
                 .id,
-            *foreign_agency_or_subsidiary_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1318,8 +1262,8 @@ impl CreditLedger {
                 .disbursed_receivable
                 .non_domiciled_company
                 .id,
-            *non_domiciled_company_disbursed_receivable_parent_id_for_attach,
-            &new_meta,
+            *non_domiciled_company_disbursed_receivable_parent_account_set_id,
+            &charts_integration_meta,
             |meta| meta.non_domiciled_company_disbursed_receivable_parent_account_set_id,
         )
         .await?;
@@ -1331,23 +1275,23 @@ impl CreditLedger {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-struct ChartOfAccountsIntegrationMeta {
-    config: ChartOfAccountsIntegrationConfig,
-    facility_omnibus_parent_account_set_id: LedgerAccountSetId,
-    collateral_omnibus_parent_account_set_id: LedgerAccountSetId,
-    facility_parent_account_set_id: LedgerAccountSetId,
-    collateral_parent_account_set_id: LedgerAccountSetId,
-    interest_receivable_parent_account_set_id: LedgerAccountSetId,
-    interest_income_parent_account_set_id: LedgerAccountSetId,
-    fee_income_parent_account_set_id: LedgerAccountSetId,
+pub struct ChartOfAccountsIntegrationMeta {
+    pub config: ChartOfAccountsIntegrationConfig,
+    pub audit_info: AuditInfo,
 
-    individual_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
-    government_entity_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
-    private_company_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
-    bank_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
-    financial_institution_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
-    foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
-    non_domiciled_company_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub facility_omnibus_parent_account_set_id: LedgerAccountSetId,
+    pub collateral_omnibus_parent_account_set_id: LedgerAccountSetId,
+    pub facility_parent_account_set_id: LedgerAccountSetId,
+    pub collateral_parent_account_set_id: LedgerAccountSetId,
+    pub interest_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub interest_income_parent_account_set_id: LedgerAccountSetId,
+    pub fee_income_parent_account_set_id: LedgerAccountSetId,
 
-    audit_info: AuditInfo,
+    pub individual_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub government_entity_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub private_company_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub bank_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub financial_institution_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
+    pub non_domiciled_company_disbursed_receivable_parent_account_set_id: LedgerAccountSetId,
 }

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -252,15 +252,12 @@ where
             .await?
             .expect("audit info missing");
 
-        if self.config.customer_active_check_enabled
-            && self
-                .customer
-                .find_by_id(sub, customer_id)
-                .await?
-                .ok_or(CoreCreditError::CustomerNotFound)?
-                .status
-                .is_inactive()
-        {
+        let customer = self
+            .customer
+            .find_by_id(sub, customer_id)
+            .await?
+            .ok_or(CoreCreditError::CustomerNotFound)?;
+        if self.config.customer_active_check_enabled && customer.status.is_inactive() {
             return Err(CoreCreditError::CustomerNotActive);
         }
 
@@ -292,6 +289,7 @@ where
                 &mut op,
                 credit_facility.id,
                 credit_facility.account_ids,
+                customer.customer_type.into(),
             )
             .await?;
 
@@ -923,14 +921,41 @@ where
             chart.account_set_id_from_code(&config.chart_of_account_facility_parent_code)?;
         let collateral_parent_account_set_id =
             chart.account_set_id_from_code(&config.chart_of_account_collateral_parent_code)?;
-        let disbursed_receivable_parent_account_set_id = chart
-            .account_set_id_from_code(&config.chart_of_account_disbursed_receivable_parent_code)?;
         let interest_receivable_parent_account_set_id = chart
             .account_set_id_from_code(&config.chart_of_account_interest_receivable_parent_code)?;
         let interest_income_parent_account_set_id =
             chart.account_set_id_from_code(&config.chart_of_account_interest_income_parent_code)?;
         let fee_income_parent_account_set_id =
             chart.account_set_id_from_code(&config.chart_of_account_fee_income_parent_code)?;
+
+        let individual_disbursed_receivable_parent_account_set_id = chart
+            .account_set_id_from_code(
+                &config.chart_of_account_individual_disbursed_receivable_parent_code,
+            )?;
+        let government_entity_disbursed_receivable_parent_account_set_id = chart
+            .account_set_id_from_code(
+                &config.chart_of_account_government_entity_disbursed_receivable_parent_code,
+            )?;
+        let private_company_disbursed_receivable_parent_account_set_id = chart
+            .account_set_id_from_code(
+                &config.chart_of_account_private_company_disbursed_receivable_parent_code,
+            )?;
+        let bank_disbursed_receivable_parent_account_set_id = chart.account_set_id_from_code(
+            &config.chart_of_account_bank_disbursed_receivable_parent_code,
+        )?;
+        let financial_institution_disbursed_receivable_parent_account_set_id = chart
+            .account_set_id_from_code(
+                &config.chart_of_account_financial_institution_disbursed_receivable_parent_code,
+            )?;
+        let foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id = chart
+            .account_set_id_from_code(
+                &config
+                    .chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code,
+            )?;
+        let non_domiciled_company_disbursed_receivable_parent_account_set_id = chart
+            .account_set_id_from_code(
+                &config.chart_of_account_non_domiciled_company_disbursed_receivable_parent_code,
+            )?;
 
         let audit_info = self
             .authz
@@ -949,10 +974,16 @@ where
                 collateral_omnibus_parent_account_set_id,
                 facility_parent_account_set_id,
                 collateral_parent_account_set_id,
-                disbursed_receivable_parent_account_set_id,
                 interest_receivable_parent_account_set_id,
                 interest_income_parent_account_set_id,
                 fee_income_parent_account_set_id,
+                individual_disbursed_receivable_parent_account_set_id,
+                government_entity_disbursed_receivable_parent_account_set_id,
+                private_company_disbursed_receivable_parent_account_set_id,
+                bank_disbursed_receivable_parent_account_set_id,
+                financial_institution_disbursed_receivable_parent_account_set_id,
+                foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id,
+                non_domiciled_company_disbursed_receivable_parent_account_set_id,
             )
             .await?;
 

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -966,25 +966,29 @@ where
             )
             .await?;
 
+        let charts_integration_meta = ChartOfAccountsIntegrationMeta {
+            audit_info,
+            config: config.clone(),
+
+            facility_omnibus_parent_account_set_id,
+            collateral_omnibus_parent_account_set_id,
+            facility_parent_account_set_id,
+            collateral_parent_account_set_id,
+            interest_receivable_parent_account_set_id,
+            interest_income_parent_account_set_id,
+            fee_income_parent_account_set_id,
+
+            individual_disbursed_receivable_parent_account_set_id,
+            government_entity_disbursed_receivable_parent_account_set_id,
+            private_company_disbursed_receivable_parent_account_set_id,
+            bank_disbursed_receivable_parent_account_set_id,
+            financial_institution_disbursed_receivable_parent_account_set_id,
+            foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id,
+            non_domiciled_company_disbursed_receivable_parent_account_set_id,
+        };
+
         self.ledger
-            .attach_chart_of_accounts_account_sets(
-                audit_info,
-                &config,
-                facility_omnibus_parent_account_set_id,
-                collateral_omnibus_parent_account_set_id,
-                facility_parent_account_set_id,
-                collateral_parent_account_set_id,
-                interest_receivable_parent_account_set_id,
-                interest_income_parent_account_set_id,
-                fee_income_parent_account_set_id,
-                individual_disbursed_receivable_parent_account_set_id,
-                government_entity_disbursed_receivable_parent_account_set_id,
-                private_company_disbursed_receivable_parent_account_set_id,
-                bank_disbursed_receivable_parent_account_set_id,
-                financial_institution_disbursed_receivable_parent_account_set_id,
-                foreign_agency_or_subsidiary_disbursed_receivable_parent_account_set_id,
-                non_domiciled_company_disbursed_receivable_parent_account_set_id,
-            )
+            .attach_chart_of_accounts_account_sets(charts_integration_meta)
             .await?;
 
         Ok(config)

--- a/core/credit/src/primitives.rs
+++ b/core/credit/src/primitives.rs
@@ -9,7 +9,7 @@ pub use cala_ledger::primitives::{
     DebitOrCredit as LedgerDebitOrCredit, JournalId as LedgerJournalId,
     TransactionId as LedgerTxId, TxTemplateId as LedgerTxTemplateId,
 };
-pub use core_customer::CustomerId;
+pub use core_customer::{CustomerId, CustomerType};
 pub use core_money::*;
 pub use core_price::PriceOfOneBTC;
 pub use governance::ApprovalProcessId;
@@ -290,4 +290,28 @@ impl DisbursalIdx {
 pub enum CollateralAction {
     Add,
     Remove,
+}
+
+pub enum DisbursedReceivableAccountType {
+    Individual,
+    GovernmentEntity,
+    PrivateCompany,
+    Bank,
+    FinancialInstitution,
+    ForeignAgencyOrSubsidiary,
+    NonDomiciledCompany,
+}
+
+impl From<CustomerType> for DisbursedReceivableAccountType {
+    fn from(customer_type: CustomerType) -> Self {
+        match customer_type {
+            CustomerType::Individual => Self::Individual,
+            CustomerType::GovernmentEntity => Self::GovernmentEntity,
+            CustomerType::PrivateCompany => Self::PrivateCompany,
+            CustomerType::Bank => Self::Bank,
+            CustomerType::FinancialInstitution => Self::FinancialInstitution,
+            CustomerType::ForeignAgencyOrSubsidiary => Self::ForeignAgencyOrSubsidiary,
+            CustomerType::NonDomiciledCompany => Self::NonDomiciledCompany,
+        }
+    }
 }

--- a/core/credit/tests/chart_of_accounts_integration.rs
+++ b/core/credit/tests/chart_of_accounts_integration.rs
@@ -80,10 +80,26 @@ async fn chart_of_accounts_integration() -> anyhow::Result<()> {
                 .chart_of_account_collateral_omnibus_parent_code("2".parse().unwrap())
                 .chart_of_account_facility_parent_code("3".parse().unwrap())
                 .chart_of_account_collateral_parent_code("4".parse().unwrap())
-                .chart_of_account_disbursed_receivable_parent_code("5".parse().unwrap())
                 .chart_of_account_interest_receivable_parent_code("6".parse().unwrap())
                 .chart_of_account_interest_income_parent_code("7".parse().unwrap())
                 .chart_of_account_fee_income_parent_code("8".parse().unwrap())
+                .chart_of_account_individual_disbursed_receivable_parent_code("51".parse().unwrap())
+                .chart_of_account_government_entity_disbursed_receivable_parent_code(
+                    "52".parse().unwrap(),
+                )
+                .chart_of_account_private_company_disbursed_receivable_parent_code(
+                    "53".parse().unwrap(),
+                )
+                .chart_of_account_bank_disbursed_receivable_parent_code("54".parse().unwrap())
+                .chart_of_account_financial_institution_disbursed_receivable_parent_code(
+                    "55".parse().unwrap(),
+                )
+                .chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code(
+                    "56".parse().unwrap(),
+                )
+                .chart_of_account_non_domiciled_company_disbursed_receivable_parent_code(
+                    "57".parse().unwrap(),
+                )
                 .build()
                 .unwrap(),
         )
@@ -127,10 +143,26 @@ async fn chart_of_accounts_integration() -> anyhow::Result<()> {
                 .chart_of_account_collateral_omnibus_parent_code("2".parse().unwrap())
                 .chart_of_account_facility_parent_code("3".parse().unwrap())
                 .chart_of_account_collateral_parent_code("4".parse().unwrap())
-                .chart_of_account_disbursed_receivable_parent_code("5".parse().unwrap())
                 .chart_of_account_interest_receivable_parent_code("6".parse().unwrap())
                 .chart_of_account_interest_income_parent_code("7".parse().unwrap())
                 .chart_of_account_fee_income_parent_code("8".parse().unwrap())
+                .chart_of_account_individual_disbursed_receivable_parent_code("51".parse().unwrap())
+                .chart_of_account_government_entity_disbursed_receivable_parent_code(
+                    "52".parse().unwrap(),
+                )
+                .chart_of_account_private_company_disbursed_receivable_parent_code(
+                    "53".parse().unwrap(),
+                )
+                .chart_of_account_bank_disbursed_receivable_parent_code("54".parse().unwrap())
+                .chart_of_account_financial_institution_disbursed_receivable_parent_code(
+                    "55".parse().unwrap(),
+                )
+                .chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code(
+                    "56".parse().unwrap(),
+                )
+                .chart_of_account_non_domiciled_company_disbursed_receivable_parent_code(
+                    "57".parse().unwrap(),
+                )
                 .build()
                 .unwrap(),
         )

--- a/lana/admin-server/src/graphql/credit_config.rs
+++ b/lana/admin-server/src/graphql/credit_config.rs
@@ -11,10 +11,17 @@ pub struct CreditModuleConfig {
     chart_of_account_collateral_omnibus_parent_code: Option<String>,
     chart_of_account_facility_parent_code: Option<String>,
     chart_of_account_collateral_parent_code: Option<String>,
-    chart_of_account_disbursed_receivable_parent_code: Option<String>,
     chart_of_account_interest_receivable_parent_code: Option<String>,
     chart_of_account_interest_income_parent_code: Option<String>,
     chart_of_account_fee_income_parent_code: Option<String>,
+
+    chart_of_account_individual_disbursed_receivable_parent_code: Option<String>,
+    chart_of_account_government_entity_disbursed_receivable_parent_code: Option<String>,
+    chart_of_account_private_company_disbursed_receivable_parent_code: Option<String>,
+    chart_of_account_bank_disbursed_receivable_parent_code: Option<String>,
+    chart_of_account_financial_institution_disbursed_receivable_parent_code: Option<String>,
+    chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code: Option<String>,
+    chart_of_account_non_domiciled_company_disbursed_receivable_parent_code: Option<String>,
 
     #[graphql(skip)]
     pub(super) _entity: Arc<DomainChartOfAccountsIntegrationConfig>,
@@ -40,11 +47,6 @@ impl From<DomainChartOfAccountsIntegrationConfig> for CreditModuleConfig {
             chart_of_account_collateral_parent_code: Some(
                 values.chart_of_account_collateral_parent_code.to_string(),
             ),
-            chart_of_account_disbursed_receivable_parent_code: Some(
-                values
-                    .chart_of_account_disbursed_receivable_parent_code
-                    .to_string(),
-            ),
             chart_of_account_interest_receivable_parent_code: Some(
                 values
                     .chart_of_account_interest_receivable_parent_code
@@ -58,6 +60,41 @@ impl From<DomainChartOfAccountsIntegrationConfig> for CreditModuleConfig {
             chart_of_account_fee_income_parent_code: Some(
                 values.chart_of_account_fee_income_parent_code.to_string(),
             ),
+            chart_of_account_individual_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_individual_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
+            chart_of_account_government_entity_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_government_entity_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
+            chart_of_account_private_company_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_private_company_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
+            chart_of_account_bank_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_bank_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
+            chart_of_account_financial_institution_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_financial_institution_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
+            chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
+            chart_of_account_non_domiciled_company_disbursed_receivable_parent_code: Some(
+                values
+                    .chart_of_account_non_domiciled_company_disbursed_receivable_parent_code
+                    .to_string(),
+            ),
             _entity: Arc::new(values),
         }
     }
@@ -69,9 +106,16 @@ pub struct CreditModuleConfigureInput {
     pub chart_of_account_collateral_omnibus_parent_code: String,
     pub chart_of_account_facility_parent_code: String,
     pub chart_of_account_collateral_parent_code: String,
-    pub chart_of_account_disbursed_receivable_parent_code: String,
     pub chart_of_account_interest_receivable_parent_code: String,
     pub chart_of_account_interest_income_parent_code: String,
     pub chart_of_account_fee_income_parent_code: String,
+
+    pub chart_of_account_individual_disbursed_receivable_parent_code: String,
+    pub chart_of_account_government_entity_disbursed_receivable_parent_code: String,
+    pub chart_of_account_private_company_disbursed_receivable_parent_code: String,
+    pub chart_of_account_bank_disbursed_receivable_parent_code: String,
+    pub chart_of_account_financial_institution_disbursed_receivable_parent_code: String,
+    pub chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code: String,
+    pub chart_of_account_non_domiciled_company_disbursed_receivable_parent_code: String,
 }
 crate::mutation_payload! { CreditModuleConfigurePayload, credit_config: CreditModuleConfig }

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -601,10 +601,16 @@ type CreditModuleConfig {
 	chartOfAccountCollateralOmnibusParentCode: String
 	chartOfAccountFacilityParentCode: String
 	chartOfAccountCollateralParentCode: String
-	chartOfAccountDisbursedReceivableParentCode: String
 	chartOfAccountInterestReceivableParentCode: String
 	chartOfAccountInterestIncomeParentCode: String
 	chartOfAccountFeeIncomeParentCode: String
+	chartOfAccountIndividualDisbursedReceivableParentCode: String
+	chartOfAccountGovernmentEntityDisbursedReceivableParentCode: String
+	chartOfAccountPrivateCompanyDisbursedReceivableParentCode: String
+	chartOfAccountBankDisbursedReceivableParentCode: String
+	chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: String
+	chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: String
+	chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: String
 }
 
 input CreditModuleConfigureInput {
@@ -612,10 +618,16 @@ input CreditModuleConfigureInput {
 	chartOfAccountCollateralOmnibusParentCode: String!
 	chartOfAccountFacilityParentCode: String!
 	chartOfAccountCollateralParentCode: String!
-	chartOfAccountDisbursedReceivableParentCode: String!
 	chartOfAccountInterestReceivableParentCode: String!
 	chartOfAccountInterestIncomeParentCode: String!
 	chartOfAccountFeeIncomeParentCode: String!
+	chartOfAccountIndividualDisbursedReceivableParentCode: String!
+	chartOfAccountGovernmentEntityDisbursedReceivableParentCode: String!
+	chartOfAccountPrivateCompanyDisbursedReceivableParentCode: String!
+	chartOfAccountBankDisbursedReceivableParentCode: String!
+	chartOfAccountFinancialInstitutionDisbursedReceivableParentCode: String!
+	chartOfAccountForeignAgencyOrSubsidiaryDisbursedReceivableParentCode: String!
+	chartOfAccountNonDomiciledCompanyDisbursedReceivableParentCode: String!
 }
 
 type CreditModuleConfigurePayload {

--- a/lana/admin-server/src/graphql/schema.rs
+++ b/lana/admin-server/src/graphql/schema.rs
@@ -926,11 +926,6 @@ impl Mutation {
             .chart_of_account_collateral_parent_code(
                 input.chart_of_account_collateral_parent_code.parse()?,
             )
-            .chart_of_account_disbursed_receivable_parent_code(
-                input
-                    .chart_of_account_disbursed_receivable_parent_code
-                    .parse()?,
-            )
             .chart_of_account_interest_receivable_parent_code(
                 input
                     .chart_of_account_interest_receivable_parent_code
@@ -941,6 +936,41 @@ impl Mutation {
             )
             .chart_of_account_fee_income_parent_code(
                 input.chart_of_account_fee_income_parent_code.parse()?,
+            )
+            .chart_of_account_individual_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_individual_disbursed_receivable_parent_code
+                    .parse()?,
+            )
+            .chart_of_account_government_entity_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_government_entity_disbursed_receivable_parent_code
+                    .parse()?,
+            )
+            .chart_of_account_private_company_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_private_company_disbursed_receivable_parent_code
+                    .parse()?,
+            )
+            .chart_of_account_bank_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_bank_disbursed_receivable_parent_code
+                    .parse()?,
+            )
+            .chart_of_account_financial_institution_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_financial_institution_disbursed_receivable_parent_code
+                    .parse()?,
+            )
+            .chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_foreign_agency_or_subsidiary_disbursed_receivable_parent_code
+                    .parse()?,
+            )
+            .chart_of_account_non_domiciled_company_disbursed_receivable_parent_code(
+                input
+                    .chart_of_account_non_domiciled_company_disbursed_receivable_parent_code
+                    .parse()?,
             )
             .build()?;
         let config = app


### PR DESCRIPTION
## Description

This is to expand the number of internal credit module account sets to accommodate different kinds of loan receivable chart accounts