### PR TITLE
feat: add Obligation due events

### DIFF
--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -349,6 +349,20 @@ impl CreditFacility {
         self.terms.one_time_fee_rate.apply(self.initial_facility())
     }
 
+    fn disbursal_obligation_ids(&self) -> Vec<ObligationId> {
+        let mut obligation_ids = vec![];
+        for event in self.events.iter_all() {
+            if let CreditFacilityEvent::DisbursalConcluded {
+                obligation_id: Some(obligation_id),
+                ..
+            } = event
+            {
+                obligation_ids.push(*obligation_id);
+            }
+        }
+        obligation_ids
+    }
+
     fn total_disbursed(&self) -> UsdCents {
         let mut amounts = std::collections::HashMap::new();
         self.events
@@ -1105,7 +1119,7 @@ impl CreditFacility {
     pub(crate) fn record_overdue_disbursed_balance(
         &mut self,
         audit_info: AuditInfo,
-    ) -> Idempotent<CreditFacilityOverdueDisbursedBalance> {
+    ) -> Idempotent<(CreditFacilityOverdueDisbursedBalance, Vec<ObligationId>)> {
         idempotency_guard!(
             self.events.iter_all().rev(),
             CreditFacilityEvent::OverdueDisbursedBalanceRecorded { .. }
@@ -1127,7 +1141,7 @@ impl CreditFacility {
                 audit_info,
             });
 
-        Idempotent::Executed(res)
+        Idempotent::Executed((res, self.disbursal_obligation_ids()))
     }
 
     pub(crate) fn complete(

--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -349,20 +349,6 @@ impl CreditFacility {
         self.terms.one_time_fee_rate.apply(self.initial_facility())
     }
 
-    fn disbursal_obligation_ids(&self) -> Vec<ObligationId> {
-        let mut obligation_ids = vec![];
-        for event in self.events.iter_all() {
-            if let CreditFacilityEvent::DisbursalConcluded {
-                obligation_id: Some(obligation_id),
-                ..
-            } = event
-            {
-                obligation_ids.push(*obligation_id);
-            }
-        }
-        obligation_ids
-    }
-
     fn total_disbursed(&self) -> UsdCents {
         let mut amounts = std::collections::HashMap::new();
         self.events
@@ -1119,7 +1105,7 @@ impl CreditFacility {
     pub(crate) fn record_overdue_disbursed_balance(
         &mut self,
         audit_info: AuditInfo,
-    ) -> Idempotent<(CreditFacilityOverdueDisbursedBalance, Vec<ObligationId>)> {
+    ) -> Idempotent<CreditFacilityOverdueDisbursedBalance> {
         idempotency_guard!(
             self.events.iter_all().rev(),
             CreditFacilityEvent::OverdueDisbursedBalanceRecorded { .. }
@@ -1141,7 +1127,7 @@ impl CreditFacility {
                 audit_info,
             });
 
-        Idempotent::Executed((res, self.disbursal_obligation_ids()))
+        Idempotent::Executed(res)
     }
 
     pub(crate) fn complete(

--- a/core/credit/src/credit_facility/interest_outstanding.rs
+++ b/core/credit/src/credit_facility/interest_outstanding.rs
@@ -169,7 +169,7 @@ mod tests {
                 tx_id: LedgerTxId::new(),
                 recorded_at: Utc::now(),
                 audit_info: dummy_audit_info(),
-                canceled: false,
+                obligation_id: Some(ObligationId::new()),
             },
         ]
     }

--- a/core/credit/src/credit_facility/repayment_plan.rs
+++ b/core/credit/src/credit_facility/repayment_plan.rs
@@ -254,7 +254,7 @@ mod tests {
                 tx_id: LedgerTxId::new(),
                 recorded_at: Utc::now(),
                 audit_info: dummy_audit_info(),
-                canceled: false,
+                obligation_id: Some(ObligationId::new()),
             },
             CreditFacilityEvent::InterestAccrualCycleConcluded {
                 idx: first_interest_idx,
@@ -308,7 +308,7 @@ mod tests {
                 tx_id: LedgerTxId::new(),
                 recorded_at: Utc::now(),
                 audit_info: dummy_audit_info(),
-                canceled: false,
+                obligation_id: Some(ObligationId::new()),
             },
         ];
 
@@ -498,7 +498,7 @@ mod tests {
                 tx_id: LedgerTxId::new(),
                 recorded_at: second_disbursal_at,
                 audit_info: dummy_audit_info(),
-                canceled: false,
+                obligation_id: Some(ObligationId::new()),
             },
         ]);
         let repayment_plan = super::project(events.iter());

--- a/core/credit/src/jobs/interest_accrual_cycles.rs
+++ b/core/credit/src/jobs/interest_accrual_cycles.rs
@@ -14,7 +14,7 @@ use crate::{
     Obligation, ObligationRepo,
 };
 
-use super::obligation_overdue;
+use super::obligation_due;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CreditFacilityJobConfig<Perms, E> {
@@ -206,11 +206,11 @@ where
             .create_and_spawn_at_in_op(
                 &mut db,
                 obligation.id,
-                obligation_overdue::CreditFacilityJobConfig::<Perms> {
+                obligation_due::CreditFacilityJobConfig::<Perms> {
                     obligation_id: obligation.id,
                     _phantom: std::marker::PhantomData,
                 },
-                obligation.overdue_at(),
+                obligation.due_at(),
             )
             .await?;
         self.jobs

--- a/core/credit/src/jobs/interest_accrual_cycles.rs
+++ b/core/credit/src/jobs/interest_accrual_cycles.rs
@@ -202,9 +202,6 @@ where
                 return Ok(JobCompletion::CompleteWithOp(db));
             };
 
-        let overdue_at = obligation
-            .overdue_at()
-            .expect("No overdue_at value set on Obligation");
         self.jobs
             .create_and_spawn_at_in_op(
                 &mut db,
@@ -213,7 +210,7 @@ where
                     obligation_id: obligation.id,
                     _phantom: std::marker::PhantomData,
                 },
-                overdue_at,
+                obligation.overdue_at(),
             )
             .await?;
         self.jobs

--- a/core/credit/src/jobs/mod.rs
+++ b/core/credit/src/jobs/mod.rs
@@ -1,5 +1,6 @@
 pub mod cvl;
 pub mod interest_accrual_cycles;
 pub mod interest_accruals;
+pub mod obligation_due;
 pub mod obligation_overdue;
 pub mod overdue;

--- a/core/credit/src/jobs/mod.rs
+++ b/core/credit/src/jobs/mod.rs
@@ -1,4 +1,5 @@
 pub mod cvl;
 pub mod interest_accrual_cycles;
 pub mod interest_accruals;
+pub mod obligation_overdue;
 pub mod overdue;

--- a/core/credit/src/jobs/obligation_overdue.rs
+++ b/core/credit/src/jobs/obligation_overdue.rs
@@ -109,8 +109,11 @@ where
             )
             .await?;
 
+        obligation
+            .record_due(audit_info.clone())
+            .expect("Obligation was already marked due");
         let _overdue = if let es_entity::Idempotent::Executed(overdue) =
-            obligation.record_overdue(audit_info)
+            obligation.record_overdue(audit_info)?
         {
             overdue
         } else {

--- a/core/credit/src/jobs/obligation_overdue.rs
+++ b/core/credit/src/jobs/obligation_overdue.rs
@@ -104,8 +104,8 @@ where
             .audit
             .record_system_entry_in_tx(
                 db.tx(),
-                CoreCreditObject::all_credit_facilities(),
-                CoreCreditAction::CREDIT_FACILITY_RECORD_OVERDUE_DISBURSED_BALANCE,
+                CoreCreditObject::all_obligations(),
+                CoreCreditAction::OBLIGATION_UPDATE_STATUS,
             )
             .await?;
 

--- a/core/credit/src/jobs/obligation_overdue.rs
+++ b/core/credit/src/jobs/obligation_overdue.rs
@@ -1,0 +1,132 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use audit::AuditSvc;
+use authz::PermissionCheck;
+use job::*;
+
+use crate::{ledger::CreditLedger, obligation::ObligationRepo, primitives::*};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CreditFacilityJobConfig<Perms> {
+    pub obligation_id: ObligationId,
+    pub _phantom: std::marker::PhantomData<Perms>,
+}
+impl<Perms> JobConfig for CreditFacilityJobConfig<Perms>
+where
+    Perms: PermissionCheck,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Action: From<CoreCreditAction>,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Object: From<CoreCreditObject>,
+{
+    type Initializer = CreditFacilityProcessingJobInitializer<Perms>;
+}
+pub struct CreditFacilityProcessingJobInitializer<Perms>
+where
+    Perms: PermissionCheck,
+{
+    obligation_repo: ObligationRepo,
+    ledger: CreditLedger,
+    audit: Perms::Audit,
+}
+
+impl<Perms> CreditFacilityProcessingJobInitializer<Perms>
+where
+    Perms: PermissionCheck,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Action: From<CoreCreditAction>,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Object: From<CoreCreditObject>,
+{
+    pub fn new(
+        ledger: &CreditLedger,
+        obligation_repo: ObligationRepo,
+        audit: &Perms::Audit,
+    ) -> Self {
+        Self {
+            ledger: ledger.clone(),
+            obligation_repo,
+            audit: audit.clone(),
+        }
+    }
+}
+
+const CREDIT_FACILITY_OVERDUE_PROCESSING_JOB: JobType =
+    JobType::new("credit-facility-overdue-processing");
+impl<Perms> JobInitializer for CreditFacilityProcessingJobInitializer<Perms>
+where
+    Perms: PermissionCheck,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Action: From<CoreCreditAction>,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Object: From<CoreCreditObject>,
+{
+    fn job_type() -> JobType
+    where
+        Self: Sized,
+    {
+        CREDIT_FACILITY_OVERDUE_PROCESSING_JOB
+    }
+
+    fn init(&self, job: &Job) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        Ok(Box::new(CreditFacilityProcessingJobRunner::<Perms> {
+            config: job.config()?,
+            obligation_repo: self.obligation_repo.clone(),
+            _ledger: self.ledger.clone(),
+            audit: self.audit.clone(),
+        }))
+    }
+}
+
+pub struct CreditFacilityProcessingJobRunner<Perms>
+where
+    Perms: PermissionCheck,
+{
+    config: CreditFacilityJobConfig<Perms>,
+    obligation_repo: ObligationRepo,
+    _ledger: CreditLedger,
+    audit: Perms::Audit,
+}
+
+#[async_trait]
+impl<Perms> JobRunner for CreditFacilityProcessingJobRunner<Perms>
+where
+    Perms: PermissionCheck,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Action: From<CoreCreditAction>,
+    <<Perms as PermissionCheck>::Audit as AuditSvc>::Object: From<CoreCreditObject>,
+{
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        let mut obligation = self
+            .obligation_repo
+            .find_by_id(self.config.obligation_id)
+            .await?;
+
+        let mut db = self.obligation_repo.begin_op().await?;
+        let audit_info = self
+            .audit
+            .record_system_entry_in_tx(
+                db.tx(),
+                CoreCreditObject::all_credit_facilities(),
+                CoreCreditAction::CREDIT_FACILITY_RECORD_OVERDUE_DISBURSED_BALANCE,
+            )
+            .await?;
+
+        let _overdue = if let es_entity::Idempotent::Executed(overdue) =
+            obligation.record_overdue(audit_info)
+        {
+            overdue
+        } else {
+            return Ok(JobCompletion::Complete);
+        };
+
+        self.obligation_repo
+            .update_in_op(&mut db, &mut obligation)
+            .await?;
+
+        // TODO: switch to recording in ledger and committing
+        // self.ledger
+        //     .record_credit_facility_overdue_disbursed(db, overdue)
+        //     .await?;
+        db.commit().await?;
+
+        Ok(JobCompletion::Complete)
+    }
+}

