### PR TITLE
chore: Add journal-related permissions to authorization seed

### DIFF
--- a/core/accounting/src/primitives.rs
+++ b/core/accounting/src/primitives.rs
@@ -274,6 +274,10 @@ impl CoreAccountingObject {
         CoreAccountingObject::Chart(AllOrOne::All)
     }
 
+    pub fn all_journals() -> Self {
+        CoreAccountingObject::Journal(AllOrOne::All)
+    }
+
     pub fn journal(id: CalaJournalId) -> Self {
         CoreAccountingObject::Journal(AllOrOne::ById(id))
     }

--- a/lana/app/src/authorization/seed.rs
+++ b/lana/app/src/authorization/seed.rs
@@ -513,6 +513,13 @@ async fn add_permissions_for_bank_manager(authz: &Authorization) -> Result<(), A
     authz
         .add_permission_to_role(
             &role,
+            CoreAccountingObject::all_journals(),
+            CoreAccountingAction::JOURNAL_READ_ENTRIES,
+        )
+        .await?;
+    authz
+        .add_permission_to_role(
+            &role,
             CoreAccountingObject::all_ledger_accounts(),
             CoreAccountingAction::LEDGER_ACCOUNT_READ,
         )


### PR DESCRIPTION
After renaming General Ledger into Journal, including relevant permissions, permissions for reading journal were not added to the seed. This patch adds them.

Before:

![image](https://github.com/user-attachments/assets/9e48bfa8-1367-4e56-be50-b35402a16908)

After:

![image](https://github.com/user-attachments/assets/c45d3ee5-abd6-4cfd-a091-71351982b4a6)
