### PR TITLE
ci: discrepency between local cargo and deployed cargo

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -1,4 +1,4 @@
-flow to access in dev mode the public API
+Flow to access in dev mode the public API
 
 ```mermaid
 flowchart TD

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -10,15 +10,19 @@ RUN mkdir lana-home && mkdir lana && cd lana \
   && gh release download --repo GaloyMoney/lana-bank ${VERSION} \
   && mv lana-cli /usr/local/bin && cd ../ && rm -rf ./lana
 
-FROM gcr.io/distroless/static
-  COPY --from=load --chmod=0755 /usr/local/bin/lana-cli /bin/lana-cli
-  COPY --from=load --chown=1000:0 --chmod=755 /lana-home /lana
-  USER 1000
-  ARG VERSION
-  ARG BUILDTIME
-  ARG COMMITHASH
-  ENV VERSION ${VERSION}
-  ENV BUILDTIME ${BUILDTIME}
-  ENV COMMITHASH ${COMMITHASH}
-  ENV LANA_HOME /lana
-  CMD ["lana-cli"]
+FROM scratch
+
+COPY --from=load --chmod=0755 /usr/local/bin/lana-cli /bin/lana-cli
+COPY --from=load --chown=1000:0 --chmod=755 /lana-home /lana
+  
+USER 1000
+  
+ARG VERSION
+ARG BUILDTIME
+ARG COMMITHASH
+ENV VERSION="$VERSION" \
+    BUILDTIME="$BUILDTIME" \
+    COMMITHASH="$COMMITHASH" \
+    LANA_HOME=/lana
+  
+ENTRYPOINT ["/bin/lana-cli"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -11,7 +11,7 @@ RUN mkdir lana-home && mkdir lana && cd lana \
   && mv lana-cli /usr/local/bin && cd ../ && rm -rf ./lana
 
 FROM gcr.io/distroless/static
-  COPY --from=load /usr/local/bin/lana-cli /bin/lana-cli
+  COPY --from=load --chmod=0755 /usr/local/bin/lana-cli /bin/lana-cli
   COPY --from=load --chown=1000:0 --chmod=755 /lana-home /lana
   USER 1000
   ARG VERSION

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -7,9 +7,7 @@ ENV GH_TOKEN ${GH_TOKEN}
 ARG VERSION
 ENV VERSION ${VERSION}
 RUN mkdir lana-home && mkdir lana && cd lana \
-  && gh release download --repo GaloyMoney/lana-bank ${VERSION}\
-  && mv lana-cli-x86_64-unknown-linux-musl-${VERSION}.tar.gz lana-cli.tar.gz \
-  && tar --strip-components=1 -xf lana-cli.tar.gz \
+  && gh release download --repo GaloyMoney/lana-bank ${VERSION} \
   && mv lana-cli /usr/local/bin && cd ../ && rm -rf ./lana
 
 FROM gcr.io/distroless/static

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ run-server:
 run-server-with-bootstrap:
 	cargo run --bin lana-cli --all-features -- --config ./bats/lana-sim-time.yml | tee .e2e-logs
 
-check-code: sdl
+check-code: sdl-rust
 	git diff --exit-code lana/customer-server/src/graphql/schema.graphql
 	git diff --exit-code lana/admin-server/src/graphql/schema.graphql
 	SQLX_OFFLINE=true cargo fmt --check --all
@@ -49,11 +49,15 @@ build-for-tests:
 e2e: clean-deps start-deps build-for-tests
 	bats --setup-suite-file bats/ci-setup-suite.bash -t bats
 
-sdl:
+sdl-rust:
 	SQLX_OFFLINE=true cargo run --bin write_sdl > lana/admin-server/src/graphql/schema.graphql
 	SQLX_OFFLINE=true cargo run --bin write_customer_sdl > lana/customer-server/src/graphql/schema.graphql
+
+sdl-js:
 	cd apps/admin-panel && pnpm install && pnpm codegen
 	cd apps/customer-portal && pnpm install && pnpm codegen
+
+full-sdl: sdl-rust sdl-js
 
 # Frontend Apps
 check-code-apps: check-code-apps-admin-panel check-code-apps-customer-portal

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,10 +1,8 @@
 #@ load("@ytt:data", "data")
 
 #@ load("vendor/pipeline-fragments.lib.yml",
-#@   "build_edge_image",
 #@   "public_docker_registry",
 #@   "nodejs_task_image_config",
-#@   "check_code",
 #@   "docker_host_pool",
 #@   "test_on_docker_host",
 #@   "repo_resource",
@@ -69,10 +67,10 @@ plan:
 groups:
   - name: lana-bank
     jobs:
-      - check-code
+      - nodejs-check-code
+      - rust-check-code
       - integration-tests
       - bats-tests
-      - build-edge-image
       - release
       - release-docker
       - set-dev-version
@@ -80,20 +78,115 @@ groups:
       -  #@ build_app_edge_image_name("admin-panel")
       -  #@ build_app_edge_image_name("customer-portal")
       - build-meltano-edge-image
+      - build-static-binary
 
 jobs:
-  -  #@ check_code()
   -  #@ on_nix_host("integration-tests", "make test-in-ci")
   -  #@ on_nix_host("bats-tests", "make e2e")
-  -  #@ build_edge_image()
+
+  - name: rust-check-code
+    serial: true
+    plan:
+    - in_parallel:
+      - { get: repo, trigger: true }
+      - { get: pipeline-tasks }
+    - task: check-code
+      config:
+        platform: linux
+        image_resource: #@ rust_task_image_config()
+        inputs:
+        - name: pipeline-tasks
+        - name: repo
+        caches:
+        - path: cargo-home
+        - path: cargo-target-dir
+        run:
+          path: pipeline-tasks/ci/vendor/tasks/rust-check-code.sh
+
+  - name: nodejs-check-code
+    serial: true
+    plan:
+    - in_parallel:
+      - { get: repo, trigger: true }
+      - { get: pipeline-tasks }
+    - task: check-code
+      config:
+        platform: linux
+        image_resource: #@ nodejs_task_image_config()
+        inputs:
+        - name: pipeline-tasks
+        - name: repo
+        run:
+          path: pipeline-tasks/ci/tasks/check-code-apps.sh
+
+  - name: build-static-binary
+    serial: true
+    plan:
+    - in_parallel:
+      - get: repo
+        trigger: true
+      - get: pipeline-tasks
+    - task: cargo-build-release
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: {repository: clux/muslrust, tag: stable}
+        inputs:
+        - name: pipeline-tasks
+        - name: repo
+        outputs: [{name: bin}]
+        caches:  [{path: cargo-target}, {path: cargo-home}]
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            export CARGO_HOME="$PWD/cargo-home"
+            export CARGO_TARGET_DIR="$PWD/cargo-target-dir"
+            cd repo
+            SQLX_OFFLINE=true cargo build --release --locked --bin lana-cli --target x86_64-unknown-linux-musl
+            mkdir -p ../bin
+            cp "${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/release/lana-cli" ../bin/
+            cat > ../bin/Dockerfile <<'EOF'
+            FROM scratch
+            COPY lana-cli /lana-cli
+            ENTRYPOINT ["/lana-cli"]
+            EOF
+    - task: build-image-with-kaniko
+      privileged: true
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: gcr.io/kaniko-project/executor
+            tag: debug
+        inputs:  [{name: bin}]
+        outputs: [{name: image}]
+        run:
+          path: /kaniko/executor
+          args:
+            - --dockerfile=Dockerfile
+            - --context=bin
+            - --use-new-run
+            - --single-snapshot
+            - --cache=false
+            - --no-push
+            - --tar-path=image/image.tar
+    - put: static-binary-image
+      params:
+        image: image/image.tar
+        additional_tags: repo/.git/ref  
 
   - name: release
     serial: true
     plan:
       - in_parallel:
           - get: repo
-            passed:
-              - check-code
+            passed: 
+              - nodejs-check-code
+              - rust-check-code
               - integration-tests
               - bats-tests
             trigger: true
@@ -141,28 +234,25 @@ jobs:
               path: customer-portal-src
           run:
             path: pipeline-tasks/ci/tasks/prep-release-apps.sh
+      - get: static-binary-image
+        passed: [build-static-binary]
+        trigger: true
+      - task: unwrap-binary
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: alpine, tag: "3.20"}
+          inputs: [{name: static-binary-image}]
+          outputs: [{name: binaries}]
+          caches: [{path: apk-cache}]
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              mv static-binary-image/rootfs/* binaries
       - in_parallel:
-        - task: build-static-release
-          privileged: true
-          config:
-            platform: linux
-            image_resource:
-              type: registry-image
-              source: { repository: clux/muslrust, tag: 1.78.0-stable }
-            inputs:
-              - name: version
-              - name: pipeline-tasks
-              - name: repo
-            outputs:
-              - name: x86_64-unknown-linux-musl
-            caches:
-              - path: cargo-home
-              - path: cargo-target-dir
-            params:
-              TARGET: x86_64-unknown-linux-musl
-              OUT: x86_64-unknown-linux-musl
-            run:
-              path: pipeline-tasks/ci/tasks/build-release.sh
         - do:
           - task: build-admin-panel-release
             attempts: 2
@@ -221,7 +311,7 @@ jobs:
           image_resource: #@ rust_task_image_config()
           platform: linux
           inputs:
-            - name: x86_64-unknown-linux-musl
+            - name: binaries
             - name: version
             - name: pipeline-tasks
             - name: artifacts
@@ -435,7 +525,7 @@ resources:
         - apps/**/*
       fetch_tags: true
       uri: #@ data.values.git_uri
-      branch: #@ data.values.git_branch
+      branch: ci--discrepency-between-local-cargo-and-deployed-cargo
       private_key: #@ data.values.github_private_key
     webhook_token: ((webhook.secret))
   - name: repo-dev-out
@@ -453,7 +543,7 @@ resources:
       tag: latest
       username: #@ data.values.docker_registry_user
       password: #@ data.values.docker_registry_password
-      repository: #@ private_docker_registry() + "/" + data.values.gh_repository
+      repository: #@ private_docker_registry() + "/" + data.values.folder_registry_image
 
   - name: nix-host
     type: pool
@@ -479,8 +569,15 @@ resources:
       password: #@ data.values.docker_registry_password
       repository: #@ public_docker_registry() + "/meltano"
 
+  - name: static-binary-image
+    type: registry-image
+    source:
+      tag: latest
+      repository: #@ private_docker_registry() + "/" + data.values.folder_registry_image_static
+      username: #@ data.values.docker_registry_user
+      password: #@ data.values.docker_registry_password
+
   -  #@ pipeline_tasks_resource()
-  -  #@ edge_image_resource(publicRepo=False)
   -  #@ version_resource()
   -  #@ gh_release_resource()
   -  #@ charts_repo_bot_branch()

--- a/ci/tasks/check-code-apps.sh
+++ b/ci/tasks/check-code-apps.sh
@@ -7,4 +7,4 @@ set -eu
 
 pushd repo
 
-nix develop -c make check-code
+make check-code-apps

--- a/ci/tasks/github-release.sh
+++ b/ci/tasks/github-release.sh
@@ -3,4 +3,4 @@
 set -eu
 
 mkdir artifacts/binaries
-mv x86_64-unknown-linux-musl/* artifacts/binaries
+mv binaries/* artifacts/binaries

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -18,3 +18,6 @@ docker_host_ip: ((staging-ssh.docker_host_ip))
 git_version_branch: version
 gh_org: GaloyMoney
 gh_repository: lana-bank
+
+folder_registry_image: lana-bank
+folder_registry_image_static: lana-bank-static

--- a/ci/vendor/pipeline-fragments.lib.yml
+++ b/ci/vendor/pipeline-fragments.lib.yml
@@ -403,7 +403,7 @@ source:
   ignore_paths: ["ci/*[^md]"]
   fetch_tags: true
   uri: #@ data.values.git_uri
-  branch: #@ data.values.git_branch
+  branch: ci--discrepency-between-local-cargo-and-deployed-cargo
   private_key: #@ data.values.github_private_key
 #@ if webhook:
 webhook_token: ((webhook.secret))
@@ -416,7 +416,7 @@ type: git
 source:
   paths: [ci/vendor/*, ci/tasks/*, ci/config/*, Makefile]
   uri: #@ data.values.git_uri
-  branch: #@ data.values.git_branch
+  branch: ci--discrepency-between-local-cargo-and-deployed-cargo
   private_key: #@ data.values.github_private_key
 #@ end
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   - "apps/*"
   - "lib/js/*"
-  - "package.json"
+  - "."


### PR DESCRIPTION
local cargo is cargo 1.86.0
runtime is based on 1.78.0

what is the right strategy here to keep in sync? 
I think it's better to target stable as opposed to a defined version? on flake update we algo __generally__ stays on stable



some items done here:
- doing check code for apps (we were not doing it)
- not using nix anymore for building rust (save about ~12 min to fetch/build nix deps)
- pre-emptively compiling release build
- removing debug build: not used/not tagged