--- a/core/credit/src/jobs/obligation_overdue.rs
+++ b/core/credit/src/jobs/obligation_overdue.rs
@@ -126,7 +126,7 @@ where
 
         // TODO: switch to recording in ledger and committing
         // self.ledger
-        //     .record_credit_facility_overdue_disbursed(db, overdue)
+        //     .record_overdue_obligation(db, overdue)
         //     .await?;
         db.commit().await?;
 

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -176,7 +176,16 @@ where
         jobs.add_initializer(
             overdue::CreditFacilityProcessingJobInitializer::<Perms, E>::new(
                 &ledger,
+                obligation_repo.clone(),
                 credit_facility_repo.clone(),
+                jobs,
+                authz.audit(),
+            ),
+        );
+        jobs.add_initializer(
+            obligation_overdue::CreditFacilityProcessingJobInitializer::<Perms>::new(
+                &ledger,
+                obligation_repo.clone(),
                 authz.audit(),
             ),
         );

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -137,6 +137,7 @@ where
         let approve_credit_facility =
             ApproveCreditFacility::new(&credit_facility_repo, authz.audit(), governance);
         let activate_credit_facility = ActivateCreditFacility::new(
+            &obligation_repo,
             &credit_facility_repo,
             &disbursal_repo,
             &ledger,

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -182,6 +182,11 @@ where
                 authz.audit(),
             ),
         );
