### PR TITLE
feat(reporting): dbt macro to drop stale tables

### DIFF
--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -33,6 +33,9 @@ jobs:
 - name: sync-sumsub
   tasks:
   - tap-sumsubapi target-bigquery
+- name: drop-old-relations
+  tasks:
+    - dbt-bigquery:drop-old-relations
 schedules:
 - name: postgres-to-bigquery-dbt
   interval: '*/10 * * * *'
@@ -46,6 +49,9 @@ schedules:
 - name: test-dbt-daily
   interval: '@daily'
   job: test-dbt
+- name: drop-old-relations-weekly
+  interval: '@weekly'
+  job: drop-old-relations
 plugins:
   extractors:
   - name: tap-postgres
@@ -86,6 +92,9 @@ plugins:
     config:
       auth_method: service-account
       project: lana-dev-440721
+    commands:
+      drop-old-relations:
+        args: run-operation drop_old_relations
   utilities:
   - name: sqlfluff
     variant: sqlfluff

--- a/meltano/transform/macros/util/drop_old_relations.sql
+++ b/meltano/transform/macros/util/drop_old_relations.sql
@@ -1,0 +1,60 @@
+{% macro drop_old_relations(schema=target.schema, dryrun=False) %}
+
+{# Get the models that currently exist in dbt #}
+{% if execute %}
+  {% set current_models=[] %}
+
+  {% for node in graph.nodes.values()
+     | selectattr("resource_type", "in", ["model", "seed", "snapshot"])%}
+        {% do current_models.append(node.name) %}
+
+  {% endfor %}
+{% endif %}
+
+{# Run a query to create the drop statements for all relations in BQ that are NOT in the dbt project #}
+{% set cleanup_query %}
+
+      WITH MODELS_TO_DROP AS (
+          SELECT
+            CASE
+              WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE'
+              WHEN TABLE_TYPE = 'VIEW' THEN 'VIEW'
+            END AS RELATION_TYPE,
+            CONCAT('{{ schema }}','.',TABLE_NAME) AS RELATION_NAME
+          FROM
+            {{ schema }}.INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = '{{ schema }}'
+            AND UPPER(TABLE_NAME) NOT IN
+              ({%- for model in current_models -%}
+                  '{{ model.upper() }}'
+                  {%- if not loop.last -%}
+                      ,
+                  {% endif %}
+              {%- endfor -%}))
+      SELECT
+        'DROP ' || RELATION_TYPE || ' ' || RELATION_NAME || ';' as DROP_COMMANDS
+      FROM
+        MODELS_TO_DROP
+  {% endset %}
+
+{% set drop_commands = run_query(cleanup_query).columns[0].values() %}
+
+{# Execute each of the drop commands for each relation #}
+
+{% if drop_commands %}
+  {% if dryrun | as_bool == False %}
+    {% do log('Executing DROP commands...', True) %}
+  {% else %}
+    {% do log('Printing DROP commands...', True) %}
+  {% endif %}
+  {% for drop_command in drop_commands %}
+    {% do log(drop_command, True) %}
+    {% if dryrun | as_bool == False %}
+      {% do run_query(drop_command) %}
+    {% endif %}
+  {% endfor %}
+{% else %}
+  {% do log('No relations to clean.', True) %}
+{% endif %}
+
+{%- endmacro -%}


### PR DESCRIPTION
There's a bug in the regulatory reports screen where the old versions of reports we've renamed are still showing up because dbt doesn't automatically delete the old tables for renamed queries.

This PR adds a macro to do this automatically on a weekly basis.