### PR TITLE
chore: not waiting for core to compile pnpm apps

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -53,10 +53,6 @@ local_resource(
         ),
     ),
     allow_parallel=True,
-    resource_deps=[
-        "mailhog",
-        "core",
-    ],
     links = [
         link("http://localhost:4455/admin", "admin-panel"),
     ]
@@ -71,10 +67,6 @@ local_resource(
     },
     serve_cmd="cd ../apps/customer-portal && pnpm install && pnpm run dev",
     allow_parallel=True,
-    resource_deps=[
-        "mailhog",
-        "core",
-    ],
     links = [
         link("http://localhost:4455/app", "customer-portal"),
     ]


### PR DESCRIPTION
I don't think we need to wait for `core` to be up to start compile apps. it's not like compiling apps would fail is core is not up, and doing both in parrallel would accelerate the overall compile time