+        jobs.add_initializer(obligation_due::CreditFacilityProcessingJobInitializer::<
+            Perms,
+        >::new(
+            &ledger, obligation_repo.clone(), jobs, authz.audit()
+        ));
         jobs.add_initializer(
             obligation_overdue::CreditFacilityProcessingJobInitializer::<Perms>::new(
                 &ledger,

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -129,6 +129,7 @@ where
             &disbursal_repo,
             &obligation_repo,
             &credit_facility_repo,
+            jobs,
             authz.audit(),
             governance,
             &ledger,
@@ -177,9 +178,7 @@ where
         jobs.add_initializer(
             overdue::CreditFacilityProcessingJobInitializer::<Perms, E>::new(
                 &ledger,
-                obligation_repo.clone(),
                 credit_facility_repo.clone(),
-                jobs,
                 authz.audit(),
             ),
         );

--- a/core/credit/src/obligation/entity.rs
+++ b/core/credit/src/obligation/entity.rs
@@ -106,6 +106,10 @@ impl NewObligation {
         NewObligationBuilder::default()
     }
 
+    pub(crate) fn id(&self) -> ObligationId {
+        self.id
+    }
+
     pub(super) fn reference(&self) -> String {
         match self.reference.as_deref() {
             None => self.id.to_string(),

--- a/core/credit/src/obligation/entity.rs
+++ b/core/credit/src/obligation/entity.rs
@@ -62,6 +62,16 @@ impl Obligation {
             .expect("entity_first_persisted_at not found")
     }
 
+    pub fn due_at(&self) -> DateTime<Utc> {
+        self.events
+            .iter_all()
+            .find_map(|e| match e {
+                ObligationEvent::Initialized { due_date, .. } => Some(*due_date),
+                _ => None,
+            })
+            .expect("Entity was not Initialized")
+    }
+
     pub fn overdue_at(&self) -> DateTime<Utc> {
         self.events
             .iter_all()

--- a/core/credit/src/obligation/error.rs
+++ b/core/credit/src/obligation/error.rs
@@ -8,6 +8,8 @@ pub enum ObligationError {
     EsEntityError(es_entity::EsEntityError),
     #[error("ObligationError - CursorDestructureError: {0}")]
     CursorDestructureError(#[from] es_entity::CursorDestructureError),
+    #[error("ObligationError - InvalidStatusTransitionToOverdue")]
+    InvalidStatusTransitionToOverdue,
 }
 
 es_entity::from_es_entity_error!(ObligationError);

--- a/core/credit/src/obligation/repo.rs
+++ b/core/credit/src/obligation/repo.rs
@@ -10,7 +10,7 @@ use super::{entity::*, error::*};
 #[es_repo(
     entity = "Obligation",
     err = "ObligationError",
-    columns(reference(ty = "String", create(accessor = "reference()"))),
+    columns(reference(ty = "String", create(accessor = "reference()")),),
     tbl_prefix = "core"
 )]
 pub struct ObligationRepo {

--- a/core/credit/src/primitives.rs
+++ b/core/credit/src/primitives.rs
@@ -41,6 +41,8 @@ pub struct LedgerOmnibusAccountIds {
 
 pub type CreditFacilityAllOrOne = AllOrOne<CreditFacilityId>;
 pub type ChartOfAccountsIntegrationConfigAllOrOne = AllOrOne<ChartOfAccountsIntegrationConfigId>;
+pub type DisbursalAllOrOne = AllOrOne<DisbursalId>;
+pub type ObligationAllOrOne = AllOrOne<ObligationId>;
 
 #[derive(Clone, Copy, Debug, PartialEq, strum::EnumDiscriminants)]
 #[strum_discriminants(derive(strum::Display, strum::EnumString))]
@@ -48,6 +50,8 @@ pub type ChartOfAccountsIntegrationConfigAllOrOne = AllOrOne<ChartOfAccountsInte
 pub enum CoreCreditObject {
     CreditFacility(CreditFacilityAllOrOne),
     ChartOfAccountsIntegration(ChartOfAccountsIntegrationConfigAllOrOne),
+    Disbursal(DisbursalAllOrOne),
+    Obligation(ObligationAllOrOne),
 }
 
 impl CoreCreditObject {
@@ -62,6 +66,22 @@ impl CoreCreditObject {
     pub fn chart_of_accounts_integration() -> Self {
         CoreCreditObject::ChartOfAccountsIntegration(AllOrOne::All)
     }
+
+    pub fn disbursal(id: DisbursalId) -> Self {
+        CoreCreditObject::Disbursal(AllOrOne::ById(id))
+    }
+
+    pub fn all_disbursals() -> Self {
+        CoreCreditObject::Disbursal(AllOrOne::All)
+    }
+
+    pub fn obligation(id: ObligationId) -> Self {
+        CoreCreditObject::Obligation(AllOrOne::ById(id))
+    }
+
+    pub fn all_obligations() -> Self {
+        CoreCreditObject::Obligation(AllOrOne::All)
+    }
 }
 
 impl std::fmt::Display for CoreCreditObject {
@@ -70,7 +90,9 @@ impl std::fmt::Display for CoreCreditObject {
         use CoreCreditObject::*;
         match self {
             CreditFacility(obj_ref) => write!(f, "{}/{}", discriminant, obj_ref),
-            &ChartOfAccountsIntegration(obj_ref) => write!(f, "{}/{}", discriminant, obj_ref),
+            ChartOfAccountsIntegration(obj_ref) => write!(f, "{}/{}", discriminant, obj_ref),
+            Disbursal(obj_ref) => write!(f, "{}/{}", discriminant, obj_ref),
+            Obligation(obj_ref) => write!(f, "{}/{}", discriminant, obj_ref),
         }
     }
 }
@@ -90,6 +112,14 @@ impl FromStr for CoreCreditObject {
                 let obj_ref = id.parse().map_err(|_| "could not parse CoreCreditObject")?;
                 CoreCreditObject::ChartOfAccountsIntegration(obj_ref)
             }
+            Obligation => {
+                let obj_ref = id.parse().map_err(|_| "could not parse CoreCreditObject")?;
+                CoreCreditObject::Obligation(obj_ref)
+            }
+            Disbursal => {
+                let obj_ref = id.parse().map_err(|_| "could not parse CoreCreditObject")?;
+                CoreCreditObject::Disbursal(obj_ref)
+            }
         };
         Ok(res)
     }
@@ -102,6 +132,7 @@ pub enum CoreCreditAction {
     CreditFacility(CreditFacilityAction),
     ChartOfAccountsIntegrationConfig(ChartOfAccountsIntegrationConfigAction),
     Disbursal(DisbursalAction),
+    Obligation(ObligationAction),
 }
 
 impl CoreCreditAction {
@@ -142,6 +173,9 @@ impl CoreCreditAction {
     pub const DISBURSAL_LIST: Self = CoreCreditAction::Disbursal(DisbursalAction::List);
     pub const DISBURSAL_CONCLUDE_APPROVAL_PROCESS: Self =
         CoreCreditAction::Disbursal(DisbursalAction::ConcludeApprovalProcess);
+
+    pub const OBLIGATION_UPDATE_STATUS: Self =
+        CoreCreditAction::Obligation(ObligationAction::UpdateStatus);
 }
 
 impl std::fmt::Display for CoreCreditAction {
@@ -152,6 +186,7 @@ impl std::fmt::Display for CoreCreditAction {
             CreditFacility(action) => action.fmt(f),
             ChartOfAccountsIntegrationConfig(action) => action.fmt(f),
             Disbursal(action) => action.fmt(f),
+            Obligation(action) => action.fmt(f),
         }
     }
 }
@@ -170,6 +205,7 @@ impl FromStr for CoreCreditAction {
                 CoreCreditAction::from(action.parse::<ChartOfAccountsIntegrationConfigAction>()?)
             }
             Disbursal => CoreCreditAction::from(action.parse::<DisbursalAction>()?),
+            Obligation => CoreCreditAction::from(action.parse::<ObligationAction>()?),
         };
         Ok(res)
     }
@@ -220,6 +256,17 @@ pub enum ChartOfAccountsIntegrationConfigAction {
 impl From<ChartOfAccountsIntegrationConfigAction> for CoreCreditAction {
     fn from(action: ChartOfAccountsIntegrationConfigAction) -> Self {
         CoreCreditAction::ChartOfAccountsIntegrationConfig(action)
+    }
+}
+
+#[derive(PartialEq, Clone, Copy, Debug, strum::Display, strum::EnumString)]
+#[strum(serialize_all = "kebab-case")]
+pub enum ObligationAction {
+    UpdateStatus,
+}
+impl From<ObligationAction> for CoreCreditAction {
+    fn from(action: ObligationAction) -> Self {
+        Self::Obligation(action)
     }
 }
 

--- a/core/credit/src/primitives.rs
+++ b/core/credit/src/primitives.rs
@@ -27,6 +27,7 @@ es_entity::entity_id! {
 
     CreditFacilityId => job::JobId,
     InterestAccrualCycleId => job::JobId,
+    ObligationId => job::JobId,
 
     DisbursalId => LedgerTxId,
     PaymentId => LedgerTxId,

--- a/core/credit/src/processes/activate_credit_facility/mod.rs
+++ b/core/credit/src/processes/activate_credit_facility/mod.rs
@@ -11,7 +11,7 @@ use outbox::OutboxEventMarker;
 use crate::{
     error::CoreCreditError, interest_accruals, ledger::CreditLedger, overdue,
     primitives::CreditFacilityId, CoreCreditAction, CoreCreditEvent, CoreCreditObject,
-    CreditFacility, CreditFacilityRepo, DisbursalRepo, Jobs, LedgerTxId,
+    CreditFacility, CreditFacilityRepo, DisbursalRepo, Jobs, LedgerTxId, ObligationRepo,
 };
 
 pub use job::*;
@@ -21,6 +21,7 @@ where
     Perms: PermissionCheck,
     E: OutboxEventMarker<CoreCreditEvent>,
 {
+    obligation_repo: ObligationRepo,
     credit_facility_repo: CreditFacilityRepo<E>,
     disbursal_repo: DisbursalRepo,
     ledger: CreditLedger,
@@ -36,6 +37,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
+            obligation_repo: self.obligation_repo.clone(),
             credit_facility_repo: self.credit_facility_repo.clone(),
             disbursal_repo: self.disbursal_repo.clone(),
             ledger: self.ledger.clone(),
@@ -53,6 +55,7 @@ where
     E: OutboxEventMarker<CoreCreditEvent>,
 {
     pub fn new(
+        obligation_repo: &ObligationRepo,
         credit_facility_repo: &CreditFacilityRepo<E>,
         disbursal_repo: &DisbursalRepo,
         ledger: &CreditLedger,
@@ -61,6 +64,7 @@ where
         audit: &Perms::Audit,
     ) -> Self {
         Self {
+            obligation_repo: obligation_repo.clone(),
             credit_facility_repo: credit_facility_repo.clone(),
             disbursal_repo: disbursal_repo.clone(),
             ledger: ledger.clone(),
@@ -124,14 +128,23 @@ where
             .await?;
 
         let tx_id = LedgerTxId::new();
-        let obligation_id = disbursal
+        let new_obligation = disbursal
             .approval_process_concluded(tx_id, true, audit_info.clone())
             .expect("First instance of idempotent action ignored")
-            .map(|n| n.id());
+            .expect("First disbursal obligation was already created");
         credit_facility
-            .disbursal_concluded(&disbursal, tx_id, obligation_id, now, audit_info.clone())
+            .disbursal_concluded(
+                &disbursal,
+                tx_id,
+                Some(new_obligation.id()),
+                now,
+                audit_info.clone(),
+            )
             .expect("First instance of idempotent action ignored");
 
+        self.obligation_repo
+            .create_in_op(&mut db, new_obligation)
+            .await?;
         self.disbursal_repo
             .update_in_op(&mut db, &mut disbursal)
             .await?;

--- a/core/credit/src/processes/activate_credit_facility/mod.rs
+++ b/core/credit/src/processes/activate_credit_facility/mod.rs
@@ -124,13 +124,13 @@ where
             .await?;
 
         let tx_id = LedgerTxId::new();
-        let is_canceled = disbursal
+        let obligation_id = disbursal
             .approval_process_concluded(tx_id, true, audit_info.clone())
-            .expect("First instance of idempotent action was ignored")
-            .is_none();
+            .expect("First instance of idempotent action ignored")
+            .map(|n| n.id());
         credit_facility
-            .disbursal_concluded(&disbursal, tx_id, is_canceled, now, audit_info.clone())
-            .expect("First instance of idempotent action was ignored");
+            .disbursal_concluded(&disbursal, tx_id, obligation_id, now, audit_info.clone())
+            .expect("First instance of idempotent action ignored");
 
         self.disbursal_repo
             .update_in_op(&mut db, &mut disbursal)

--- a/core/credit/src/processes/activate_credit_facility/mod.rs
+++ b/core/credit/src/processes/activate_credit_facility/mod.rs
@@ -1,8 +1,8 @@
 mod job;
 
-use ::job::JobId;
 use tracing::instrument;
 
+use ::job::JobId;
 use audit::AuditSvc;
 use authz::PermissionCheck;
 use core_price::Price;

--- a/core/credit/src/processes/approve_disbursal/mod.rs
+++ b/core/credit/src/processes/approve_disbursal/mod.rs
@@ -123,8 +123,7 @@ where
             .audit
             .record_system_entry_in_tx(
                 db.tx(),
-                // NOTE: change to DisbursalObject
-                CoreCreditObject::credit_facility(disbursal.facility_id),
+                CoreCreditObject::disbursal(disbursal.id),
                 CoreCreditAction::DISBURSAL_CONCLUDE_APPROVAL_PROCESS,
             )
             .await?;
@@ -133,7 +132,7 @@ where
             .record_system_entry_in_tx(
                 db.tx(),
                 // NOTE: change to DisbursalObject
-                CoreCreditObject::credit_facility(credit_facility.id),
+                CoreCreditObject::disbursal(disbursal.id),
                 CoreCreditAction::DISBURSAL_SETTLE,
             )
             .await?;

--- a/core/credit/src/processes/approve_disbursal/mod.rs
+++ b/core/credit/src/processes/approve_disbursal/mod.rs
@@ -143,11 +143,12 @@ where
         let new_obligation = if let Idempotent::Executed(new_obligation) =
             disbursal.approval_process_concluded(tx_id, approved, audit_info.clone())
         {
+            let obligation_id = new_obligation.as_ref().map(|n| n.id());
             if credit_facility
                 .disbursal_concluded(
                     &disbursal,
                     tx_id,
-                    new_obligation.is_none(),
+                    obligation_id,
                     executed_at,
                     disbursal_audit_info,
                 )

--- a/core/credit/src/processes/approve_disbursal/mod.rs
+++ b/core/credit/src/processes/approve_disbursal/mod.rs
@@ -14,7 +14,7 @@ use governance::{
 use outbox::OutboxEventMarker;
 
 use crate::{
-    credit_facility::CreditFacilityRepo, ledger::CreditLedger, obligation_overdue,
+    credit_facility::CreditFacilityRepo, jobs::obligation_due, ledger::CreditLedger,
     primitives::DisbursalId, CoreCreditAction, CoreCreditError, CoreCreditEvent, CoreCreditObject,
     Disbursal, DisbursalRepo, LedgerTxId, ObligationRepo,
 };
@@ -186,11 +186,11 @@ where
                 .create_and_spawn_at_in_op(
                     &mut db,
                     obligation.id,
-                    obligation_overdue::CreditFacilityJobConfig::<Perms> {
+                    obligation_due::CreditFacilityJobConfig::<Perms> {
                         obligation_id: obligation.id,
                         _phantom: std::marker::PhantomData,
                     },
-                    obligation.overdue_at(),
+                    obligation.due_at(),
                 )
                 .await?;
 

--- a/core/credit/src/processes/approve_disbursal/mod.rs
+++ b/core/credit/src/processes/approve_disbursal/mod.rs
@@ -182,9 +182,6 @@ where
                 .create_in_op(&mut db, new_obligation)
                 .await?;
 
-            let overdue_at = obligation
-                .overdue_at()
-                .expect("No overdue_at value set on Obligation");
             self.jobs
                 .create_and_spawn_at_in_op(
                     &mut db,
@@ -193,7 +190,7 @@ where
                         obligation_id: obligation.id,
                         _phantom: std::marker::PhantomData,
                     },
-                    overdue_at,
+                    obligation.overdue_at(),
                 )
                 .await?;
 


### PR DESCRIPTION
Note: after #1726 is merged, can rebase with `git rebase --onto main obligations` locally after pulling the updated `main` branch

## Description

This PR introduces `MarkedDue` and `MarkedOverdue` events and updates them in the respective use-cases/jobs