### PR TITLE
chore: Allow to set effective date when creating manual transaction

### DIFF
--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -1206,6 +1206,7 @@ export type ManualTransactionEntryInput = {
 
 export type ManualTransactionExecuteInput = {
   description: Scalars['String']['input'];
+  effective?: InputMaybe<Scalars['Timestamp']['input']>;
   entries: Array<ManualTransactionEntryInput>;
   reference?: InputMaybe<Scalars['String']['input']>;
 };

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -24,6 +24,7 @@ export type Scalars = {
   AccountCode: { input: any; output: any; }
   AnnualRatePct: { input: any; output: any; }
   CVLPct: { input: any; output: any; }
+  Date: { input: any; output: any; }
   Decimal: { input: any; output: any; }
   DisbursalIdx: { input: any; output: any; }
   OneTimeFeeRatePct: { input: any; output: any; }
@@ -1206,7 +1207,7 @@ export type ManualTransactionEntryInput = {
 
 export type ManualTransactionExecuteInput = {
   description: Scalars['String']['input'];
-  effective?: InputMaybe<Scalars['Timestamp']['input']>;
+  effective?: InputMaybe<Scalars['Date']['input']>;
   entries: Array<ManualTransactionEntryInput>;
   reference?: InputMaybe<Scalars['String']['input']>;
 };

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -1518,7 +1518,7 @@ export const mockManualTransactionExecuteInput = (overrides?: Partial<ManualTran
     relationshipsToOmit.add('ManualTransactionExecuteInput');
     return {
         description: overrides && overrides.hasOwnProperty('description') ? overrides.description! : generateMockValue.description(),
-        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : generateMockValue.timestamp(),
+        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : faker.date.past({ years: 1, refDate: new Date(2022, 0) }).toISOString(),
         entries: overrides && overrides.hasOwnProperty('entries') ? overrides.entries! : [relationshipsToOmit.has('ManualTransactionEntryInput') ? {} as ManualTransactionEntryInput : mockManualTransactionEntryInput({}, relationshipsToOmit)],
         reference: overrides && overrides.hasOwnProperty('reference') ? overrides.reference! : generateMockValue.reference(),
     };

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -1518,6 +1518,7 @@ export const mockManualTransactionExecuteInput = (overrides?: Partial<ManualTran
     relationshipsToOmit.add('ManualTransactionExecuteInput');
     return {
         description: overrides && overrides.hasOwnProperty('description') ? overrides.description! : generateMockValue.description(),
+        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : generateMockValue.timestamp(),
         entries: overrides && overrides.hasOwnProperty('entries') ? overrides.entries! : [relationshipsToOmit.has('ManualTransactionEntryInput') ? {} as ManualTransactionEntryInput : mockManualTransactionEntryInput({}, relationshipsToOmit)],
         reference: overrides && overrides.hasOwnProperty('reference') ? overrides.reference! : generateMockValue.reference(),
     };

--- a/bats/accounting.bats
+++ b/bats/accounting.bats
@@ -101,7 +101,7 @@ teardown_file() {
     '{
       input: {
         description: "Manual transaction - test",
-        effective: "2025-01-01T00:00:00Z",
+        effective: "2025-01-01",
         entries: [
           {
              "accountRef": "201",

--- a/bats/accounting.bats
+++ b/bats/accounting.bats
@@ -101,6 +101,7 @@ teardown_file() {
     '{
       input: {
         description: "Manual transaction - test",
+        effective: "2025-01-01T00:00:00Z",
         entries: [
           {
              "accountRef": "201",

--- a/core/accounting/src/lib.rs
+++ b/core/accounting/src/lib.rs
@@ -169,7 +169,7 @@ where
         chart_ref: &str,
         reference: Option<String>,
         description: String,
-        effective: Option<chrono::DateTime<chrono::Utc>>,
+        effective: Option<chrono::NaiveDate>,
         entries: Vec<ManualEntryInput>,
     ) -> Result<LedgerTransaction, CoreAccountingError> {
         let chart = self
@@ -187,7 +187,7 @@ where
                 &chart,
                 reference,
                 description,
-                effective.unwrap_or_else(chrono::Utc::now),
+                effective.unwrap_or_else(|| chrono::Utc::now().date_naive()),
                 entries,
             )
             .await?;

--- a/core/accounting/src/lib.rs
+++ b/core/accounting/src/lib.rs
@@ -169,6 +169,7 @@ where
         chart_ref: &str,
         reference: Option<String>,
         description: String,
+        effective: Option<chrono::DateTime<chrono::Utc>>,
         entries: Vec<ManualEntryInput>,
     ) -> Result<LedgerTransaction, CoreAccountingError> {
         let chart = self
@@ -181,7 +182,14 @@ where
 
         let tx = self
             .manual_transactions
-            .execute(sub, &chart, reference, description, entries)
+            .execute(
+                sub,
+                &chart,
+                reference,
+                description,
+                effective.unwrap_or_else(chrono::Utc::now),
+                entries,
+            )
             .await?;
 
         let ledger_tx_id = tx.ledger_transaction_id;

--- a/core/accounting/src/manual_transaction/ledger/template.rs
+++ b/core/accounting/src/manual_transaction/ledger/template.rs
@@ -90,23 +90,18 @@ impl EntryParams {
 pub struct ManualTransactionParams {
     pub journal_id: JournalId,
     pub description: String,
+    pub effective: chrono::DateTime<chrono::Utc>,
     pub entry_params: Vec<EntryParams>,
 }
 
 impl From<ManualTransactionParams> for Params {
-    fn from(
-        ManualTransactionParams {
-            journal_id,
-            description,
-            entry_params,
-        }: ManualTransactionParams,
-    ) -> Self {
+    fn from(input_params: ManualTransactionParams) -> Self {
         let mut params = Self::default();
-        params.insert("journal_id", journal_id);
-        params.insert("description", description);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("journal_id", input_params.journal_id);
+        params.insert("description", input_params.description);
+        params.insert("effective", input_params.effective.date_naive());
 
-        for (n, entry) in entry_params.iter().enumerate() {
+        for (n, entry) in input_params.entry_params.iter().enumerate() {
             entry.populate_params(&mut params, n);
         }
 

--- a/core/accounting/src/manual_transaction/ledger/template.rs
+++ b/core/accounting/src/manual_transaction/ledger/template.rs
@@ -90,7 +90,7 @@ impl EntryParams {
 pub struct ManualTransactionParams {
     pub journal_id: JournalId,
     pub description: String,
-    pub effective: chrono::DateTime<chrono::Utc>,
+    pub effective: chrono::NaiveDate,
     pub entry_params: Vec<EntryParams>,
 }
 
@@ -99,7 +99,7 @@ impl From<ManualTransactionParams> for Params {
         let mut params = Self::default();
         params.insert("journal_id", input_params.journal_id);
         params.insert("description", input_params.description);
-        params.insert("effective", input_params.effective.date_naive());
+        params.insert("effective", input_params.effective);
 
         for (n, entry) in input_params.entry_params.iter().enumerate() {
             entry.populate_params(&mut params, n);

--- a/core/accounting/src/manual_transaction/mod.rs
+++ b/core/accounting/src/manual_transaction/mod.rs
@@ -110,7 +110,7 @@ where
         chart: &Chart,
         reference: Option<String>,
         description: String,
-        effective: chrono::DateTime<chrono::Utc>,
+        effective: chrono::NaiveDate,
         entries: Vec<ManualEntryInput>,
     ) -> Result<ManualTransaction, ManualTransactionError> {
         let audit_info = self

--- a/core/accounting/src/manual_transaction/mod.rs
+++ b/core/accounting/src/manual_transaction/mod.rs
@@ -110,6 +110,7 @@ where
         chart: &Chart,
         reference: Option<String>,
         description: String,
+        effective: chrono::DateTime<chrono::Utc>,
         entries: Vec<ManualEntryInput>,
     ) -> Result<ManualTransaction, ManualTransactionError> {
         let audit_info = self
@@ -159,6 +160,7 @@ where
                     journal_id: self.journal_id,
                     description,
                     entry_params,
+                    effective,
                 },
             )
             .await?;

--- a/core/accounting/tests/manual_transaction.rs
+++ b/core/accounting/tests/manual_transaction.rs
@@ -33,7 +33,7 @@ async fn manual_transaction() -> anyhow::Result<()> {
         ManualEntryInput::builder().account_id_or_code(to.clone()).amount(dec!(100)).currency(Currency::USD).direction(DebitOrCredit::Debit).description("test 1 debit").build().unwrap(),
         ManualEntryInput::builder().account_id_or_code(from.clone()).amount(dec!(100)).currency(Currency::USD).direction(DebitOrCredit::Credit).description("test 1 credit").build().unwrap(),
     ];
-    accounting.execute_manual_transaction(&DummySubject, &chart_ref, None, "Test transaction 1".to_string(), entries).await?;
+    accounting.execute_manual_transaction(&DummySubject, &chart_ref, None, "Test transaction 1".to_string(), None, entries).await?;
 
     let account = accounting.find_ledger_account_by_code(&DummySubject, &chart_ref, "2".to_string()).await?.unwrap();
     assert_eq!(account.usd_balance_range.expect("should have balance").end.expect("balance missing").settled(), dec!(100));

--- a/lana/admin-server/src/graphql/accounting/manual_transaction.rs
+++ b/lana/admin-server/src/graphql/accounting/manual_transaction.rs
@@ -3,7 +3,7 @@ use async_graphql::*;
 pub use lana_app::accounting::manual_transaction::ManualEntryInput;
 
 use crate::graphql::primitives::*;
-use crate::primitives::Timestamp;
+use crate::primitives::Date;
 
 use cala_ledger::DebitOrCredit;
 
@@ -13,7 +13,7 @@ use super::ledger_transaction::LedgerTransaction;
 pub struct ManualTransactionExecuteInput {
     pub description: String,
     pub reference: Option<String>,
-    pub effective: Option<Timestamp>,
+    pub effective: Option<Date>,
     pub entries: Vec<ManualTransactionEntryInput>,
 }
 crate::mutation_payload! { ManualTransactionExecutePayload, transaction: LedgerTransaction }

--- a/lana/admin-server/src/graphql/accounting/manual_transaction.rs
+++ b/lana/admin-server/src/graphql/accounting/manual_transaction.rs
@@ -3,6 +3,7 @@ use async_graphql::*;
 pub use lana_app::accounting::manual_transaction::ManualEntryInput;
 
 use crate::graphql::primitives::*;
+use crate::primitives::Timestamp;
 
 use cala_ledger::DebitOrCredit;
 
@@ -12,6 +13,7 @@ use super::ledger_transaction::LedgerTransaction;
 pub struct ManualTransactionExecuteInput {
     pub description: String,
     pub reference: Option<String>,
+    pub effective: Option<Timestamp>,
     pub entries: Vec<ManualTransactionEntryInput>,
 }
 crate::mutation_payload! { ManualTransactionExecutePayload, transaction: LedgerTransaction }

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -820,6 +820,8 @@ type Dashboard {
 	totalCollateral: Satoshis!
 }
 
+scalar Date
+
 enum DebitOrCredit {
 	DEBIT
 	CREDIT
@@ -1193,7 +1195,7 @@ input ManualTransactionEntryInput {
 input ManualTransactionExecuteInput {
 	description: String!
 	reference: String
-	effective: Timestamp
+	effective: Date
 	entries: [ManualTransactionEntryInput!]!
 }
 

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -1193,6 +1193,7 @@ input ManualTransactionEntryInput {
 input ManualTransactionExecuteInput {
 	description: String!
 	reference: String
+	effective: Timestamp
 	entries: [ManualTransactionEntryInput!]!
 }
 

--- a/lana/admin-server/src/graphql/schema.rs
+++ b/lana/admin-server/src/graphql/schema.rs
@@ -915,6 +915,7 @@ impl Mutation {
                 CHART_REF.0,
                 input.reference,
                 input.description,
+                input.effective.map(|ts| ts.into_inner()),
                 entries
             )
         )

--- a/lana/admin-server/src/primitives.rs
+++ b/lana/admin-server/src/primitives.rs
@@ -47,6 +47,22 @@ impl Timestamp {
     }
 }
 
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Date(chrono::NaiveDate);
+scalar!(Date);
+impl From<chrono::NaiveDate> for Date {
+    fn from(value: chrono::NaiveDate) -> Self {
+        Self(value)
+    }
+}
+impl Date {
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> chrono::NaiveDate {
+        self.0
+    }
+}
+
 #[derive(SimpleObject)]
 pub struct SuccessPayload {
     pub success: bool,


### PR DESCRIPTION
The effective date is optional on GraphQL level, so users are not required to provide it. If they don't provide it, current date is used.

This only allows to pass effective date from user and store it in the transaction's parameters. The effective date has no effect (😛) on calculations yet.