### PR TITLE
chore: remove interest overdue state

### DIFF
--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -302,7 +302,6 @@ impl InterestAccrualCycle {
                     account_to_be_credited_id: self.account_ids.interest_income_account_id,
                 })
                 .due_date(self.accrual_cycle_ends_at())
-                .overdue_date(self.accrual_cycle_ends_at())
                 .recorded_at(posted_at)
                 .audit_info(audit_info)
                 .build()

--- a/core/credit/src/jobs/obligation_due.rs
+++ b/core/credit/src/jobs/obligation_due.rs
@@ -132,17 +132,19 @@ where
             .update_in_op(&mut db, &mut obligation)
             .await?;
 
-        self.jobs
-            .create_and_spawn_at_in_op(
-                &mut db,
-                JobId::new(),
-                obligation_overdue::CreditFacilityJobConfig::<Perms, E> {
-                    obligation_id: obligation.id,
-                    _phantom: std::marker::PhantomData,
-                },
-                obligation.overdue_at(),
-            )
-            .await?;
+        if let Some(overdue_at) = obligation.overdue_at() {
+            self.jobs
+                .create_and_spawn_at_in_op(
+                    &mut db,
+                    JobId::new(),
+                    obligation_overdue::CreditFacilityJobConfig::<Perms, E> {
+                        obligation_id: obligation.id,
+                        _phantom: std::marker::PhantomData,
+                    },
+                    overdue_at,
+                )
+                .await?;
+        }
 
         self.ledger.record_obligation_due(db, due).await?;
 


### PR DESCRIPTION
## Description

Interest is only ever due and there are no obvious actions/requirements for an overdue state so this is removed here.

In future we may want to re-introduce an overdue state for things like sending late payment notifications, or to warn of upcoming default etc.