### PR TITLE
Feat: add ledger account index page

### DIFF
--- a/apps/admin-panel/app/ledger-account/[ledger-account-ref]/ledger-account-ref.stories.tsx
+++ b/apps/admin-panel/app/ledger-account/[ledger-account-ref]/ledger-account-ref.stories.tsx
@@ -66,7 +66,7 @@ const LedgerAccountStory = () => {
 }
 
 const meta: Meta = {
-  title: "Pages/ChartOfAccounts/LedgerAccountDetails",
+  title: "Pages/LedgerAccounts/LedgerAccountDetails",
   component: LedgerAccountStory,
   parameters: { layout: "fullscreen", nextjs: { appDirectory: true } },
 }
@@ -78,7 +78,7 @@ export const Default: Story = {
   parameters: {
     nextjs: {
       navigation: {
-        pathname: `/chart-of-accounts/${ledgerAccountCode}`,
+        pathname: `/ledger-account/${ledgerAccountCode}`,
       },
     },
   },
@@ -128,7 +128,7 @@ export const Loading: Story = {
   parameters: {
     nextjs: {
       navigation: {
-        pathname: `/chart-of-accounts/${ledgerAccountCode}`,
+        pathname: `/ledger-account/${ledgerAccountCode}`,
       },
     },
   },

--- a/apps/admin-panel/app/ledger-account/ledger-account-page.stories.tsx
+++ b/apps/admin-panel/app/ledger-account/ledger-account-page.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import LedgerAccountIndexPage from "./page"
+
+const LedgerAccountIndexPageStory = () => {
+  return <LedgerAccountIndexPage />
+}
+
+const meta: Meta = {
+  title: "Pages/LedgerAccounts",
+  component: LedgerAccountIndexPageStory,
+  parameters: { layout: "fullscreen", nextjs: { appDirectory: true } },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Index: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: `/ledger-account`,
+      },
+    },
+  },
+}
+

--- a/apps/admin-panel/app/ledger-account/page.tsx
+++ b/apps/admin-panel/app/ledger-account/page.tsx
@@ -1,10 +1,60 @@
 "use client"
 
+import React, { useState } from "react"
+
 import { useRouter } from "next/navigation"
 
-export default function LedgerAccount() {
-  const router = useRouter()
-  router.push("/chart-of-accounts")
+import { Input } from "@lana/web/ui/input"
+import { Button } from "@lana/web/ui/button"
+import { Label } from "@lana/web/ui/label"
+import { useTranslations } from "next-intl"
 
-  return <></>
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@lana/web/ui/card"
+
+export default function LedgerAccount() {
+  const t = useTranslations("LedgerTransaction")
+  const router = useRouter()
+  const [transactionId, setTransactionId] = useState("")
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.push(`/ledger-account/${transactionId}`)
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit}>
+          <Label htmlFor="ledger-transactions">{t("form.labels.transaction")}</Label>
+          <div className="flex flex-wrap md:flex-nowrap">
+            <Input
+              id="ledger-transactions"
+              type="string"
+              className="mr-2"
+              value={transactionId}
+              onChange={(e) => {
+                const { value } = e.target
+                setTransactionId(value)
+              }}
+              required
+              placeholder={t("form.placeholders.transaction")}
+              data-testid="search-ledger-transaction"
+            />
+            <Button type="submit" className="mt-2 md:mt-0">
+              Search
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
 }

--- a/apps/admin-panel/components/app-sidebar/nav-items.tsx
+++ b/apps/admin-panel/components/app-sidebar/nav-items.tsx
@@ -20,6 +20,7 @@ import {
   Grid2x2,
   Cog,
   ScrollIcon,
+  ScrollText,
   SquareAsterisk,
 } from "lucide-react"
 import { useTranslations } from "next-intl"
@@ -80,6 +81,7 @@ export function useNavItems() {
       url: "/transaction-templates",
       icon: SquareAsterisk,
     },
+    { title: t("ledgerAccount"), url: "/ledger-account", icon: ScrollText },
   ]
 
   const allNavItems: NavItem[] = [

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -43,6 +43,7 @@
       "auditLogs": "Audit Logs",
       "committees": "Committees",
       "chartOfAccounts": "Chart of Accounts",
+      "ledgerAccount": "Ledger Account",
       "journal": "Journal",
       "users": "Users",
       "balanceSheet": "Balance Sheet",
@@ -1421,6 +1422,14 @@
       "credit": "Credit",
       "amount": "Amount",
       "ledgerAccount": "Ledger Account"
+    },
+    "form": {
+      "labels": {
+        "transaction": "Search Transaction"
+      },
+      "placeholders": {
+        "transaction": "Transaction ID or Code"
+      }
     }
   },
   "ManualTransactions": {

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -43,6 +43,7 @@
       "auditLogs": "Registros de Auditoría",
       "committees": "Comités",
       "chartOfAccounts": "Plan de Cuentas",
+      "ledgerAccount": "Cuenta del Libro Mayor",
       "journal": "Diario",
       "users": "Usuarios",
       "balanceSheet": "Balance General",
@@ -1421,6 +1422,14 @@
       "credit": "Crédito",
       "amount": "Monto",
       "ledgerAccount": "Cuenta del libro mayor"
+    },
+    "form": {
+      "labels": {
+        "transaction": "Busqueda de Transacciones"
+      },
+      "placeholders": {
+        "transaction": "Codigo o Referencia de la Transacción"
+      }
     }
   },
   "ManualTransactions": {


### PR DESCRIPTION
Addresses https://github.com/GaloyMoney/lana-bank/issues/1818

Updates the `/ledger-account` route to show a search bar for locating a specific ledger transaction. 
The search bar simply updates the URL with the resource id. 
![image](https://github.com/user-attachments/assets/7b30da12-618d-472e-b870-190ece56bb1d)

Notes regarding the work: 
- I did not add e2e test at the moment, I usually follow up with a PR for that
- as you can see, I simply added the menu item to the sidebar at the bottom of the nav group and chose an icon from lucide, let me know if the location/icon is appropriate.
- I added the translations in ES and ES took liberties with copy (I have never really worked in banking in Spanish, so given that, and the fact that I am not even really getting actual data, it's hard to tell whether I did it appropriately)
- Tried to follow the style of putting every dashboard item in a card, the code is really intuitive to find the style.

Some notes for future consideration:
- We should definitely add meta titles to all pages for easier navigation with open tabs.
- We should definitely add vitest testing for unit testing and not rely on e2e testing for all the frontend needs
- The application is really consuming a lot of my resources would be nice to run the frontend backed by some hosted test environment if possible. 