### PR TITLE
fix: check-code sdl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ run-server:
 run-server-with-bootstrap:
 	cargo run --bin lana-cli --all-features -- --config ./bats/lana-sim-time.yml | tee .e2e-logs
 
-check-code: sdl-rust
+check-code: full-sdl
 	git diff --exit-code lana/customer-server/src/graphql/schema.graphql
 	git diff --exit-code lana/admin-server/src/graphql/schema.graphql
 	SQLX_OFFLINE=true cargo fmt --check --all

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ run-server:
 run-server-with-bootstrap:
 	cargo run --bin lana-cli --all-features -- --config ./bats/lana-sim-time.yml | tee .e2e-logs
 
-check-code: full-sdl
+check-code: sdl-rust
 	git diff --exit-code lana/customer-server/src/graphql/schema.graphql
 	git diff --exit-code lana/admin-server/src/graphql/schema.graphql
 	SQLX_OFFLINE=true cargo fmt --check --all
@@ -60,7 +60,7 @@ sdl-js:
 full-sdl: sdl-rust sdl-js
 
 # Frontend Apps
-check-code-apps: check-code-apps-admin-panel check-code-apps-customer-portal
+check-code-apps: sdl-js check-code-apps-admin-panel check-code-apps-customer-portal
 
 start-admin:
 	cd apps/admin-panel && pnpm install --frozen-lockfile && pnpm dev


### PR DESCRIPTION
Broke due to this : https://github.com/GaloyMoney/lana-bank/commit/0ac58afeea5ceacbd86e6de133eb1bb522265358 
We need to use `full-sdl` so that we trigger codegen, which will fail the check-code if we use incorrect GraphQL in the front end.