### PR TITLE
fix: rollback multi-stage operations where one stage errors

### DIFF
--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -437,7 +437,7 @@ impl CreditLedger {
                 id
             }
             Err(cala_ledger::account::error::AccountError::ExternalIdAlreadyExists) => {
-                op.commit().await?;
+                op.rollback().await?;
                 cala.accounts().find_by_external_id(reference).await?.id
             }
             Err(e) => return Err(e.into()),

--- a/core/deposit/src/ledger/mod.rs
+++ b/core/deposit/src/ledger/mod.rs
@@ -210,7 +210,7 @@ impl DepositLedger {
                 id
             }
             Err(cala_ledger::account::error::AccountError::ExternalIdAlreadyExists) => {
-                op.commit().await?;
+                op.rollback().await?;
                 cala.accounts().find_by_external_id(reference).await?.id
             }
             Err(e) => return Err(e.into()),


### PR DESCRIPTION
Note: depends on https://github.com/GaloyMoney/cala/pull/347 and cala bump