### PR TITLE
fix: Capitalize meta title in customer portal

### DIFF
--- a/apps/customer-portal/app/layout.tsx
+++ b/apps/customer-portal/app/layout.tsx
@@ -13,7 +13,7 @@ import NavBar from "@/components/nav-bar"
 import { meQuery } from "@/lib/graphql/query/me"
 
 export const metadata: Metadata = {
-  title: "lana Bank",
+  title: "Lana Bank",
   description: "Where the lana keeps flowing",
 }
 const inter = Inter_Tight({ subsets: ["latin"], display: "auto" })


### PR DESCRIPTION
Did a tiny fix for the title, hope this helps.

<img width="667" alt="image" src="https://github.com/user-attachments/assets/a2f7515c-9281-4cc0-a7f6-3547137bf520" />
