### PR TITLE
fix(reporting): sql mistake causing tap-sumsubapi to fail

### DIFF
--- a/meltano/extract/tap-sumsubapi/tap_sumsubapi/postgres_client.py
+++ b/meltano/extract/tap-sumsubapi/tap_sumsubapi/postgres_client.py
@@ -34,7 +34,7 @@ class PostgresClient:
                 SELECT customer_id, recorded_at
                 FROM sumsub_callbacks
                 WHERE recorded_at > %s
-                    AND content->>'type' IN ("applicantReviewed", "applicantPersonalInfoChanged")
+                    AND content->>'type' IN ('applicantReviewed', 'applicantPersonalInfoChanged')
             """
             cursor.execute(query, (starting_timestamp,))
             yield from cursor


### PR DESCRIPTION
Used double quotes `"` as in bigquery sql instead of single quotes `'` for strings.
