### PR TITLE
chore: Switch to using effective balances in ranges

### DIFF
--- a/.sqlx/query-0012e34ca11d1d4f2595c3d648bfa458d1dcf31881f4e5653c6373b5022fe5df.json
+++ b/.sqlx/query-0012e34ca11d1d4f2595c3d648bfa458d1dcf31881f4e5653c6373b5022fe5df.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT journal_id, id FROM cala_entries WHERE ((journal_id = $1) AND (COALESCE(id > $3, true))) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0012e34ca11d1d4f2595c3d648bfa458d1dcf31881f4e5653c6373b5022fe5df"
+}

--- a/.sqlx/query-007a601f6a9d9cb77e0e98379e07284bdddedfb421958b14c60dca0f569def13.json
+++ b/.sqlx/query-007a601f6a9d9cb77e0e98379e07284bdddedfb421958b14c60dca0f569def13.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "007a601f6a9d9cb77e0e98379e07284bdddedfb421958b14c60dca0f569def13"
+}

--- a/.sqlx/query-027974685a3d8accfb891acd094c055897a1f93023072f09fc6317bad9965240.json
+++ b/.sqlx/query-027974685a3d8accfb891acd094c055897a1f93023072f09fc6317bad9965240.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          SELECT m.account_set_id AS \"set_id!: AccountSetId\", m.member_account_id AS \"account_id!: AccountId\"\n          FROM cala_account_set_member_accounts m\n          JOIN cala_account_sets s\n          ON m.account_set_id = s.id AND s.journal_id = $1\n          WHERE m.member_account_id = ANY($2)\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "set_id!: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "027974685a3d8accfb891acd094c055897a1f93023072f09fc6317bad9965240"
+}

--- a/.sqlx/query-030ce137853044242ffa49d9c61c7a650116df7dc5c650736a8f7e0d096db6e9.json
+++ b/.sqlx/query-030ce137853044242ffa49d9c61c7a650116df7dc5c650736a8f7e0d096db6e9.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT values, latest_values\n            FROM cala_velocity_account_controls v\n            JOIN cala_accounts a\n            ON v.account_id = a.id\n            WHERE account_id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "latest_values",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "030ce137853044242ffa49d9c61c7a650116df7dc5c650736a8f7e0d096db6e9"
+}

--- a/.sqlx/query-031466649e761e92d8e682880b7803e13ab2c0c03c462bfecc72e2588ec7aa3d.json
+++ b/.sqlx/query-031466649e761e92d8e682880b7803e13ab2c0c03c462bfecc72e2588ec7aa3d.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_control_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "031466649e761e92d8e682880b7803e13ab2c0c03c462bfecc72e2588ec7aa3d"
+}

--- a/.sqlx/query-03225edba16e945a3073c1b08ee16b108da41de6ade1ab20f68cafb912cfd11b.json
+++ b/.sqlx/query-03225edba16e945a3073c1b08ee16b108da41de6ade1ab20f68cafb912cfd11b.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH pairs AS (\n              SELECT account_id, currency\n            FROM (\n            SELECT * FROM UNNEST($2::uuid[], $3::text[]) AS v(account_id, currency)\n            ) AS v\n            JOIN cala_accounts a\n            ON account_id = a.id\n            WHERE eventually_consistent = FALSE\n            ),\n          current_balances AS (\n            SELECT b.journal_id, b.account_id, b.currency, b.latest_version\n              FROM cala_current_balances b\n              JOIN pairs p ON p.account_id = b.account_id AND p.currency = b.currency\n              WHERE b.journal_id = $1\n          ),\n          values AS (\n            SELECT p.account_id, p.currency, h.values\n            FROM pairs p\n            LEFT JOIN current_balances b\n            ON p.account_id = b.account_id\n              AND p.currency = b.currency\n            LEFT JOIN cala_balance_history h\n            ON b.journal_id = h.journal_id\n              AND b.account_id = h.account_id\n              AND b.currency = h.currency\n              AND b.latest_version = h.version\n          )\n          SELECT account_id AS \"account_id!: AccountId\", currency AS \"currency!\", values FROM values\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "currency!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "values",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      true
+    ]
+  },
+  "hash": "03225edba16e945a3073c1b08ee16b108da41de6ade1ab20f68cafb912cfd11b"
+}

--- a/.sqlx/query-04b7a8b3aeeeed28c884ab136993fe363319ad7f0e4984df668b4a4fb524ac41.json
+++ b/.sqlx/query-04b7a8b3aeeeed28c884ab136993fe363319ad7f0e4984df668b4a4fb524ac41.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_controls WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "04b7a8b3aeeeed28c884ab136993fe363319ad7f0e4984df668b4a4fb524ac41"
+}

--- a/.sqlx/query-04ca969137e905e751f157dc0dcee46b8f0e59f973d3755fd15e5dba7f6e84ef.json
+++ b/.sqlx/query-04ca969137e905e751f157dc0dcee46b8f0e59f973d3755fd15e5dba7f6e84ef.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_tx_templates WHERE data_source_id = $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "04ca969137e905e751f157dc0dcee46b8f0e59f973d3755fd15e5dba7f6e84ef"
+}

--- a/.sqlx/query-05e1c6bd7a56ac14abcd4181a64e1e227c7f2af88bd2388820aa30f6372d80c5.json
+++ b/.sqlx/query-05e1c6bd7a56ac14abcd4181a64e1e227c7f2af88bd2388820aa30f6372d80c5.json
@@ -1,0 +1,63 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      WITH inputs AS (\n        SELECT *\n        FROM UNNEST(\n          $1::jsonb[], \n          $2::text[], \n          $3::uuid[], \n          $4::uuid[], \n          $5::uuid[], \n          $6::uuid[]\n        )\n        AS v(partition_window, currency, journal_id, account_id, velocity_control_id, velocity_limit_id)\n      )\n      SELECT \n          i.partition_window as \"partition_window!: serde_json::Value\", \n          i.currency as \"currency!\", \n          i.journal_id as \"journal_id!: JournalId\", \n          i.account_id as \"account_id!: AccountId\", \n          i.velocity_control_id as \"velocity_control_id!: VelocityControlId\", \n          i.velocity_limit_id as \"velocity_limit_id!: VelocityLimitId\",\n          h.values as \"values?: serde_json::Value\"\n      FROM inputs i\n      LEFT JOIN cala_velocity_current_balances b\n        ON i.partition_window = b.partition_window\n        AND i.currency = b.currency\n        AND i.journal_id = b.journal_id\n        AND i.account_id = b.account_id\n        AND i.velocity_control_id = b.velocity_control_id\n        AND i.velocity_limit_id = b.velocity_limit_id\n      LEFT JOIN cala_velocity_balance_history h\n        ON b.partition_window = h.partition_window\n        AND b.currency = h.currency\n        AND b.journal_id = h.journal_id\n        AND b.account_id = h.account_id\n        AND b.velocity_control_id = h.velocity_control_id\n        AND b.velocity_limit_id = h.velocity_limit_id\n        AND b.latest_version = h.version\n      ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "partition_window!: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "currency!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "journal_id!: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "velocity_control_id!: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "velocity_limit_id!: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "values?: serde_json::Value",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "JsonbArray",
+        "TextArray",
+        "UuidArray",
+        "UuidArray",
+        "UuidArray",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      true
+    ]
+  },
+  "hash": "05e1c6bd7a56ac14abcd4181a64e1e227c7f2af88bd2388820aa30f6372d80c5"
+}

--- a/.sqlx/query-06e9f222a35d79deda5c0ad5a907cb2bcbfdb27cb21575398ed79d0e5c204105.json
+++ b/.sqlx/query-06e9f222a35d79deda5c0ad5a907cb2bcbfdb27cb21575398ed79d0e5c204105.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE id = $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "06e9f222a35d79deda5c0ad5a907cb2bcbfdb27cb21575398ed79d0e5c204105"
+}

--- a/.sqlx/query-08dc2c99d22343feedced326055a999143f931fdc5a5f0c0de8dbdb741385384.json
+++ b/.sqlx/query-08dc2c99d22343feedced326055a999143f931fdc5a5f0c0de8dbdb741385384.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, created_at, id FROM cala_account_sets WHERE ((name = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "08dc2c99d22343feedced326055a999143f931fdc5a5f0c0de8dbdb741385384"
+}

--- a/.sqlx/query-0bda4bb7b10c662d14e2a924ddc81d4a067e6090b58b2988b1db17f4008f251b.json
+++ b/.sqlx/query-0bda4bb7b10c662d14e2a924ddc81d4a067e6090b58b2988b1db17f4008f251b.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_controls WHERE id = $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0bda4bb7b10c662d14e2a924ddc81d4a067e6090b58b2988b1db17f4008f251b"
+}

--- a/.sqlx/query-0c3bbb19b3fc1c3b341b798779881d7b31d7da4f7aaead8d64a7e1a8840b8133.json
+++ b/.sqlx/query-0c3bbb19b3fc1c3b341b798779881d7b31d7da4f7aaead8d64a7e1a8840b8133.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH limits AS (\n              SELECT id, l.created_at AS entity_created_at\n              FROM cala_velocity_limits l\n              JOIN cala_velocity_control_limits ON id = velocity_limit_id\n              WHERE velocity_control_id = $1\n            )\n            SELECT l.id as entity_id, e.sequence, e.event, e.recorded_at\n            FROM limits l\n            JOIN cala_velocity_limit_events e ON l.id = e.id\n            ORDER BY l.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0c3bbb19b3fc1c3b341b798779881d7b31d7da4f7aaead8d64a7e1a8840b8133"
+}

--- a/.sqlx/query-0d327ebdfedc973b4a2fd598a9f8d81dd413bcf8c499b9f9ead5455096975e66.json
+++ b/.sqlx/query-0d327ebdfedc973b4a2fd598a9f8d81dd413bcf8c499b9f9ead5455096975e66.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM cala_velocity_controls i JOIN cala_velocity_control_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0d327ebdfedc973b4a2fd598a9f8d81dd413bcf8c499b9f9ead5455096975e66"
+}

--- a/.sqlx/query-108f2ca9f2a9bd688a05c937aca7275ced73deff0f0a05ea3a0c6a075d7d9d0d.json
+++ b/.sqlx/query-108f2ca9f2a9bd688a05c937aca7275ced73deff0f0a05ea3a0c6a075d7d9d0d.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_transactions (id, external_id, correlation_id, journal_id, tx_template_id, data_source_id, effective, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Date",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "108f2ca9f2a9bd688a05c937aca7275ced73deff0f0a05ea3a0c6a075d7d9d0d"
+}

--- a/.sqlx/query-12f665724e9317d09dca96a68aa14d6d872f3b5753d86531158e9ba854d0fe98.json
+++ b/.sqlx/query-12f665724e9317d09dca96a68aa14d6d872f3b5753d86531158e9ba854d0fe98.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_journals WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "12f665724e9317d09dca96a68aa14d6d872f3b5753d86531158e9ba854d0fe98"
+}

--- a/.sqlx/query-135ee74ff7b5e89f6b63aa974cba2c514f6ed7bd0e0db0f2e7e82d2c7f733a22.json
+++ b/.sqlx/query-135ee74ff7b5e89f6b63aa974cba2c514f6ed7bd0e0db0f2e7e82d2c7f733a22.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_control_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "135ee74ff7b5e89f6b63aa974cba2c514f6ed7bd0e0db0f2e7e82d2c7f733a22"
+}

--- a/.sqlx/query-142f41e72aed810515c083aae2566a01b944a298a27d8b706d5d03633a769fa8.json
+++ b/.sqlx/query-142f41e72aed810515c083aae2566a01b944a298a27d8b706d5d03633a769fa8.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          WITH RECURSIVE parents AS (\n            SELECT m.member_account_set_id, m.account_set_id\n            FROM cala_account_set_member_account_sets m\n            JOIN cala_account_sets s\n            ON s.id = m.account_set_id\n            WHERE m.member_account_set_id = $1\n\n            UNION ALL\n            SELECT p.member_account_set_id, m.account_set_id\n            FROM parents p\n            JOIN cala_account_set_member_account_sets m\n                ON p.account_set_id = m.member_account_set_id\n          ),\n          non_transitive_insert AS (\n            INSERT INTO cala_account_set_member_accounts (account_set_id, member_account_id)\n            VALUES ($1, $2)\n          ),\n          transitive_insert AS (\n            INSERT INTO cala_account_set_member_accounts (account_set_id, member_account_id, transitive)\n            SELECT p.account_set_id, $2, TRUE\n            FROM parents p\n          )\n          SELECT account_set_id, NULL AS now\n          FROM parents\n          UNION ALL\n          SELECT NULL AS account_set_id, NOW() AS now\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_set_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "now",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "142f41e72aed810515c083aae2566a01b944a298a27d8b706d5d03633a769fa8"
+}

--- a/.sqlx/query-157b3c169b10f77ff24ca11ce7f55985652f3d4611c113b63a479dcc71ed4d06.json
+++ b/.sqlx/query-157b3c169b10f77ff24ca11ce7f55985652f3d4611c113b63a479dcc71ed4d06.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT h.values, a.normal_balance_type AS \"normal_balance_type!: DebitOrCredit\"\n            FROM cala_balance_history h\n            JOIN cala_current_balances c\n            ON h.journal_id = c.journal_id\n            AND h.account_id = c.account_id\n            AND h.currency = c.currency\n            AND h.version = c.latest_version\n            JOIN cala_accounts a\n            ON c.account_id = a.id\n            WHERE c.journal_id = $1\n            AND c.account_id = $2\n            AND c.currency = $3\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "157b3c169b10f77ff24ca11ce7f55985652f3d4611c113b63a479dcc71ed4d06"
+}

--- a/.sqlx/query-171da8b1fdbdd206764313718ba795927e3c4fba9b58767d23789c8b0b9dc1e1.json
+++ b/.sqlx/query-171da8b1fdbdd206764313718ba795927e3c4fba9b58767d23789c8b0b9dc1e1.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH member_accounts AS (\n              SELECT\n                member_account_id AS member_id,\n                member_account_id,\n                NULL::uuid AS member_account_set_id,\n                created_at\n              FROM cala_account_set_member_accounts\n              WHERE\n                transitive IS FALSE\n                AND account_set_id = $4\n                AND (COALESCE((created_at, member_account_id) < ($3, $2), $2 IS NULL))\n              ORDER BY created_at DESC, member_account_id DESC\n              LIMIT $1\n            ), member_sets AS (\n              SELECT\n                member_account_set_id AS member_id,\n                NULL::uuid AS member_account_id,\n                member_account_set_id,\n                created_at\n              FROM cala_account_set_member_account_sets\n              WHERE\n                account_set_id = $4\n                AND (COALESCE((created_at, member_account_set_id) < ($3, $2), $2 IS NULL))\n              ORDER BY created_at DESC, member_account_set_id DESC\n              LIMIT $1\n            ), all_members AS (\n              SELECT * FROM member_accounts\n              UNION ALL\n              SELECT * FROM member_sets\n            )\n            SELECT * FROM all_members\n            ORDER BY created_at DESC, member_id DESC\n            LIMIT $1\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "member_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "member_account_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "member_account_set_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "171da8b1fdbdd206764313718ba795927e3c4fba9b58767d23789c8b0b9dc1e1"
+}

--- a/.sqlx/query-197c0c7f6a29ec59c20a33fdc439078bde0a7239c6eb1f725c85ac1dfb730881.json
+++ b/.sqlx/query-197c0c7f6a29ec59c20a33fdc439078bde0a7239c6eb1f725c85ac1dfb730881.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_limits WHERE data_source_id = $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "197c0c7f6a29ec59c20a33fdc439078bde0a7239c6eb1f725c85ac1dfb730881"
+}

--- a/.sqlx/query-1ab089f1ec5ac8957134b1cad274e944838d6231cb5e15feeb8b4b07f6c3109f.json
+++ b/.sqlx/query-1ab089f1ec5ac8957134b1cad274e944838d6231cb5e15feeb8b4b07f6c3109f.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT pg_advisory_xact_lock(hashtext(concat(\n            partition_window::text,\n            currency,\n            journal_id::text,\n            account_id::text,\n            velocity_control_id::text,\n            velocity_limit_id::text\n        )))\n        FROM UNNEST(\n            $1::jsonb[], \n            $2::text[], \n            $3::uuid[], \n            $4::uuid[], \n            $5::uuid[], \n            $6::uuid[]\n        )\n        AS v(partition_window, currency, journal_id, account_id, velocity_control_id, velocity_limit_id)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "JsonbArray",
+        "TextArray",
+        "UuidArray",
+        "UuidArray",
+        "UuidArray",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1ab089f1ec5ac8957134b1cad274e944838d6231cb5e15feeb8b4b07f6c3109f"
+}

--- a/.sqlx/query-1cabd2f674da323da9e0da724d3bcfe5f968b31500e8c8cf97fe16814bc04164.json
+++ b/.sqlx/query-1cabd2f674da323da9e0da724d3bcfe5f968b31500e8c8cf97fe16814bc04164.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO casbin_rule ( ptype, v0, v1, v2, v3, v4, v5 )\n                 VALUES ( $1, $2, $3, $4, $5, $6, $7 )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1cabd2f674da323da9e0da724d3bcfe5f968b31500e8c8cf97fe16814bc04164"
+}

--- a/.sqlx/query-1e4169b7da5e68ed377f63680e02d9e89bc89199926d3adf361418ad501a45ed.json
+++ b/.sqlx/query-1e4169b7da5e68ed377f63680e02d9e89bc89199926d3adf361418ad501a45ed.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE code = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1e4169b7da5e68ed377f63680e02d9e89bc89199926d3adf361418ad501a45ed"
+}

--- a/.sqlx/query-1ef5c1ee7de5fae29f50714867666d3e32fd766f70b5edfbdcfff671eb05886f.json
+++ b/.sqlx/query-1ef5c1ee7de5fae29f50714867666d3e32fd766f70b5edfbdcfff671eb05886f.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT tx_template_id, created_at, id FROM cala_transactions WHERE ((tx_template_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1ef5c1ee7de5fae29f50714867666d3e32fd766f70b5edfbdcfff671eb05886f"
+}

--- a/.sqlx/query-1f18e7dc3507f6f585dccece3aabc89a052c4ee615d24efd601a0a337d631587.json
+++ b/.sqlx/query-1f18e7dc3507f6f585dccece3aabc89a052c4ee615d24efd601a0a337d631587.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          WITH RECURSIVE parents AS (\n            SELECT m.member_account_set_id, m.account_set_id\n            FROM cala_account_set_member_account_sets m\n            JOIN cala_account_sets s\n            ON s.id = m.account_set_id\n            WHERE m.member_account_set_id = $1\n\n            UNION ALL\n            SELECT p.member_account_set_id, m.account_set_id\n            FROM parents p\n            JOIN cala_account_set_member_account_sets m\n                ON p.account_set_id = m.member_account_set_id\n          ),\n          member_accounts_deletion AS (\n            DELETE FROM cala_account_set_member_accounts\n            WHERE account_set_id IN (SELECT account_set_id FROM parents UNION SELECT $1)\n            AND member_account_id IN (SELECT member_account_id FROM cala_account_set_member_accounts\n                                      WHERE account_set_id = $2)\n          ),\n          member_account_set_deletion AS (\n            DELETE FROM cala_account_set_member_account_sets\n            WHERE account_set_id IN (SELECT account_set_id FROM parents UNION SELECT $1)\n            AND member_account_set_id = $2\n          )\n          SELECT account_set_id, NULL AS now\n          FROM parents\n          UNION ALL\n          SELECT NULL AS account_set_id, NOW() AS now\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_set_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "now",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "1f18e7dc3507f6f585dccece3aabc89a052c4ee615d24efd601a0a337d631587"
+}

--- a/.sqlx/query-1f299262f01a2c9d2ee94079a12766573c91b2775a086c65bc9a5fdc91300bb0.json
+++ b/.sqlx/query-1f299262f01a2c9d2ee94079a12766573c91b2775a086c65bc9a5fdc91300bb0.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v3 is NULL OR v3 = COALESCE($2,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($3,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($4,v5))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1f299262f01a2c9d2ee94079a12766573c91b2775a086c65bc9a5fdc91300bb0"
+}

--- a/.sqlx/query-22ab5cd0a448f2971ee8e8b680f0c80d6a3463468c838795bdacf25d7e34c550.json
+++ b/.sqlx/query-22ab5cd0a448f2971ee8e8b680f0c80d6a3463468c838795bdacf25d7e34c550.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "22ab5cd0a448f2971ee8e8b680f0c80d6a3463468c838795bdacf25d7e34c550"
+}

--- a/.sqlx/query-23192e145bbc7a7a8e4c426996318b7eb04b6b3662c819d9156ca8470b6c33fa.json
+++ b/.sqlx/query-23192e145bbc7a7a8e4c426996318b7eb04b6b3662c819d9156ca8470b6c33fa.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_velocity_controls WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "23192e145bbc7a7a8e4c426996318b7eb04b6b3662c819d9156ca8470b6c33fa"
+}

--- a/.sqlx/query-24876462291b90324dfe3682e9f36247a328db780a48da47c9402e1d3ebd80c9.json
+++ b/.sqlx/query-24876462291b90324dfe3682e9f36247a328db780a48da47c9402e1d3ebd80c9.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "24876462291b90324dfe3682e9f36247a328db780a48da47c9402e1d3ebd80c9"
+}

--- a/.sqlx/query-251f1465f66ca8bdfcf7de5418c6f5432ce8b1b9b8087a6c662ab63f635f231e.json
+++ b/.sqlx/query-251f1465f66ca8bdfcf7de5418c6f5432ce8b1b9b8087a6c662ab63f635f231e.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_tx_template_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "251f1465f66ca8bdfcf7de5418c6f5432ce8b1b9b8087a6c662ab63f635f231e"
+}

--- a/.sqlx/query-263fdccba1b3204249e71a8d348db13dcc9c4e37a9819451920447983426325c.json
+++ b/.sqlx/query-263fdccba1b3204249e71a8d348db13dcc9c4e37a9819451920447983426325c.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_tx_templates WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "263fdccba1b3204249e71a8d348db13dcc9c4e37a9819451920447983426325c"
+}

--- a/.sqlx/query-2683a9da76daa92a1718e958bcdb1e97285549f9b2e6eb5c1a799b8cc81ffa3b.json
+++ b/.sqlx/query-2683a9da76daa92a1718e958bcdb1e97285549f9b2e6eb5c1a799b8cc81ffa3b.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT transaction_id, id FROM cala_entries WHERE ((transaction_id = $1) AND (COALESCE(id > $3, true))) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2683a9da76daa92a1718e958bcdb1e97285549f9b2e6eb5c1a799b8cc81ffa3b"
+}

--- a/.sqlx/query-2872b56bbc5bed96b1a303bf9cf44610fb79a1b9330730c65953f0c1b88c2a53.json
+++ b/.sqlx/query-2872b56bbc5bed96b1a303bf9cf44610fb79a1b9330730c65953f0c1b88c2a53.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    v0 = $2 AND\n                    v1 = $3 AND\n                    v2 = $4 AND\n                    v3 = $5 AND\n                    v4 = $6 AND\n                    v5 = $7",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2872b56bbc5bed96b1a303bf9cf44610fb79a1b9330730c65953f0c1b88c2a53"
+}

--- a/.sqlx/query-28b8e3778c17b3f7d0cddda31d04c489041858391f80c32e4ec225130ad4ea38.json
+++ b/.sqlx/query-28b8e3778c17b3f7d0cddda31d04c489041858391f80c32e4ec225130ad4ea38.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH member_account_sets AS (\n              SELECT a.id, a.name, a.created_at\n              FROM cala_account_set_member_accounts asm\n              JOIN cala_account_sets a ON asm.account_set_id = a.id\n              WHERE asm.member_account_id = $1 AND transitive IS FALSE\n              AND ((a.name, a.id) > ($3, $2) OR ($3 IS NULL AND $2 IS NULL))\n              ORDER BY a.name, a.id\n              LIMIT $4\n            )\n            SELECT mas.id AS \"entity_id!: AccountSetId\", e.sequence, e.event, e.recorded_at\n              FROM member_account_sets mas\n              JOIN cala_account_set_events e ON mas.id = e.id\n              ORDER BY mas.name, mas.id, e.sequence\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "28b8e3778c17b3f7d0cddda31d04c489041858391f80c32e4ec225130ad4ea38"
+}

--- a/.sqlx/query-29225b902a8924d5b14baa0329d94c70e8d83b2c286505f993c6d050992a963a.json
+++ b/.sqlx/query-29225b902a8924d5b14baa0329d94c70e8d83b2c286505f993c6d050992a963a.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT code, id FROM cala_accounts WHERE (COALESCE((code, id) > ($3, $2), $2 IS NULL)) ORDER BY code ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.code asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "29225b902a8924d5b14baa0329d94c70e8d83b2c286505f993c6d050992a963a"
+}

--- a/.sqlx/query-2abf0570fe5c3c6b1e2af195230987f9b3227076c7912c07ae5302de8e8983b7.json
+++ b/.sqlx/query-2abf0570fe5c3c6b1e2af195230987f9b3227076c7912c07ae5302de8e8983b7.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_tx_templates WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2abf0570fe5c3c6b1e2af195230987f9b3227076c7912c07ae5302de8e8983b7"
+}

--- a/.sqlx/query-2b370058c0ebe9851feb5488ec404115c0184b6d5efb90e465281248a97035b7.json
+++ b/.sqlx/query-2b370058c0ebe9851feb5488ec404115c0184b6d5efb90e465281248a97035b7.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE data_source_id = $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2b370058c0ebe9851feb5488ec404115c0184b6d5efb90e465281248a97035b7"
+}

--- a/.sqlx/query-2b871028a18fe2a6a586e89752d0e64602f6fb5b916dc700f2bb6c58c55b445e.json
+++ b/.sqlx/query-2b871028a18fe2a6a586e89752d0e64602f6fb5b916dc700f2bb6c58c55b445e.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT account_id, created_at, id FROM cala_entries WHERE ((account_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2b871028a18fe2a6a586e89752d0e64602f6fb5b916dc700f2bb6c58c55b445e"
+}

--- a/.sqlx/query-2f03e709d0ae22f223c62907dfa09942d115792af4d92ebc6835a4b4dcd1b140.json
+++ b/.sqlx/query-2f03e709d0ae22f223c62907dfa09942d115792af4d92ebc6835a4b4dcd1b140.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(MAX(sequence), 0) AS \"max!\" FROM cala_outbox_events",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "max!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2f03e709d0ae22f223c62907dfa09942d115792af4d92ebc6835a4b4dcd1b140"
+}

--- a/.sqlx/query-2f43be93a9c6d674e12e5b83edb95d6f5d432bc67a13f7da06f9ca3bda0fc2e9.json
+++ b/.sqlx/query-2f43be93a9c6d674e12e5b83edb95d6f5d432bc67a13f7da06f9ca3bda0fc2e9.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2f43be93a9c6d674e12e5b83edb95d6f5d432bc67a13f7da06f9ca3bda0fc2e9"
+}

--- a/.sqlx/query-2fd253fbcdef29444ee92ddfb83b683342171a890712c78915cc36f10ba0c0ae.json
+++ b/.sqlx/query-2fd253fbcdef29444ee92ddfb83b683342171a890712c78915cc36f10ba0c0ae.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH locked_accounts AS (\n              SELECT 1\n              FROM cala_accounts a\n              WHERE a.id = $1\n              FOR UPDATE\n            ), locked_balances AS (\n              SELECT journal_id, account_id, currency, latest_version\n              FROM cala_current_balances\n              WHERE journal_id = $2\n              AND account_id = $1\n              FOR UPDATE\n            )\n            SELECT h.values\n            FROM cala_balance_history h\n            JOIN locked_balances b\n            ON b.journal_id = h.journal_id\n              AND b.account_id = h.account_id\n              AND b.currency = h.currency\n              AND b.latest_version = h.version\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "values",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2fd253fbcdef29444ee92ddfb83b683342171a890712c78915cc36f10ba0c0ae"
+}

--- a/.sqlx/query-3022cb733970ae5836ab3891367b209a7e1f0974242ecd0f55e5b0098152bad5.json
+++ b/.sqlx/query-3022cb733970ae5836ab3891367b209a7e1f0974242ecd0f55e5b0098152bad5.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM casbin_rule",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "ptype",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "v0",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "v1",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "v2",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "v3",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "v4",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "v5",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3022cb733970ae5836ab3891367b209a7e1f0974242ecd0f55e5b0098152bad5"
+}

--- a/.sqlx/query-3129ae51eef385441a2f5f5314712aae752635887db898efc190863285a99e21.json
+++ b/.sqlx/query-3129ae51eef385441a2f5f5314712aae752635887db898efc190863285a99e21.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT external_id, id FROM cala_account_sets WHERE ((external_id IS NOT DISTINCT FROM $3) AND COALESCE(id < $2, true) OR COALESCE(external_id < $3, external_id IS NOT NULL)) ORDER BY external_id DESC NULLS LAST, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.external_id desc nulls last, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3129ae51eef385441a2f5f5314712aae752635887db898efc190863285a99e21"
+}

--- a/.sqlx/query-32e423a12f03ac17feafd99af7a9d417d4377b8d48bdf0033a059ddc9d0d845e.json
+++ b/.sqlx/query-32e423a12f03ac17feafd99af7a9d417d4377b8d48bdf0033a059ddc9d0d845e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE journal_id = $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "32e423a12f03ac17feafd99af7a9d417d4377b8d48bdf0033a059ddc9d0d845e"
+}

--- a/.sqlx/query-333d3e41c73ef64708d25ca8e79a9c6d3c24119d5159baf2de193f783aabc1cc.json
+++ b/.sqlx/query-333d3e41c73ef64708d25ca8e79a9c6d3c24119d5159baf2de193f783aabc1cc.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_tx_templates WHERE id = $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "333d3e41c73ef64708d25ca8e79a9c6d3c24119d5159baf2de193f783aabc1cc"
+}

--- a/.sqlx/query-3391d7308cd8a77f031240c198f342ea95649179cce6431f20bd4436c22ec7b1.json
+++ b/.sqlx/query-3391d7308cd8a77f031240c198f342ea95649179cce6431f20bd4436c22ec7b1.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE data_source_id = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3391d7308cd8a77f031240c198f342ea95649179cce6431f20bd4436c22ec7b1"
+}

--- a/.sqlx/query-34122d3d9367712c0f93800220caf293dcc9d7e02f4738c7c2c22ea2a3bb803e.json
+++ b/.sqlx/query-34122d3d9367712c0f93800220caf293dcc9d7e02f4738c7c2c22ea2a3bb803e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE tx_template_id = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "34122d3d9367712c0f93800220caf293dcc9d7e02f4738c7c2c22ea2a3bb803e"
+}

--- a/.sqlx/query-35838a1dadec39b3ff3d8cf9a69453db63a834a9fea6ec03dc9b40b1ffab5245.json
+++ b/.sqlx/query-35838a1dadec39b3ff3d8cf9a69453db63a834a9fea6ec03dc9b40b1ffab5245.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          WITH RECURSIVE parents AS (\n            SELECT m.member_account_set_id, m.account_set_id\n            FROM cala_account_set_member_account_sets m\n            JOIN cala_account_sets s\n            ON s.id = m.account_set_id\n            WHERE m.member_account_set_id = $1\n\n            UNION ALL\n            SELECT p.member_account_set_id, m.account_set_id\n            FROM parents p\n            JOIN cala_account_set_member_account_sets m\n                ON p.account_set_id = m.member_account_set_id\n          ),\n          set_insert AS (\n            INSERT INTO cala_account_set_member_account_sets (account_set_id, member_account_set_id)\n            VALUES ($1, $2)\n          ),\n          new_members AS (\n            INSERT INTO cala_account_set_member_accounts (account_set_id, member_account_id, transitive)\n            SELECT $1, m.member_account_id, TRUE\n            FROM cala_account_set_member_accounts m\n            WHERE m.account_set_id = $2\n            RETURNING member_account_id\n          ),\n          transitive_inserts AS (\n            INSERT INTO cala_account_set_member_accounts (account_set_id, member_account_id, transitive)\n            SELECT p.account_set_id, n.member_account_id, TRUE\n            FROM parents p\n            CROSS JOIN new_members n\n          )\n          SELECT account_set_id, NULL AS now\n          FROM parents\n          UNION ALL\n          SELECT NULL AS account_set_id, NOW() AS now\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_set_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "now",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "35838a1dadec39b3ff3d8cf9a69453db63a834a9fea6ec03dc9b40b1ffab5245"
+}

--- a/.sqlx/query-36238751a6cdb77ba46bd352347505c861fe052578a1cc33fbb2c851eb1a1201.json
+++ b/.sqlx/query-36238751a6cdb77ba46bd352347505c861fe052578a1cc33fbb2c851eb1a1201.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_account_controls (account_id, velocity_control_id, values)\n            VALUES ($1, $2, $3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "36238751a6cdb77ba46bd352347505c861fe052578a1cc33fbb2c851eb1a1201"
+}

--- a/.sqlx/query-362a85a1429b9c1b7d68261a88d8e249171ab7be68956199e39c2f97627c7960.json
+++ b/.sqlx/query-362a85a1429b9c1b7d68261a88d8e249171ab7be68956199e39c2f97627c7960.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE cala_accounts SET name = $2, code = $3, external_id = $4, normal_balance_type = $5, latest_values = $6 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        },
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "362a85a1429b9c1b7d68261a88d8e249171ab7be68956199e39c2f97627c7960"
+}

--- a/.sqlx/query-3731dd5037d24f10824b11961a0021daba8d6c57a904f53fb2387f17c35ddb5f.json
+++ b/.sqlx/query-3731dd5037d24f10824b11961a0021daba8d6c57a904f53fb2387f17c35ddb5f.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3731dd5037d24f10824b11961a0021daba8d6c57a904f53fb2387f17c35ddb5f"
+}

--- a/.sqlx/query-37592bfb1c29bde05289e8bac77aaa151f02ed1cfdb70cd96e48c6d8b5d2ce78.json
+++ b/.sqlx/query-37592bfb1c29bde05289e8bac77aaa151f02ed1cfdb70cd96e48c6d8b5d2ce78.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_controls WHERE data_source_id = $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "37592bfb1c29bde05289e8bac77aaa151f02ed1cfdb70cd96e48c6d8b5d2ce78"
+}

--- a/.sqlx/query-3948af6ec679e466ab96d35c3754561cf331dc243cafb61d5c9545aef748025a.json
+++ b/.sqlx/query-3948af6ec679e466ab96d35c3754561cf331dc243cafb61d5c9545aef748025a.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE effective = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Date"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3948af6ec679e466ab96d35c3754561cf331dc243cafb61d5c9545aef748025a"
+}

--- a/.sqlx/query-3976ee82fbe2a0f2b72c67da9957ea6a843778fb98f3b8b4aab1e58f024bff69.json
+++ b/.sqlx/query-3976ee82fbe2a0f2b72c67da9957ea6a843778fb98f3b8b4aab1e58f024bff69.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT external_id, id FROM cala_account_sets WHERE ((external_id IS NOT DISTINCT FROM $3) AND COALESCE(id > $2, true) OR COALESCE(external_id > $3, external_id IS NOT NULL)) ORDER BY external_id ASC NULLS FIRST, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.external_id asc nulls first, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3976ee82fbe2a0f2b72c67da9957ea6a843778fb98f3b8b4aab1e58f024bff69"
+}

--- a/.sqlx/query-3a7822d9b1c355b11ee0dffd58fef197b999461df83ad615b5a9720a552a01d4.json
+++ b/.sqlx/query-3a7822d9b1c355b11ee0dffd58fef197b999461df83ad615b5a9720a552a01d4.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_velocity_limits WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3a7822d9b1c355b11ee0dffd58fef197b999461df83ad615b5a9720a552a01d4"
+}

--- a/.sqlx/query-3e521b66ec69bf3fc1c641d6dceb36cfde97707985a667a26734ddaac783bf40.json
+++ b/.sqlx/query-3e521b66ec69bf3fc1c641d6dceb36cfde97707985a667a26734ddaac783bf40.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE name = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3e521b66ec69bf3fc1c641d6dceb36cfde97707985a667a26734ddaac783bf40"
+}

--- a/.sqlx/query-3e9e91edb6e7608d37a764eac4824dc37921d5cecf6f4f36441ff106cbabf2f9.json
+++ b/.sqlx/query-3e9e91edb6e7608d37a764eac4824dc37921d5cecf6f4f36441ff106cbabf2f9.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_transactions WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3e9e91edb6e7608d37a764eac4824dc37921d5cecf6f4f36441ff106cbabf2f9"
+}

--- a/.sqlx/query-3f6bc04f79eaa6a6a7791d7de4e4505cd08522806f69fb72e5983e6aeada2819.json
+++ b/.sqlx/query-3f6bc04f79eaa6a6a7791d7de4e4505cd08522806f69fb72e5983e6aeada2819.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_accounts WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3f6bc04f79eaa6a6a7791d7de4e4505cd08522806f69fb72e5983e6aeada2819"
+}

--- a/.sqlx/query-3f836d81aa46305c562d2eea58340c9177fa54a3a9e310c0c6871ff6d930dd1e.json
+++ b/.sqlx/query-3f836d81aa46305c562d2eea58340c9177fa54a3a9e310c0c6871ff6d930dd1e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: EntryId\", e.sequence, e.event, e.recorded_at FROM cala_entries i JOIN cala_entry_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3f836d81aa46305c562d2eea58340c9177fa54a3a9e310c0c6871ff6d930dd1e"
+}

--- a/.sqlx/query-4015a95fc97bca7ca4477a8f4bf1e78cea75c4b31b08815f29ce116f35b2bd5d.json
+++ b/.sqlx/query-4015a95fc97bca7ca4477a8f4bf1e78cea75c4b31b08815f29ce116f35b2bd5d.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE data_source_id = $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4015a95fc97bca7ca4477a8f4bf1e78cea75c4b31b08815f29ce116f35b2bd5d"
+}

--- a/.sqlx/query-40a7eee2286e68fc5d380f71720b9c7379e3359b0ebd2042262f4b59a5d7f942.json
+++ b/.sqlx/query-40a7eee2286e68fc5d380f71720b9c7379e3359b0ebd2042262f4b59a5d7f942.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_account_set_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "40a7eee2286e68fc5d380f71720b9c7379e3359b0ebd2042262f4b59a5d7f942"
+}

--- a/.sqlx/query-438ee38e669be96e562d09d3bc5806b4c78b7aa2a9609c4eccb941c7dff7b107.json
+++ b/.sqlx/query-438ee38e669be96e562d09d3bc5806b4c78b7aa2a9609c4eccb941c7dff7b107.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "CREATE TABLE IF NOT EXISTS casbin_rule (\n                    id SERIAL PRIMARY KEY,\n                    ptype VARCHAR NOT NULL,\n                    v0 VARCHAR NOT NULL,\n                    v1 VARCHAR NOT NULL,\n                    v2 VARCHAR NOT NULL,\n                    v3 VARCHAR NOT NULL,\n                    v4 VARCHAR NOT NULL,\n                    v5 VARCHAR NOT NULL,\n                    CONSTRAINT unique_key_sqlx_adapter UNIQUE(ptype, v0, v1, v2, v3, v4, v5)\n                    );\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "438ee38e669be96e562d09d3bc5806b4c78b7aa2a9609c4eccb941c7dff7b107"
+}

--- a/.sqlx/query-443fb2b7248bf11d830d36c7f4a209d8763a8cf017da1bb441011e272f7040c4.json
+++ b/.sqlx/query-443fb2b7248bf11d830d36c7f4a209d8763a8cf017da1bb441011e272f7040c4.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE id = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "443fb2b7248bf11d830d36c7f4a209d8763a8cf017da1bb441011e272f7040c4"
+}

--- a/.sqlx/query-478d78eb06c30c5c7960d10f84f057842363d0008b81ef5cf8d6b8fc0778d4a2.json
+++ b/.sqlx/query-478d78eb06c30c5c7960d10f84f057842363d0008b81ef5cf8d6b8fc0778d4a2.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT tx_template_id, id FROM cala_transactions WHERE ((tx_template_id = $1) AND (COALESCE(id < $3, true))) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "478d78eb06c30c5c7960d10f84f057842363d0008b81ef5cf8d6b8fc0778d4a2"
+}

--- a/.sqlx/query-48e0baa2fecb1d49399e62ce42cd763833cf9bbffdd372a446f8e854ce4bdf75.json
+++ b/.sqlx/query-48e0baa2fecb1d49399e62ce42cd763833cf9bbffdd372a446f8e854ce4bdf75.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_account_set_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "48e0baa2fecb1d49399e62ce42cd763833cf9bbffdd372a446f8e854ce4bdf75"
+}

--- a/.sqlx/query-4a2c66932678814aa7420c360acbb3de32b627d2421414dc139e4bda879fa839.json
+++ b/.sqlx/query-4a2c66932678814aa7420c360acbb3de32b627d2421414dc139e4bda879fa839.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH max_sequence AS (\n                SELECT COALESCE(MAX(sequence), 0) AS max FROM cala_outbox_events\n            )\n            SELECT\n              g.seq AS \"sequence!: EventSequence\",\n              e.id AS \"id?\",\n              e.payload AS \"payload?\",\n              e.recorded_at AS \"recorded_at?\"\n            FROM\n                generate_series(LEAST($1 + 1, (SELECT max FROM max_sequence)),\n                  LEAST($1 + $2, (SELECT max FROM max_sequence)))\n                AS g(seq)\n            LEFT JOIN\n                cala_outbox_events e ON g.seq = e.sequence\n            WHERE\n                g.seq > $1\n            ORDER BY\n                g.seq ASC\n            LIMIT $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "sequence!: EventSequence",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "payload?",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at?",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "4a2c66932678814aa7420c360acbb3de32b627d2421414dc139e4bda879fa839"
+}

--- a/.sqlx/query-4acfe0086a593b08177791bb3b47cb75a999041a3eb6a8f8177bebfa3c30d56f.json
+++ b/.sqlx/query-4acfe0086a593b08177791bb3b47cb75a999041a3eb6a8f8177bebfa3c30d56f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v4 is NULL OR v4 = COALESCE($2,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($3,v5))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4acfe0086a593b08177791bb3b47cb75a999041a3eb6a8f8177bebfa3c30d56f"
+}

--- a/.sqlx/query-4d039ea3618c888ff22e928e0e5545be4621076c93c1819fe4f9fbd109bfae11.json
+++ b/.sqlx/query-4d039ea3618c888ff22e928e0e5545be4621076c93c1819fe4f9fbd109bfae11.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT code, id FROM cala_accounts WHERE (COALESCE((code, id) < ($3, $2), $2 IS NULL)) ORDER BY code DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.code desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4d039ea3618c888ff22e928e0e5545be4621076c93c1819fe4f9fbd109bfae11"
+}

--- a/.sqlx/query-4d883ef488458b3844a255ab24c3f161551ad2dfc79b54ac0ad6b61ad3b48400.json
+++ b/.sqlx/query-4d883ef488458b3844a255ab24c3f161551ad2dfc79b54ac0ad6b61ad3b48400.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE id = $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4d883ef488458b3844a255ab24c3f161551ad2dfc79b54ac0ad6b61ad3b48400"
+}

--- a/.sqlx/query-4e7b82d256f7298564f46af6a45b89853785c32a5f83cb0b25609329c760428a.json
+++ b/.sqlx/query-4e7b82d256f7298564f46af6a45b89853785c32a5f83cb0b25609329c760428a.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v1 is NULL OR v1 = COALESCE($2,v1)) AND\n                    (v2 is NULL OR v2 = COALESCE($3,v2)) AND\n                    (v3 is NULL OR v3 = COALESCE($4,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($5,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($6,v5))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4e7b82d256f7298564f46af6a45b89853785c32a5f83cb0b25609329c760428a"
+}

--- a/.sqlx/query-4f2edc55de76a195be999f95f62f2c4ac6769f7d47dc9556182fa98cefe9a5c0.json
+++ b/.sqlx/query-4f2edc55de76a195be999f95f62f2c4ac6769f7d47dc9556182fa98cefe9a5c0.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT transaction_id, created_at, id FROM cala_entries WHERE ((transaction_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4f2edc55de76a195be999f95f62f2c4ac6769f7d47dc9556182fa98cefe9a5c0"
+}

--- a/.sqlx/query-52239f92825e2fb77644574fe148695d1456fa5af698639b34dd2f5ca3c73a66.json
+++ b/.sqlx/query-52239f92825e2fb77644574fe148695d1456fa5af698639b34dd2f5ca3c73a66.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_tx_template_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "52239f92825e2fb77644574fe148695d1456fa5af698639b34dd2f5ca3c73a66"
+}

--- a/.sqlx/query-526738af6d85232a4cf18dbac5d4da0e5d0d8d7bbc77d91721b5286b30f2ac71.json
+++ b/.sqlx/query-526738af6d85232a4cf18dbac5d4da0e5d0d8d7bbc77d91721b5286b30f2ac71.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT account_id, created_at, id FROM cala_entries WHERE ((account_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "526738af6d85232a4cf18dbac5d4da0e5d0d8d7bbc77d91721b5286b30f2ac71"
+}

--- a/.sqlx/query-53b20c4d2300345d45bd22b17f6557a5d34b451eec43fbc2e72a0c2bba76cdf5.json
+++ b/.sqlx/query-53b20c4d2300345d45bd22b17f6557a5d34b451eec43fbc2e72a0c2bba76cdf5.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_account_sets WHERE (COALESCE((name, id) > ($3, $2), $2 IS NULL)) ORDER BY name ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.name asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "53b20c4d2300345d45bd22b17f6557a5d34b451eec43fbc2e72a0c2bba76cdf5"
+}

--- a/.sqlx/query-5450eca75064add5d1656299f7c2fb599f0aa3aac3b963c50de3476e88140e4b.json
+++ b/.sqlx/query-5450eca75064add5d1656299f7c2fb599f0aa3aac3b963c50de3476e88140e4b.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: TransactionId\", e.sequence, e.event, e.recorded_at FROM cala_transactions i JOIN cala_transaction_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5450eca75064add5d1656299f7c2fb599f0aa3aac3b963c50de3476e88140e4b"
+}

--- a/.sqlx/query-5681b4263dc59b363054d221c517939ff4dee142ab0dd12c6aa55d946f44f21c.json
+++ b/.sqlx/query-5681b4263dc59b363054d221c517939ff4dee142ab0dd12c6aa55d946f44f21c.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (\n                            SELECT created_at, id\n                            FROM cala_entries\n                            JOIN cala_balance_history ON cala_entries.id = cala_balance_history.latest_entry_id\n                            WHERE cala_balance_history.account_id = $4\n                              AND (COALESCE((created_at, id) < ($3, $2), $2 IS NULL))\n                            ORDER BY created_at DESC, id DESC\n                            LIMIT $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5681b4263dc59b363054d221c517939ff4dee142ab0dd12c6aa55d946f44f21c"
+}

--- a/.sqlx/query-58cbff4aaa7278776c1314edc85fe9701c8399ef465712207af13ff313e0d798.json
+++ b/.sqlx/query-58cbff4aaa7278776c1314edc85fe9701c8399ef465712207af13ff313e0d798.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_account_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "58cbff4aaa7278776c1314edc85fe9701c8399ef465712207af13ff313e0d798"
+}

--- a/.sqlx/query-5b93458e65fbc816353530e7b0165622acc350311f428392cbe9e41071c6a939.json
+++ b/.sqlx/query-5b93458e65fbc816353530e7b0165622acc350311f428392cbe9e41071c6a939.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT external_id, id FROM cala_accounts WHERE ((external_id IS NOT DISTINCT FROM $3) AND COALESCE(id < $2, true) OR COALESCE(external_id < $3, external_id IS NOT NULL)) ORDER BY external_id DESC NULLS LAST, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.external_id desc nulls last, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5b93458e65fbc816353530e7b0165622acc350311f428392cbe9e41071c6a939"
+}

--- a/.sqlx/query-5d4afcded9484595ef163f3f86a677d009b8358ad66e72d4f9ff1b161a652000.json
+++ b/.sqlx/query-5d4afcded9484595ef163f3f86a677d009b8358ad66e72d4f9ff1b161a652000.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE normal_balance_type = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5d4afcded9484595ef163f3f86a677d009b8358ad66e72d4f9ff1b161a652000"
+}

--- a/.sqlx/query-5d662960f2bfc723c5c3a027c5d0c90508d96a54b93a795f7a6e7543c72a9377.json
+++ b/.sqlx/query-5d662960f2bfc723c5c3a027c5d0c90508d96a54b93a795f7a6e7543c72a9377.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_control_limits (velocity_control_id, velocity_limit_id)\n            VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5d662960f2bfc723c5c3a027c5d0c90508d96a54b93a795f7a6e7543c72a9377"
+}

--- a/.sqlx/query-5d89f5feb4a2b4ee9fd6849a96ec996c367694ff0e8afc6188140377408cd381.json
+++ b/.sqlx/query-5d89f5feb4a2b4ee9fd6849a96ec996c367694ff0e8afc6188140377408cd381.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT transaction_id, id FROM cala_entries WHERE ((transaction_id = $1) AND (COALESCE(id < $3, true))) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5d89f5feb4a2b4ee9fd6849a96ec996c367694ff0e8afc6188140377408cd381"
+}

--- a/.sqlx/query-5d9695252ef2438a7a667e12ac1cd161eb3cd539d2e6778af6a80598a1c34c4a.json
+++ b/.sqlx/query-5d9695252ef2438a7a667e12ac1cd161eb3cd539d2e6778af6a80598a1c34c4a.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_account_sets WHERE ((name = $1) AND (COALESCE(id > $3, true))) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5d9695252ef2438a7a667e12ac1cd161eb3cd539d2e6778af6a80598a1c34c4a"
+}

--- a/.sqlx/query-5ebc454e7dbc00d45859cb24f5ab9b87cf3ee271fcf85e55d5140b5be5f8ed50.json
+++ b/.sqlx/query-5ebc454e7dbc00d45859cb24f5ab9b87cf3ee271fcf85e55d5140b5be5f8ed50.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_controls (id, name, data_source_id, created_at) VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5ebc454e7dbc00d45859cb24f5ab9b87cf3ee271fcf85e55d5140b5be5f8ed50"
+}

--- a/.sqlx/query-5ebd33b02ba2ac389a2558f8bf438c23990ace1716520b2de81ec58a4d8660ab.json
+++ b/.sqlx/query-5ebd33b02ba2ac389a2558f8bf438c23990ace1716520b2de81ec58a4d8660ab.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5ebd33b02ba2ac389a2558f8bf438c23990ace1716520b2de81ec58a4d8660ab"
+}

--- a/.sqlx/query-63c9a1919373ca5d700f2921ea8201c27c240e12b86cfbb67142454c22ee18bc.json
+++ b/.sqlx/query-63c9a1919373ca5d700f2921ea8201c27c240e12b86cfbb67142454c22ee18bc.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_limit_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "63c9a1919373ca5d700f2921ea8201c27c240e12b86cfbb67142454c22ee18bc"
+}

--- a/.sqlx/query-64276b23f90c0071b6a3934214a3528db6fdc940b592734ca8dbf7276c936dc0.json
+++ b/.sqlx/query-64276b23f90c0071b6a3934214a3528db6fdc940b592734ca8dbf7276c936dc0.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE journal_id = $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "64276b23f90c0071b6a3934214a3528db6fdc940b592734ca8dbf7276c936dc0"
+}

--- a/.sqlx/query-66e6452ff6458d51d65baebc98d43cc28f976db4fecd622b693bb70dfc5900ec.json
+++ b/.sqlx/query-66e6452ff6458d51d65baebc98d43cc28f976db4fecd622b693bb70dfc5900ec.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_limits (id, name, data_source_id, created_at) VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "66e6452ff6458d51d65baebc98d43cc28f976db4fecd622b693bb70dfc5900ec"
+}

--- a/.sqlx/query-66eb2a4ba90e69c369b04fdccbb02497e84348ce53b37753b222bd94e19b72f7.json
+++ b/.sqlx/query-66eb2a4ba90e69c369b04fdccbb02497e84348ce53b37753b222bd94e19b72f7.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM cala_account_sets i JOIN cala_account_set_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "66eb2a4ba90e69c369b04fdccbb02497e84348ce53b37753b222bd94e19b72f7"
+}

--- a/.sqlx/query-6ba4f18cb99eb0050b17acd072241e9e35f8c0dd648947a73a566edb566f3da8.json
+++ b/.sqlx/query-6ba4f18cb99eb0050b17acd072241e9e35f8c0dd648947a73a566edb566f3da8.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_journals (id, name, code, data_source_id, created_at) VALUES ($1, $2, $3, $4, $5)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6ba4f18cb99eb0050b17acd072241e9e35f8c0dd648947a73a566edb566f3da8"
+}

--- a/.sqlx/query-6bae2f6ec3f8d5295b935cef18cb3dd649758b5afcf70feb2a6eff7d69925bfc.json
+++ b/.sqlx/query-6bae2f6ec3f8d5295b935cef18cb3dd649758b5afcf70feb2a6eff7d69925bfc.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT NOW()",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "now",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6bae2f6ec3f8d5295b935cef18cb3dd649758b5afcf70feb2a6eff7d69925bfc"
+}

--- a/.sqlx/query-6bfe053edb94d679904602c97c754c2ba5b4bbe5302423e42881f3aa551c79f1.json
+++ b/.sqlx/query-6bfe053edb94d679904602c97c754c2ba5b4bbe5302423e42881f3aa551c79f1.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_account_sets WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6bfe053edb94d679904602c97c754c2ba5b4bbe5302423e42881f3aa551c79f1"
+}

--- a/.sqlx/query-701ece34e1131b22ed09b5213c692d1f3bec83ce36a44424fc075d4a90d2cb5c.json
+++ b/.sqlx/query-701ece34e1131b22ed09b5213c692d1f3bec83ce36a44424fc075d4a90d2cb5c.json
@@ -1,0 +1,78 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH balance_ids AS (\n                SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::text[]) \n                AS v(journal_id, account_id, currency)\n            ),\n            first AS (\n                SELECT *\n                FROM (\n                    SELECT\n                        true AS first, false AS last, h.values,\n                        a.normal_balance_type AS normal_balance_type, h.recorded_at,\n                        h.journal_id, h.account_id, h.currency,\n                        ROW_NUMBER() OVER (\n                            PARTITION BY h.journal_id, h.account_id, h.currency\n                            ORDER BY h.recorded_at DESC, h.version DESC\n                        ) as rn\n                    FROM cala_balance_history h\n                    JOIN cala_accounts a ON h.account_id = a.id\n                    JOIN balance_ids b ON \n                        h.journal_id = b.journal_id \n                        AND h.account_id = b.account_id \n                        AND h.currency = b.currency\n                    WHERE h.recorded_at < $4\n                ) ranked\n                WHERE rn = 1\n            ),\n            last AS (\n                SELECT *\n                FROM (\n                    SELECT\n                        false AS first, true AS last, h.values,\n                        a.normal_balance_type AS normal_balance_type, h.recorded_at,\n                        h.journal_id, h.account_id, h.currency,\n                        ROW_NUMBER() OVER (\n                            PARTITION BY h.journal_id, h.account_id, h.currency\n                            ORDER BY h.recorded_at DESC, h.version DESC\n                        ) as rn\n                    FROM cala_balance_history h\n                    JOIN cala_accounts a ON h.account_id = a.id\n                    JOIN balance_ids b ON \n                        h.journal_id = b.journal_id \n                        AND h.account_id = b.account_id \n                        AND h.currency = b.currency\n                    WHERE h.recorded_at <= COALESCE($5, NOW())\n                ) ranked\n                WHERE rn = 1\n            )\n            SELECT\n                first, last, values, \n                normal_balance_type as \"normal_balance_type!: DebitOrCredit\",\n                recorded_at,\n                journal_id as \"journal_id: JournalId\",\n                account_id as \"account_id: AccountId\",\n                currency\n            FROM first\n            UNION ALL\n            SELECT\n                first, last, values,\n                normal_balance_type as \"normal_balance_type!: DebitOrCredit\",\n                recorded_at,\n                journal_id as \"journal_id: JournalId\",\n                account_id as \"account_id: AccountId\",\n                currency\n            FROM last",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 1,
+        "name": "last",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "journal_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "account_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "currency",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "UuidArray",
+        "TextArray",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "701ece34e1131b22ed09b5213c692d1f3bec83ce36a44424fc075d4a90d2cb5c"
+}

--- a/.sqlx/query-705a2fced6e1a2db308def8bdec146050605d7b94843fa596cc9a7e577eb6d3c.json
+++ b/.sqlx/query-705a2fced6e1a2db308def8bdec146050605d7b94843fa596cc9a7e577eb6d3c.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH first AS (\n            SELECT\n              true AS first, false AS last, h.values,\n              a.normal_balance_type AS \"normal_balance_type!: DebitOrCredit\", h.recorded_at\n            FROM cala_balance_history h\n            JOIN cala_accounts a\n            ON h.account_id = a.id\n            WHERE h.journal_id = $1\n            AND h.account_id = $2\n            AND h.currency = $3\n            AND h.recorded_at < $4\n            ORDER BY h.recorded_at DESC, h.version DESC\n            LIMIT 1\n        ),\n        last AS (\n            SELECT\n              false AS first, true AS last, h.values,\n              a.normal_balance_type AS \"normal_balance_type!: DebitOrCredit\", h.recorded_at\n            FROM cala_balance_history h\n            JOIN cala_accounts a\n            ON h.account_id = a.id\n            WHERE h.journal_id = $1\n            AND h.account_id = $2\n            AND h.currency = $3\n            AND h.recorded_at <= COALESCE($5, NOW())\n            ORDER BY h.recorded_at DESC, h.version DESC\n            LIMIT 1\n        )\n        SELECT * FROM first\n        UNION ALL\n        SELECT * FROM last\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 1,
+        "name": "last",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "705a2fced6e1a2db308def8bdec146050605d7b94843fa596cc9a7e577eb6d3c"
+}

--- a/.sqlx/query-70bbb082472d1679b8945fdfd7817cd027ae0327a4dd73a4fd2dec006421e5ad.json
+++ b/.sqlx/query-70bbb082472d1679b8945fdfd7817cd027ae0327a4dd73a4fd2dec006421e5ad.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_account_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "70bbb082472d1679b8945fdfd7817cd027ae0327a4dd73a4fd2dec006421e5ad"
+}

--- a/.sqlx/query-78f49c36600832215a8cc560be56f74fd189d353230d5f49a4cab23f006fa612.json
+++ b/.sqlx/query-78f49c36600832215a8cc560be56f74fd189d353230d5f49a4cab23f006fa612.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_account_sets (id, name, journal_id, external_id, data_source_id, created_at) VALUES ($1, $2, $3, $4, $5, $6)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Uuid",
+        "Varchar",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "78f49c36600832215a8cc560be56f74fd189d353230d5f49a4cab23f006fa612"
+}

--- a/.sqlx/query-79969a08606fa96e8c230a1191dbced2cb50886bab09c62ee7f059b09e709b77.json
+++ b/.sqlx/query-79969a08606fa96e8c230a1191dbced2cb50886bab09c62ee7f059b09e709b77.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "79969a08606fa96e8c230a1191dbced2cb50886bab09c62ee7f059b09e709b77"
+}

--- a/.sqlx/query-79da0107ff9bbca7c80ca3bcbb803298a10133956609704da9f2523b3ae42abe.json
+++ b/.sqlx/query-79da0107ff9bbca7c80ca3bcbb803298a10133956609704da9f2523b3ae42abe.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT pg_advisory_xact_lock(hashtext(concat($1::text, account_id::text, currency)))\n            FROM (\n            SELECT * FROM UNNEST($2::uuid[], $3::text[]) AS v(account_id, currency)\n            ) AS v\n            JOIN cala_accounts a\n            ON account_id = a.id\n            WHERE eventually_consistent = FALSE\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "79da0107ff9bbca7c80ca3bcbb803298a10133956609704da9f2523b3ae42abe"
+}

--- a/.sqlx/query-79dd2b6e80276d9a6d9328ddcbf45548e54b94b3c72e26aea4ab321734f8ea66.json
+++ b/.sqlx/query-79dd2b6e80276d9a6d9328ddcbf45548e54b94b3c72e26aea4ab321734f8ea66.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          SELECT event\n          FROM cala_tx_template_events\n          WHERE id = $1 AND sequence = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "event",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "79dd2b6e80276d9a6d9328ddcbf45548e54b94b3c72e26aea4ab321734f8ea66"
+}

--- a/.sqlx/query-7a515f3defcb2f4a7411179cbe9892318fc02212d2b72257665b1fbd6a211343.json
+++ b/.sqlx/query-7a515f3defcb2f4a7411179cbe9892318fc02212d2b72257665b1fbd6a211343.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_accounts (id, name, code, external_id, normal_balance_type, eventually_consistent, latest_values, data_source_id, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        },
+        "Bool",
+        "Jsonb",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7a515f3defcb2f4a7411179cbe9892318fc02212d2b72257665b1fbd6a211343"
+}

--- a/.sqlx/query-7af1d3e5930d1bfb35197f9041025f4f0c25add11e21ac141ba74d66d40f97e4.json
+++ b/.sqlx/query-7af1d3e5930d1bfb35197f9041025f4f0c25add11e21ac141ba74d66d40f97e4.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_velocity_limits WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7af1d3e5930d1bfb35197f9041025f4f0c25add11e21ac141ba74d66d40f97e4"
+}

--- a/.sqlx/query-7e8cb1f6f72d6e07a793eebc3c54083b6626b5bc80d9bef48e9a654183fa7eee.json
+++ b/.sqlx/query-7e8cb1f6f72d6e07a793eebc3c54083b6626b5bc80d9bef48e9a654183fa7eee.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE external_id = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7e8cb1f6f72d6e07a793eebc3c54083b6626b5bc80d9bef48e9a654183fa7eee"
+}

--- a/.sqlx/query-80ac450d62575381f692c1476b7bcb949899d97660cf2d5ec2746758b2460300.json
+++ b/.sqlx/query-80ac450d62575381f692c1476b7bcb949899d97660cf2d5ec2746758b2460300.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE id = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "80ac450d62575381f692c1476b7bcb949899d97660cf2d5ec2746758b2460300"
+}

--- a/.sqlx/query-83902f4777684df6016cc3e06beafc2f8698d54286b81ee552c54024b4aacba4.json
+++ b/.sqlx/query-83902f4777684df6016cc3e06beafc2f8698d54286b81ee552c54024b4aacba4.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE correlation_id = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "83902f4777684df6016cc3e06beafc2f8698d54286b81ee552c54024b4aacba4"
+}

--- a/.sqlx/query-8393038f5e090d48f26366a63df66277ffcb22f444ff95643e23b6fde9ac2629.json
+++ b/.sqlx/query-8393038f5e090d48f26366a63df66277ffcb22f444ff95643e23b6fde9ac2629.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT journal_id, id FROM cala_entries WHERE ((journal_id = $1) AND (COALESCE(id < $3, true))) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8393038f5e090d48f26366a63df66277ffcb22f444ff95643e23b6fde9ac2629"
+}

--- a/.sqlx/query-87709c792b886edf2374373aa0d563f8e80470035de31448f15278b48a3d6fad.json
+++ b/.sqlx/query-87709c792b886edf2374373aa0d563f8e80470035de31448f15278b48a3d6fad.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_journal_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "87709c792b886edf2374373aa0d563f8e80470035de31448f15278b48a3d6fad"
+}

--- a/.sqlx/query-87a61093c8f800d9ab596c6e39b5eaad28a6b1c99608ba6266d5aecb2e88924a.json
+++ b/.sqlx/query-87a61093c8f800d9ab596c6e39b5eaad28a6b1c99608ba6266d5aecb2e88924a.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_tx_templates WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "87a61093c8f800d9ab596c6e39b5eaad28a6b1c99608ba6266d5aecb2e88924a"
+}

--- a/.sqlx/query-87ce93a40e1f3432bf7e4652d3567777b3978351a1781f1798ff9fe146df1517.json
+++ b/.sqlx/query-87ce93a40e1f3432bf7e4652d3567777b3978351a1781f1798ff9fe146df1517.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_account_sets WHERE ((name = $1) AND (COALESCE(id < $3, true))) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "87ce93a40e1f3432bf7e4652d3567777b3978351a1781f1798ff9fe146df1517"
+}

--- a/.sqlx/query-880622c69f899dc6b83dc4c24761f8bd1c696138e116201513b54599727b5c74.json
+++ b/.sqlx/query-880622c69f899dc6b83dc4c24761f8bd1c696138e116201513b54599727b5c74.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          WITH RECURSIVE parents AS (\n            SELECT m.member_account_set_id, m.account_set_id\n            FROM cala_account_set_member_account_sets m\n            JOIN cala_account_sets s\n            ON s.id = m.account_set_id\n            WHERE m.member_account_set_id = $1\n\n            UNION ALL\n            SELECT p.member_account_set_id, m.account_set_id\n            FROM parents p\n            JOIN cala_account_set_member_account_sets m\n                ON p.account_set_id = m.member_account_set_id\n          ),\n          deletions as (\n            DELETE FROM cala_account_set_member_accounts\n            WHERE account_set_id IN (SELECT account_set_id FROM parents UNION SELECT $1)\n            AND member_account_id = $2\n          )\n          SELECT account_set_id, NULL AS now\n          FROM parents\n          UNION ALL\n          SELECT NULL AS account_set_id, NOW() AS now\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_set_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "now",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "880622c69f899dc6b83dc4c24761f8bd1c696138e116201513b54599727b5c74"
+}

--- a/.sqlx/query-8d0933e1a3638115cf4968b6972d2ec775e0d6db6f28d939b7b6b2068f52af8e.json
+++ b/.sqlx/query-8d0933e1a3638115cf4968b6972d2ec775e0d6db6f28d939b7b6b2068f52af8e.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT account_id, id FROM cala_entries WHERE ((account_id = $1) AND (COALESCE(id < $3, true))) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8d0933e1a3638115cf4968b6972d2ec775e0d6db6f28d939b7b6b2068f52af8e"
+}

--- a/.sqlx/query-8dc4984c9dc757869e6a1c8b83c1c30d03552f59f077bf67e48866297c6e143e.json
+++ b/.sqlx/query-8dc4984c9dc757869e6a1c8b83c1c30d03552f59f077bf67e48866297c6e143e.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH first AS (\n            SELECT\n              true AS first, false AS last, values,\n              a.normal_balance_type AS \"normal_balance_type!: DebitOrCredit\",\n              all_time_version\n            FROM cala_cumulative_effective_balances\n            JOIN cala_accounts a\n            ON account_id = a.id\n            WHERE journal_id = $1\n            AND account_id = $2\n            AND currency = $3\n            AND effective < $4\n            ORDER BY effective DESC, version DESC\n            LIMIT 1\n        ),\n        last AS (\n            SELECT\n              false AS first, true AS last, values,\n              a.normal_balance_type AS \"normal_balance_type!: DebitOrCredit\",\n              all_time_version\n            FROM cala_cumulative_effective_balances\n            JOIN cala_accounts a\n            ON account_id = a.id\n            WHERE journal_id = $1\n            AND account_id = $2\n            AND currency = $3\n            AND effective <= COALESCE($5, NOW()::DATE)\n            ORDER BY effective DESC, version DESC\n            LIMIT 1\n        )\n        SELECT * FROM first\n        UNION ALL\n        SELECT * FROM last\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 1,
+        "name": "last",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "all_time_version",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Date",
+        "Date"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "8dc4984c9dc757869e6a1c8b83c1c30d03552f59f077bf67e48866297c6e143e"
+}

--- a/.sqlx/query-8de456b1eae40e9434af753807e48c5d9ff5640e57bfbdb898b2eda0df48519b.json
+++ b/.sqlx/query-8de456b1eae40e9434af753807e48c5d9ff5640e57bfbdb898b2eda0df48519b.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_account_sets WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8de456b1eae40e9434af753807e48c5d9ff5640e57bfbdb898b2eda0df48519b"
+}

--- a/.sqlx/query-8edfa4222813f6f80841225a2b28875f9b45a7483e638ed808df905d90ef6d1a.json
+++ b/.sqlx/query-8edfa4222813f6f80841225a2b28875f9b45a7483e638ed808df905d90ef6d1a.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_account_sets WHERE ((name = $1) AND (COALESCE((name, id) > ($4, $3), $3 IS NULL))) ORDER BY name ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.name asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8edfa4222813f6f80841225a2b28875f9b45a7483e638ed808df905d90ef6d1a"
+}

--- a/.sqlx/query-8f0b219948d3a526f60161c16cb3fa68741288d57727ee21bf8d14dbbfad29b2.json
+++ b/.sqlx/query-8f0b219948d3a526f60161c16cb3fa68741288d57727ee21bf8d14dbbfad29b2.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT code, id FROM cala_tx_templates WHERE (COALESCE((code, id) > ($3, $2), $2 IS NULL)) ORDER BY code ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.code asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8f0b219948d3a526f60161c16cb3fa68741288d57727ee21bf8d14dbbfad29b2"
+}

--- a/.sqlx/query-9045e5c6b639e1accb4095ca648f89d23e5a32ecf79d3ba24e6f545bee1931be.json
+++ b/.sqlx/query-9045e5c6b639e1accb4095ca648f89d23e5a32ecf79d3ba24e6f545bee1931be.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH member_account_sets AS (\n              SELECT a.id, a.name, a.created_at\n              FROM cala_account_set_member_account_sets asm\n              JOIN cala_account_sets a ON asm.account_set_id = a.id\n              WHERE asm.member_account_set_id = $1\n              AND ((a.name, a.id) > ($3, $2) OR ($3 IS NULL AND $2 IS NULL))\n              ORDER BY a.name, a.id\n              LIMIT $4\n            )\n            SELECT mas.id AS \"entity_id!: AccountSetId\", e.sequence, e.event, e.recorded_at\n              FROM member_account_sets mas\n              JOIN cala_account_set_events e ON mas.id = e.id\n              ORDER BY mas.name, mas.id, e.sequence\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9045e5c6b639e1accb4095ca648f89d23e5a32ecf79d3ba24e6f545bee1931be"
+}

--- a/.sqlx/query-914b80a281196fc4a412b3f77c2efd04f99f5caac2cbcb30822a660dcba106c2.json
+++ b/.sqlx/query-914b80a281196fc4a412b3f77c2efd04f99f5caac2cbcb30822a660dcba106c2.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE transaction_id = $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "914b80a281196fc4a412b3f77c2efd04f99f5caac2cbcb30822a660dcba106c2"
+}

--- a/.sqlx/query-95b7a4cf1ec8ba58726b90e4fa770649c6e70c6290ff1b0c0a5c8ea9f6e6128d.json
+++ b/.sqlx/query-95b7a4cf1ec8ba58726b90e4fa770649c6e70c6290ff1b0c0a5c8ea9f6e6128d.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT external_id, id FROM cala_accounts WHERE ((external_id IS NOT DISTINCT FROM $3) AND COALESCE(id > $2, true) OR COALESCE(external_id > $3, external_id IS NOT NULL)) ORDER BY external_id ASC NULLS FIRST, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.external_id asc nulls first, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "95b7a4cf1ec8ba58726b90e4fa770649c6e70c6290ff1b0c0a5c8ea9f6e6128d"
+}

--- a/.sqlx/query-96760c1c50dc05b9269926d18862fd69eae249f8233d248a33e4de2a80bf08fb.json
+++ b/.sqlx/query-96760c1c50dc05b9269926d18862fd69eae249f8233d248a33e4de2a80bf08fb.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT code, id FROM cala_tx_templates WHERE (COALESCE((code, id) < ($3, $2), $2 IS NULL)) ORDER BY code DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.code desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "96760c1c50dc05b9269926d18862fd69eae249f8233d248a33e4de2a80bf08fb"
+}

--- a/.sqlx/query-9a0064fd333ea8fd009356aeb8600ecccbfde7ac96dc49e3be8f83c118945cac.json
+++ b/.sqlx/query-9a0064fd333ea8fd009356aeb8600ecccbfde7ac96dc49e3be8f83c118945cac.json
@@ -1,0 +1,78 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH balance_ids AS (\n              SELECT journal_id, account_id, currency, normal_balance_type\n              FROM (\n                SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::text[])\n                AS v(journal_id, account_id, currency)\n              ) AS v\n              JOIN cala_accounts a\n              ON account_id = a.id\n            ),\n            first AS (\n              SELECT\n                true AS first, false AS last, values,\n                normal_balance_type,\n                all_time_version,\n                h.journal_id, h.account_id, h.currency\n                FROM balance_ids\n                JOIN LATERAL (\n                    SELECT DISTINCT ON (journal_id, account_id, currency)\n                        journal_id, account_id, currency, values, all_time_version\n                    FROM cala_cumulative_effective_balances\n                    WHERE journal_id = balance_ids.journal_id\n                      AND account_id = balance_ids.account_id\n                      AND currency = balance_ids.currency\n                      AND effective < $4\n                    ORDER BY journal_id, account_id, currency, effective DESC, version DESC\n                ) h ON TRUE\n            ),\n            last AS (\n              SELECT\n                false AS first, true AS last, values,\n                normal_balance_type,\n                all_time_version,\n                h.journal_id, h.account_id, h.currency\n                FROM balance_ids\n                JOIN LATERAL (\n                    SELECT DISTINCT ON (journal_id, account_id, currency)\n                        journal_id, account_id, currency, values, all_time_version\n                    FROM cala_cumulative_effective_balances\n                    WHERE journal_id = balance_ids.journal_id\n                      AND account_id = balance_ids.account_id\n                      AND currency = balance_ids.currency\n                      AND effective <= COALESCE($5, NOW()::DATE)\n                    ORDER BY journal_id, account_id, currency, effective DESC, version DESC\n                ) h ON TRUE\n            )\n            SELECT\n                first, last, values, \n                normal_balance_type as \"normal_balance_type!: DebitOrCredit\",\n                all_time_version,\n                journal_id as \"journal_id: JournalId\",\n                account_id as \"account_id: AccountId\",\n                currency\n            FROM first\n            UNION ALL\n            SELECT\n                first, last, values,\n                normal_balance_type as \"normal_balance_type!: DebitOrCredit\",\n                all_time_version,\n                journal_id as \"journal_id: JournalId\",\n                account_id as \"account_id: AccountId\",\n                currency\n            FROM last",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 1,
+        "name": "last",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "all_time_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "journal_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "account_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "currency",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "UuidArray",
+        "TextArray",
+        "Date",
+        "Date"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "9a0064fd333ea8fd009356aeb8600ecccbfde7ac96dc49e3be8f83c118945cac"
+}

--- a/.sqlx/query-9b4c5c5397a5bff62afe5c3949166629596c83ef17434e7706fe2409bbd9de38.json
+++ b/.sqlx/query-9b4c5c5397a5bff62afe5c3949166629596c83ef17434e7706fe2409bbd9de38.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, external_id, id FROM cala_account_sets WHERE ((name = $1) AND ((external_id IS NOT DISTINCT FROM $4) AND COALESCE(id > $3, true) OR COALESCE(external_id > $4, external_id IS NOT NULL))) ORDER BY external_id ASC NULLS FIRST, id ASC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.external_id asc nulls first, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9b4c5c5397a5bff62afe5c3949166629596c83ef17434e7706fe2409bbd9de38"
+}

--- a/.sqlx/query-9b95830f21421e2d0468e84a65d800c83b9155ef65495af32d6974426d82722e.json
+++ b/.sqlx/query-9b95830f21421e2d0468e84a65d800c83b9155ef65495af32d6974426d82722e.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          WITH pairs AS (\n            SELECT account_id, currency\n            FROM (\n              SELECT * FROM UNNEST($2::uuid[], $3::text[]) AS v(account_id, currency)\n            ) AS v\n            JOIN cala_accounts a\n            ON account_id = a.id\n            WHERE eventually_consistent = FALSE\n          ),\n          delete_balances AS (\n            DELETE FROM cala_cumulative_effective_balances\n            WHERE journal_id = $1\n              AND (account_id, currency) IN (SELECT account_id, currency FROM pairs)\n              AND effective >= $4\n            RETURNING account_id, currency, effective, values\n          ),\n          values AS (\n            SELECT \n              p.account_id,\n              p.currency,\n              b.values,\n              b.all_time_version\n            FROM pairs p\n            LEFT JOIN LATERAL (\n              SELECT DISTINCT ON (account_id, currency)\n                account_id,\n                currency,\n                values,\n                all_time_version\n              FROM cala_cumulative_effective_balances\n              WHERE journal_id = $1\n                AND effective < $4\n                AND account_id = p.account_id\n                AND currency = p.currency\n              ORDER BY account_id, currency, effective DESC, version DESC\n            ) b ON TRUE\n          )\n          SELECT\n            v.account_id AS \"account_id!: AccountId\",\n            v.currency AS \"currency!\",\n            v.values AS \"values?: serde_json::Value\",\n            v.all_time_version AS \"all_time_version?: i32\",\n            COALESCE(\n              jsonb_agg(\n                jsonb_build_object('effective', d.effective, 'values', d.values)\n              ) FILTER (WHERE d.values IS NOT NULL),\n              '[]'::jsonb\n            ) AS \"deleted_values!: serde_json::Value\"\n          FROM values v\n          LEFT JOIN delete_balances d\n            ON v.account_id = d.account_id AND v.currency = d.currency\n          GROUP BY v.account_id, v.currency, v.values, v.all_time_version\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "currency!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "values?: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "all_time_version?: i32",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "deleted_values!: serde_json::Value",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray",
+        "TextArray",
+        "Date"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "9b95830f21421e2d0468e84a65d800c83b9155ef65495af32d6974426d82722e"
+}

--- a/.sqlx/query-9be6ec29ff68101eec0427f6afab51556244512f9f3a858317186423e5174e8f.json
+++ b/.sqlx/query-9be6ec29ff68101eec0427f6afab51556244512f9f3a858317186423e5174e8f.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: JournalId\", e.sequence, e.event, e.recorded_at FROM cala_journals i JOIN cala_journal_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9be6ec29ff68101eec0427f6afab51556244512f9f3a858317186423e5174e8f"
+}

--- a/.sqlx/query-9e8cbf7b0defdbebfe3b60fd61834734050a0cde90ffca641c7b219e29818336.json
+++ b/.sqlx/query-9e8cbf7b0defdbebfe3b60fd61834734050a0cde90ffca641c7b219e29818336.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_tx_templates (id, code, data_source_id, created_at) VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9e8cbf7b0defdbebfe3b60fd61834734050a0cde90ffca641c7b219e29818336"
+}

--- a/.sqlx/query-a020d643a6d385c5a4292c8715a61743e95e9d9a6ac18fd3e4fa1b2966604dce.json
+++ b/.sqlx/query-a020d643a6d385c5a4292c8715a61743e95e9d9a6ac18fd3e4fa1b2966604dce.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_accounts WHERE (COALESCE((name, id) < ($3, $2), $2 IS NULL)) ORDER BY name DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.name desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a020d643a6d385c5a4292c8715a61743e95e9d9a6ac18fd3e4fa1b2966604dce"
+}

--- a/.sqlx/query-a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247.json
+++ b/.sqlx/query-a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_advisory_xact_lock($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247"
+}

--- a/.sqlx/query-a1449f51d618fcdfa2e6cd19a491b0b15e43340786a6959927476cf4926d506d.json
+++ b/.sqlx/query-a1449f51d618fcdfa2e6cd19a491b0b15e43340786a6959927476cf4926d506d.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, external_id, id FROM cala_account_sets WHERE ((name = $1) AND ((external_id IS NOT DISTINCT FROM $4) AND COALESCE(id < $3, true) OR COALESCE(external_id < $4, external_id IS NOT NULL))) ORDER BY external_id DESC NULLS LAST, id DESC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.external_id desc nulls last, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a1449f51d618fcdfa2e6cd19a491b0b15e43340786a6959927476cf4926d506d"
+}

--- a/.sqlx/query-a1e83a170a78181c9f77de65890838c73310de126ffdb22a55b509836c8ce6ca.json
+++ b/.sqlx/query-a1e83a170a78181c9f77de65890838c73310de126ffdb22a55b509836c8ce6ca.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH balance_ids AS (\n                SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::text[]) \n                AS v(journal_id, account_id, currency)\n            )\n            SELECT \n                h.values,\n                a.normal_balance_type as \"normal_balance_type!: DebitOrCredit\"\n            FROM cala_balance_history h\n            JOIN cala_current_balances c\n                ON h.journal_id = c.journal_id\n                AND h.account_id = c.account_id\n                AND h.currency = c.currency\n                AND h.version = c.latest_version\n            JOIN cala_accounts a\n                ON c.account_id = a.id\n            JOIN balance_ids b \n                ON c.journal_id = b.journal_id\n                AND c.account_id = b.account_id\n                AND c.currency = b.currency",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "a1e83a170a78181c9f77de65890838c73310de126ffdb22a55b509836c8ce6ca"
+}

--- a/.sqlx/query-a380c353e2a0388b927a4a5a73e1172e87f7ee5ded42f2101a404d487e4e86ea.json
+++ b/.sqlx/query-a380c353e2a0388b927a4a5a73e1172e87f7ee5ded42f2101a404d487e4e86ea.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_account_sets WHERE (COALESCE((name, id) < ($3, $2), $2 IS NULL)) ORDER BY name DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.name desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a380c353e2a0388b927a4a5a73e1172e87f7ee5ded42f2101a404d487e4e86ea"
+}

--- a/.sqlx/query-a5cc5fc5ba91438832b23683ef8455bae810c560710a00da05a8072cbc4a4444.json
+++ b/.sqlx/query-a5cc5fc5ba91438832b23683ef8455bae810c560710a00da05a8072cbc4a4444.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_velocity_controls WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a5cc5fc5ba91438832b23683ef8455bae810c560710a00da05a8072cbc4a4444"
+}

--- a/.sqlx/query-a8db82d775822389f02959fe3a60998c9da3e94af3323d749b7a6fe9fcfb7cf7.json
+++ b/.sqlx/query-a8db82d775822389f02959fe3a60998c9da3e94af3323d749b7a6fe9fcfb7cf7.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_transaction_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a8db82d775822389f02959fe3a60998c9da3e94af3323d749b7a6fe9fcfb7cf7"
+}

--- a/.sqlx/query-a9fec4dd7e7ae1986b95ce422e616edb144cb7f8e0d66d8684ed174be01427a8.json
+++ b/.sqlx/query-a9fec4dd7e7ae1986b95ce422e616edb144cb7f8e0d66d8684ed174be01427a8.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_account_sets WHERE ((name = $1) AND (COALESCE((name, id) < ($4, $3), $3 IS NULL))) ORDER BY name DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.name desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a9fec4dd7e7ae1986b95ce422e616edb144cb7f8e0d66d8684ed174be01427a8"
+}

--- a/.sqlx/query-aa4e05726495b3f1c11668661b17c29302c486144d4bc9793e55ecd7de75a2ea.json
+++ b/.sqlx/query-aa4e05726495b3f1c11668661b17c29302c486144d4bc9793e55ecd7de75a2ea.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: AccountId\", e.sequence, e.event, e.recorded_at FROM cala_accounts i JOIN cala_account_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "aa4e05726495b3f1c11668661b17c29302c486144d4bc9793e55ecd7de75a2ea"
+}

--- a/.sqlx/query-aad0ac88d4644e3f89898a1b85ff444f41b33400d31d71de019636f9fc2585a5.json
+++ b/.sqlx/query-aad0ac88d4644e3f89898a1b85ff444f41b33400d31d71de019636f9fc2585a5.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE account_id = $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "aad0ac88d4644e3f89898a1b85ff444f41b33400d31d71de019636f9fc2585a5"
+}

--- a/.sqlx/query-ac2c8d138d9728f66d18a20a58771d0971c7492f59cbfe94ce28a4d7d18e769e.json
+++ b/.sqlx/query-ac2c8d138d9728f66d18a20a58771d0971c7492f59cbfe94ce28a4d7d18e769e.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_entries WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ac2c8d138d9728f66d18a20a58771d0971c7492f59cbfe94ce28a4d7d18e769e"
+}

--- a/.sqlx/query-af9b032484e425b32744afcbf220a82a7d83c82422a36afd47722923432763aa.json
+++ b/.sqlx/query-af9b032484e425b32744afcbf220a82a7d83c82422a36afd47722923432763aa.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE cala_journals SET name = $2, code = $3 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "af9b032484e425b32744afcbf220a82a7d83c82422a36afd47722923432763aa"
+}

--- a/.sqlx/query-b1211142fe8c890bc505417a0f78569d51e2f96631002065e8dd8fcd05e9f5da.json
+++ b/.sqlx/query-b1211142fe8c890bc505417a0f78569d51e2f96631002065e8dd8fcd05e9f5da.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE eventually_consistent = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b1211142fe8c890bc505417a0f78569d51e2f96631002065e8dd8fcd05e9f5da"
+}

--- a/.sqlx/query-b25bd8cb2f8acb04d17ade6b1f163f99416d5c3b13fa291b3f7dc01932245529.json
+++ b/.sqlx/query-b25bd8cb2f8acb04d17ade6b1f163f99416d5c3b13fa291b3f7dc01932245529.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE name = $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b25bd8cb2f8acb04d17ade6b1f163f99416d5c3b13fa291b3f7dc01932245529"
+}

--- a/.sqlx/query-b3fbf551ab0ffd29411879fb4cd012f9c85cdbfec3a9410ec07d04d9ef0218a3.json
+++ b/.sqlx/query-b3fbf551ab0ffd29411879fb4cd012f9c85cdbfec3a9410ec07d04d9ef0218a3.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT transaction_id, created_at, id FROM cala_entries WHERE ((transaction_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b3fbf551ab0ffd29411879fb4cd012f9c85cdbfec3a9410ec07d04d9ef0218a3"
+}

--- a/.sqlx/query-b41a1c97c1f1087936ff39b1a5fd7e90c5ce385892fb73b24edb16725456270d.json
+++ b/.sqlx/query-b41a1c97c1f1087936ff39b1a5fd7e90c5ce385892fb73b24edb16725456270d.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b41a1c97c1f1087936ff39b1a5fd7e90c5ce385892fb73b24edb16725456270d"
+}

--- a/.sqlx/query-b5a81d27f254a807dafbd7809b0bc339a06fc7ef23b23ca08209ff3c0984ff73.json
+++ b/.sqlx/query-b5a81d27f254a807dafbd7809b0bc339a06fc7ef23b23ca08209ff3c0984ff73.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_limits WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b5a81d27f254a807dafbd7809b0bc339a06fc7ef23b23ca08209ff3c0984ff73"
+}

--- a/.sqlx/query-b5d40e76f3d34b60c9992633e4ffa1691c2ca2939cb5f3556a682f6d4db2badb.json
+++ b/.sqlx/query-b5d40e76f3d34b60c9992633e4ffa1691c2ca2939cb5f3556a682f6d4db2badb.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_transactions WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b5d40e76f3d34b60c9992633e4ffa1691c2ca2939cb5f3556a682f6d4db2badb"
+}

--- a/.sqlx/query-b97e75c567f4553f342556165e7bf8b9d382e091a4d4bbd46bfffaccf0b47229.json
+++ b/.sqlx/query-b97e75c567f4553f342556165e7bf8b9d382e091a4d4bbd46bfffaccf0b47229.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_controls WHERE name = $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b97e75c567f4553f342556165e7bf8b9d382e091a4d4bbd46bfffaccf0b47229"
+}

--- a/.sqlx/query-be2ee189a825e4a2ce62f8cc528d8f29a27d72ec452e16e144f13c8b39828082.json
+++ b/.sqlx/query-be2ee189a825e4a2ce62f8cc528d8f29a27d72ec452e16e144f13c8b39828082.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "be2ee189a825e4a2ce62f8cc528d8f29a27d72ec452e16e144f13c8b39828082"
+}

--- a/.sqlx/query-bf0ee7f3fd1db85944c916fc155dddccee12c4023ab3cd7319285f43a90d7aaf.json
+++ b/.sqlx/query-bf0ee7f3fd1db85944c916fc155dddccee12c4023ab3cd7319285f43a90d7aaf.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT t.id AS \"id?: TxTemplateId\", MAX(e.sequence) AS \"version\" \n            FROM cala_tx_templates t\n            JOIN cala_tx_template_events e ON t.id = e.id\n            WHERE t.code = $1\n            GROUP BY t.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id?: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "bf0ee7f3fd1db85944c916fc155dddccee12c4023ab3cd7319285f43a90d7aaf"
+}

--- a/.sqlx/query-bf5cbcd07e48210524388a951f05b5ca8ed690bb7b24ca20747296cb0e1a8fa4.json
+++ b/.sqlx/query-bf5cbcd07e48210524388a951f05b5ca8ed690bb7b24ca20747296cb0e1a8fa4.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM cala_tx_templates i JOIN cala_tx_template_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bf5cbcd07e48210524388a951f05b5ca8ed690bb7b24ca20747296cb0e1a8fa4"
+}

--- a/.sqlx/query-bff48c51c85f4065933a688b3ba921dbbbc0f77104ecf5603bfbc124b7c70d9c.json
+++ b/.sqlx/query-bff48c51c85f4065933a688b3ba921dbbbc0f77104ecf5603bfbc124b7c70d9c.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, created_at, id FROM cala_account_sets WHERE ((name = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bff48c51c85f4065933a688b3ba921dbbbc0f77104ecf5603bfbc124b7c70d9c"
+}

--- a/.sqlx/query-c09c34d3b19e38e1997541a0df25360386d079d1335cea56585e70b84e91df60.json
+++ b/.sqlx/query-c09c34d3b19e38e1997541a0df25360386d079d1335cea56585e70b84e91df60.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT account_id, id FROM cala_entries WHERE ((account_id = $1) AND (COALESCE(id > $3, true))) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c09c34d3b19e38e1997541a0df25360386d079d1335cea56585e70b84e91df60"
+}

--- a/.sqlx/query-c1796c681976a85440963f4a316293957dc547dd481eb4345466df2615c6dc94.json
+++ b/.sqlx/query-c1796c681976a85440963f4a316293957dc547dd481eb4345466df2615c6dc94.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE code = $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c1796c681976a85440963f4a316293957dc547dd481eb4345466df2615c6dc94"
+}

--- a/.sqlx/query-c1e16b22fc0352a4f1cd5ad180aca9fde3349bbdd32a78c8f69930712782b392.json
+++ b/.sqlx/query-c1e16b22fc0352a4f1cd5ad180aca9fde3349bbdd32a78c8f69930712782b392.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_controls WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: VelocityControlId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_control_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityControlId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c1e16b22fc0352a4f1cd5ad180aca9fde3349bbdd32a78c8f69930712782b392"
+}

--- a/.sqlx/query-c5908d380e66722d89d5ff74340ce7c018d37dc8360be846b3d41b1faa43a350.json
+++ b/.sqlx/query-c5908d380e66722d89d5ff74340ce7c018d37dc8360be846b3d41b1faa43a350.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT journal_id, created_at, id FROM cala_entries WHERE ((journal_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c5908d380e66722d89d5ff74340ce7c018d37dc8360be846b3d41b1faa43a350"
+}

--- a/.sqlx/query-c8efe8132e8f2197300f69547e8cb385ca0b8e01ce5132e5aa6f83ab4c497481.json
+++ b/.sqlx/query-c8efe8132e8f2197300f69547e8cb385ca0b8e01ce5132e5aa6f83ab4c497481.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE data_source_id = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c8efe8132e8f2197300f69547e8cb385ca0b8e01ce5132e5aa6f83ab4c497481"
+}

--- a/.sqlx/query-ccd9eba7c72866504396053ba4a00b4a97ce6d42768e64c2438f1c2d42d42d1e.json
+++ b/.sqlx/query-ccd9eba7c72866504396053ba4a00b4a97ce6d42768e64c2438f1c2d42d42d1e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_limits WHERE name = $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ccd9eba7c72866504396053ba4a00b4a97ce6d42768e64c2438f1c2d42d42d1e"
+}

--- a/.sqlx/query-ced290936645505236ce717c81ac5a6d813ad66008c21c0a10ead263fff70f13.json
+++ b/.sqlx/query-ced290936645505236ce717c81ac5a6d813ad66008c21c0a10ead263fff70f13.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_limits WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ced290936645505236ce717c81ac5a6d813ad66008c21c0a10ead263fff70f13"
+}

--- a/.sqlx/query-cf9616e074abd08990fb1c9314ad57c54950e7ea7b81e652afb4227db389f2fe.json
+++ b/.sqlx/query-cf9616e074abd08990fb1c9314ad57c54950e7ea7b81e652afb4227db389f2fe.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.id AS \"id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM cala_velocity_limits i JOIN cala_velocity_limit_events e ON i.id = e.id WHERE i.id = ANY($1) ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "cf9616e074abd08990fb1c9314ad57c54950e7ea7b81e652afb4227db389f2fe"
+}

--- a/.sqlx/query-d3d061cb7eb1f0c5009097765180619e8c6793419322a882cea05f8a12e3c7cb.json
+++ b/.sqlx/query-d3d061cb7eb1f0c5009097765180619e8c6793419322a882cea05f8a12e3c7cb.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_journals WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: JournalId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: JournalId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d3d061cb7eb1f0c5009097765180619e8c6793419322a882cea05f8a12e3c7cb"
+}

--- a/.sqlx/query-d44cef2aef676bed03cea638b4a075dd414d859b95961cd797d32565625234f1.json
+++ b/.sqlx/query-d44cef2aef676bed03cea638b4a075dd414d859b95961cd797d32565625234f1.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE name = $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d44cef2aef676bed03cea638b4a075dd414d859b95961cd797d32565625234f1"
+}

--- a/.sqlx/query-d7fc0e2d283bb6bb620f0fa91f9436cbe7bed2356c30413a792e8d0054a781a9.json
+++ b/.sqlx/query-d7fc0e2d283bb6bb620f0fa91f9436cbe7bed2356c30413a792e8d0054a781a9.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (\n                            SELECT created_at, id\n                            FROM cala_entries\n                            JOIN cala_balance_history ON cala_entries.id = cala_balance_history.latest_entry_id\n                            WHERE cala_balance_history.account_id = $4\n                              AND (COALESCE((created_at, id) > ($3, $2), $2 IS NULL))\n                            ORDER BY created_at ASC, id ASC\n                            LIMIT $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d7fc0e2d283bb6bb620f0fa91f9436cbe7bed2356c30413a792e8d0054a781a9"
+}

--- a/.sqlx/query-d88eeb1e3e61f74fca98c4f9638dd96a3dd7109770069959279b129a81229903.json
+++ b/.sqlx/query-d88eeb1e3e61f74fca98c4f9638dd96a3dd7109770069959279b129a81229903.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_entry_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d88eeb1e3e61f74fca98c4f9638dd96a3dd7109770069959279b129a81229903"
+}

--- a/.sqlx/query-d8c86f4e587992cc72d5c8134267f7c19bde6edec273b089fdfb5b93175d8fc0.json
+++ b/.sqlx/query-d8c86f4e587992cc72d5c8134267f7c19bde6edec273b089fdfb5b93175d8fc0.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE cala_account_sets SET name = $2, external_id = $3 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d8c86f4e587992cc72d5c8134267f7c19bde6edec273b089fdfb5b93175d8fc0"
+}

--- a/.sqlx/query-dcb0457a64e8fd4f7a521d4fdbb88c55338536d6542829d1520af1a07bbd2d94.json
+++ b/.sqlx/query-dcb0457a64e8fd4f7a521d4fdbb88c55338536d6542829d1520af1a07bbd2d94.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_entry_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dcb0457a64e8fd4f7a521d4fdbb88c55338536d6542829d1520af1a07bbd2d94"
+}

--- a/.sqlx/query-dedd6bbd3831c920f75654298daf488c622e88a7f5471ffb590dc0a619e0a891.json
+++ b/.sqlx/query-dedd6bbd3831c920f75654298daf488c622e88a7f5471ffb590dc0a619e0a891.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE id = $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dedd6bbd3831c920f75654298daf488c622e88a7f5471ffb590dc0a619e0a891"
+}

--- a/.sqlx/query-e14d0690dcbba0f40192c3f7c72d2901f02535f7866939dad145bd912b36b759.json
+++ b/.sqlx/query-e14d0690dcbba0f40192c3f7c72d2901f02535f7866939dad145bd912b36b759.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_journal_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e14d0690dcbba0f40192c3f7c72d2901f02535f7866939dad145bd912b36b759"
+}

--- a/.sqlx/query-e29215c0e5e0469f8df89df188748c17fc4a18be27f7d4a64cf6512956090c68.json
+++ b/.sqlx/query-e29215c0e5e0469f8df89df188748c17fc4a18be27f7d4a64cf6512956090c68.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT tx_template_id, id FROM cala_transactions WHERE ((tx_template_id = $1) AND (COALESCE(id > $3, true))) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e29215c0e5e0469f8df89df188748c17fc4a18be27f7d4a64cf6512956090c68"
+}

--- a/.sqlx/query-e3917353bef64a9e0332e24a5420256979363c88f2000f5e99fe0a215a8f06d4.json
+++ b/.sqlx/query-e3917353bef64a9e0332e24a5420256979363c88f2000f5e99fe0a215a8f06d4.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_tx_templates WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e3917353bef64a9e0332e24a5420256979363c88f2000f5e99fe0a215a8f06d4"
+}

--- a/.sqlx/query-e4d6ff9f867fc4eb41478d2f5cbbac04cebc2e3086e9b184dc0ca5ad75b84673.json
+++ b/.sqlx/query-e4d6ff9f867fc4eb41478d2f5cbbac04cebc2e3086e9b184dc0ca5ad75b84673.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_velocity_limits WHERE id = $1) SELECT i.id AS \"entity_id: VelocityLimitId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_velocity_limit_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: VelocityLimitId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e4d6ff9f867fc4eb41478d2f5cbbac04cebc2e3086e9b184dc0ca5ad75b84673"
+}

--- a/.sqlx/query-e56e94ae9e0c5e1d6bb77715eb207c93159acfda96c25e0588584d4314b37a6f.json
+++ b/.sqlx/query-e56e94ae9e0c5e1d6bb77715eb207c93159acfda96c25e0588584d4314b37a6f.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE external_id = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e56e94ae9e0c5e1d6bb77715eb207c93159acfda96c25e0588584d4314b37a6f"
+}

--- a/.sqlx/query-e711cccbac49b2a5016ccf674cfc870090d7b176c96ec449ed4c34b5893da526.json
+++ b/.sqlx/query-e711cccbac49b2a5016ccf674cfc870090d7b176c96ec449ed4c34b5893da526.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_entries WHERE data_source_id = $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e711cccbac49b2a5016ccf674cfc870090d7b176c96ec449ed4c34b5893da526"
+}

--- a/.sqlx/query-e76ff1b31d7cf5b2244264e3ce116adfe905e9f81ced34a875dbb3bdd5cfdc09.json
+++ b/.sqlx/query-e76ff1b31d7cf5b2244264e3ce116adfe905e9f81ced34a875dbb3bdd5cfdc09.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE latest_values = $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e76ff1b31d7cf5b2244264e3ce116adfe905e9f81ced34a875dbb3bdd5cfdc09"
+}

--- a/.sqlx/query-e983a467a77dbf5c21aa33f0ff7e70ff74e62037c3a84f74f8836756f610d333.json
+++ b/.sqlx/query-e983a467a77dbf5c21aa33f0ff7e70ff74e62037c3a84f74f8836756f610d333.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO cala_outbox_events (sequence)\n                SELECT unnest($1::bigint[]) AS sequence\n                ON CONFLICT (sequence) DO UPDATE\n                SET sequence = EXCLUDED.sequence\n                RETURNING id, sequence AS \"sequence!: EventSequence\", payload, recorded_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence!: EventSequence",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8Array"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "e983a467a77dbf5c21aa33f0ff7e70ff74e62037c3a84f74f8836756f610d333"
+}

--- a/.sqlx/query-e986221978d38f58d09566e7dc8d5de3f0e72eb1af2315ae27c5496867c3b145.json
+++ b/.sqlx/query-e986221978d38f58d09566e7dc8d5de3f0e72eb1af2315ae27c5496867c3b145.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e986221978d38f58d09566e7dc8d5de3f0e72eb1af2315ae27c5496867c3b145"
+}

--- a/.sqlx/query-ea8cfd4ad3988a601ba0adda0385e78194a42e8223a8bfa36e0dbad61d3ad74b.json
+++ b/.sqlx/query-ea8cfd4ad3988a601ba0adda0385e78194a42e8223a8bfa36e0dbad61d3ad74b.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH member_accounts AS (\n              SELECT\n                member_account_id AS member_id,\n                member_account_id,\n                NULL::uuid AS member_account_set_id,\n                a.external_id\n              FROM cala_account_set_member_accounts m\n              LEFT JOIN cala_accounts a ON m.member_account_id = a.id\n              WHERE\n                transitive IS FALSE\n                AND m.account_set_id = $4\n                AND (\n                  ($3::varchar IS NULL) OR\n                  (a.external_id IS NULL AND $3::varchar IS NOT NULL) OR\n                  (a.external_id > $3::varchar) OR\n                  (a.external_id = $3::varchar AND member_account_id > $2)\n                )\n              ORDER BY a.external_id ASC NULLS LAST, member_account_id ASC\n              LIMIT $1\n            ), member_sets AS (\n              SELECT\n                member_account_set_id AS member_id,\n                NULL::uuid AS member_account_id,\n                member_account_set_id,\n                s.external_id\n              FROM cala_account_set_member_account_sets m\n              LEFT JOIN cala_account_sets s ON m.member_account_set_id = s.id\n              WHERE\n                m.account_set_id = $4\n                AND (\n                  ($3::varchar IS NULL) OR\n                  (s.external_id IS NULL AND $3::varchar IS NOT NULL) OR\n                  (s.external_id > $3::varchar) OR\n                  (s.external_id = $3::varchar AND member_account_set_id > $2)\n                )\n              ORDER BY s.external_id ASC NULLS LAST, member_account_set_id ASC\n              LIMIT $1\n            ), all_members AS (\n              SELECT * FROM member_accounts\n              UNION ALL\n              SELECT * FROM member_sets\n            )\n            SELECT * FROM all_members\n            ORDER BY external_id ASC NULLS LAST, member_id ASC\n            LIMIT $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "member_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "member_account_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "member_account_set_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "external_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "ea8cfd4ad3988a601ba0adda0385e78194a42e8223a8bfa36e0dbad61d3ad74b"
+}

--- a/.sqlx/query-ec5deac7f225fc2d848dfa9ff437c4deb1dc2d3a7bda6df0bb792469748d534d.json
+++ b/.sqlx/query-ec5deac7f225fc2d848dfa9ff437c4deb1dc2d3a7bda6df0bb792469748d534d.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_tx_templates WHERE code = $1) SELECT i.id AS \"entity_id: TxTemplateId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_tx_template_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TxTemplateId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ec5deac7f225fc2d848dfa9ff437c4deb1dc2d3a7bda6df0bb792469748d534d"
+}

--- a/.sqlx/query-f03af09ccb782050f2067f616cccc4d06192f9575c97dfe8c907d8cec41d7908.json
+++ b/.sqlx/query-f03af09ccb782050f2067f616cccc4d06192f9575c97dfe8c907d8cec41d7908.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f03af09ccb782050f2067f616cccc4d06192f9575c97dfe8c907d8cec41d7908"
+}

--- a/.sqlx/query-f130c22d14ee2a99b9220ac1a45226ba97993ede9988a4c57d58bd066500a119.json
+++ b/.sqlx/query-f130c22d14ee2a99b9220ac1a45226ba97993ede9988a4c57d58bd066500a119.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v0 is NULL OR v0 = COALESCE($2,v0)) AND\n                    (v1 is NULL OR v1 = COALESCE($3,v1)) AND\n                    (v2 is NULL OR v2 = COALESCE($4,v2)) AND\n                    (v3 is NULL OR v3 = COALESCE($5,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($6,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($7,v5))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f130c22d14ee2a99b9220ac1a45226ba97993ede9988a4c57d58bd066500a119"
+}

--- a/.sqlx/query-f1c05d5e666750f7bced3e29318173278cd087f3ccfa8cb70816c9ece21aad31.json
+++ b/.sqlx/query-f1c05d5e666750f7bced3e29318173278cd087f3ccfa8cb70816c9ece21aad31.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT values, a.normal_balance_type AS \"normal_balance_type!: DebitOrCredit\"\n            FROM cala_cumulative_effective_balances\n            JOIN cala_accounts a\n            ON account_id = a.id\n            WHERE journal_id = $1\n            AND account_id = $2\n            AND currency = $3\n            AND effective <= $4\n            ORDER BY effective DESC, version DESC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "values",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "normal_balance_type!: DebitOrCredit",
+        "type_info": {
+          "Custom": {
+            "name": "debitorcredit",
+            "kind": {
+              "Enum": [
+                "debit",
+                "credit"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Date"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "f1c05d5e666750f7bced3e29318173278cd087f3ccfa8cb70816c9ece21aad31"
+}

--- a/.sqlx/query-f1c565f20b63fac46262fee6734e7419e5e98351d719dad04890d8ed8b76b2a7.json
+++ b/.sqlx/query-f1c565f20b63fac46262fee6734e7419e5e98351d719dad04890d8ed8b76b2a7.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_entries (id, account_id, journal_id, transaction_id, data_source_id, created_at) VALUES ($1, $2, $3, $4, $5, $6)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f1c565f20b63fac46262fee6734e7419e5e98351d719dad04890d8ed8b76b2a7"
+}

--- a/.sqlx/query-f4fcd5ca06c40deabbf2fcac35299e82efe90e58c1fefafd0f523b6251817f49.json
+++ b/.sqlx/query-f4fcd5ca06c40deabbf2fcac35299e82efe90e58c1fefafd0f523b6251817f49.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT journal_id, created_at, id FROM cala_entries WHERE ((journal_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f4fcd5ca06c40deabbf2fcac35299e82efe90e58c1fefafd0f523b6251817f49"
+}

--- a/.sqlx/query-f5181dc829ed2ff05693acf01452d0f81abad1b07a3d1c4587832b8ae912ae4c.json
+++ b/.sqlx/query-f5181dc829ed2ff05693acf01452d0f81abad1b07a3d1c4587832b8ae912ae4c.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_entries WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: EntryId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: EntryId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f5181dc829ed2ff05693acf01452d0f81abad1b07a3d1c4587832b8ae912ae4c"
+}

--- a/.sqlx/query-f5895b3d78cf250949a486e961dae15f25aba8155f5ec6ee8a19717877745e9b.json
+++ b/.sqlx/query-f5895b3d78cf250949a486e961dae15f25aba8155f5ec6ee8a19717877745e9b.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE external_id = $1) SELECT i.id AS \"entity_id: AccountSetId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountSetId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f5895b3d78cf250949a486e961dae15f25aba8155f5ec6ee8a19717877745e9b"
+}

--- a/.sqlx/query-f7ac91e8ecf9f13ab0235fc30b1fc9b31a7af2bab2c6f980101d4b3eb71ec65b.json
+++ b/.sqlx/query-f7ac91e8ecf9f13ab0235fc30b1fc9b31a7af2bab2c6f980101d4b3eb71ec65b.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE journal_id = $1) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f7ac91e8ecf9f13ab0235fc30b1fc9b31a7af2bab2c6f980101d4b3eb71ec65b"
+}

--- a/.sqlx/query-f8611a862ed1d3b982e8aa5ccab21e00c42a3fad8082cf15c2af88cd8388f41b.json
+++ b/.sqlx/query-f8611a862ed1d3b982e8aa5ccab21e00c42a3fad8082cf15c2af88cd8388f41b.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v2 is NULL OR v2 = COALESCE($2,v2)) AND\n                    (v3 is NULL OR v3 = COALESCE($3,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($4,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($5,v5))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f8611a862ed1d3b982e8aa5ccab21e00c42a3fad8082cf15c2af88cd8388f41b"
+}

--- a/.sqlx/query-f913137cb0dcc0fd536118c964f4b159f065a1875dd1f02982a1f579c9558087.json
+++ b/.sqlx/query-f913137cb0dcc0fd536118c964f4b159f065a1875dd1f02982a1f579c9558087.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_velocity_limit_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, $1, unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2::UUID[], $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "UuidArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f913137cb0dcc0fd536118c964f4b159f065a1875dd1f02982a1f579c9558087"
+}

--- a/.sqlx/query-fa3e89e009e7df93f198f41736ca0cd645e51b04720d1a01a85a778a544b368f.json
+++ b/.sqlx/query-fa3e89e009e7df93f198f41736ca0cd645e51b04720d1a01a85a778a544b368f.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM cala_accounts WHERE (COALESCE((name, id) > ($3, $2), $2 IS NULL)) ORDER BY name ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.name asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fa3e89e009e7df93f198f41736ca0cd645e51b04720d1a01a85a778a544b368f"
+}

--- a/.sqlx/query-fa51ae7af271fc17c848694fbf1b37d46c5a2f4202e1b8dce1f66a65069beb0b.json
+++ b/.sqlx/query-fa51ae7af271fc17c848694fbf1b37d46c5a2f4202e1b8dce1f66a65069beb0b.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v5 is NULL OR v5 = COALESCE($2,v5))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa51ae7af271fc17c848694fbf1b37d46c5a2f4202e1b8dce1f66a65069beb0b"
+}

--- a/.sqlx/query-fab10fcf171df145062acf5612ef38df6a96e971db2139c10041ad0170cfd0a9.json
+++ b/.sqlx/query-fab10fcf171df145062acf5612ef38df6a96e971db2139c10041ad0170cfd0a9.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cala_transaction_events (id, recorded_at, sequence, event_type, event) SELECT $1, $2, ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::text[], $5::jsonb[]) AS unnested(event_type, event)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fab10fcf171df145062acf5612ef38df6a96e971db2139c10041ad0170cfd0a9"
+}

--- a/.sqlx/query-fb7ce69e70b345d2cf0ca017523c1b90b67b053add3d4cffb8d579bfc8f08345.json
+++ b/.sqlx/query-fb7ce69e70b345d2cf0ca017523c1b90b67b053add3d4cffb8d579bfc8f08345.json
@@ -1,0 +1,75 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * from  casbin_rule WHERE (\n            ptype LIKE 'g%' AND v0 LIKE $1 AND v1 LIKE $2 AND v2 LIKE $3 AND v3 LIKE $4 AND v4 LIKE $5 AND v5 LIKE $6 )\n        OR (\n            ptype LIKE 'p%' AND v0 LIKE $7 AND v1 LIKE $8 AND v2 LIKE $9 AND v3 LIKE $10 AND v4 LIKE $11 AND v5 LIKE $12 );\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "ptype",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "v0",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "v1",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "v2",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "v3",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "v4",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "v5",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fb7ce69e70b345d2cf0ca017523c1b90b67b053add3d4cffb8d579bfc8f08345"
+}

--- a/.sqlx/query-fcafbeba17bc68565a773aaf9e5193a3ce893a72df375cfb420b9b7ab9a933c9.json
+++ b/.sqlx/query-fcafbeba17bc68565a773aaf9e5193a3ce893a72df375cfb420b9b7ab9a933c9.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT tx_template_id, created_at, id FROM cala_transactions WHERE ((tx_template_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: TransactionId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: TransactionId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fcafbeba17bc68565a773aaf9e5193a3ce893a72df375cfb420b9b7ab9a933c9"
+}

--- a/.sqlx/query-fe8ed538b549515c126b30dc923062c03b1af6949138cc500b1eccd0faf495b3.json
+++ b/.sqlx/query-fe8ed538b549515c126b30dc923062c03b1af6949138cc500b1eccd0faf495b3.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM cala_accounts WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: AccountId\", e.sequence, e.event, e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fe8ed538b549515c126b30dc923062c03b1af6949138cc500b1eccd0faf495b3"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,9 +680,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cala-cel-interpreter"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160b36155bb600490db0660e00614e292708c893f743b7b0d86cd9d734b9567c"
+checksum = "a83402448efb2b9ec611c7c91dcd7038bbd531ff243cdcd5d2d1e30ef7a94e7e"
 dependencies = [
  "cala-cel-parser",
  "chrono",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "cala-cel-parser"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c4fb44d2df9cda6b500e3ae73a09f65c3128e5702aa443d7ff57e20ce5b3b3"
+checksum = "43c3466dfe4fea565fcae805e431b45b17c7de8f399c7f6d5a17b1097605d85a"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c752242e907a744f5cc563e1167e0b51822bdc9ce2c6212f695798054e1404"
+checksum = "d1b06026eb79e68f9530a3767808541c6d70f096281d0c5d6ec73349c8ace8dd"
 dependencies = [
  "async-graphql",
  "base64 0.22.1",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger-core-types"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3e694cbe7e25c46f8d2aafcb361e6eb691d79117dcb3a49d0cc2087677d6c3"
+checksum = "05138dcd14b1c32053e192b68de33d0ad4adfcc5af3159862f5ec639c917c4e4"
 dependencies = [
  "async-graphql",
  "cala-cel-interpreter",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "cala-tracing"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed2cb77fa837846808ea72d27d7573874600fc87ee8f3d511581978071e1307"
+checksum = "1d6dc115e8a63e2a48388875d6c1df28c1ca7693b19171434d88d6b98f749e65"
 dependencies = [
  "anyhow",
  "axum-extra",
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2161ec15e33fd097be8dcccfd6f9cd6288cdda42040a7147e81386a5107c62ad"
+checksum = "31dcb30fa291885ac2a0b9521b489d64f2d97f1734362438821f4dbd67f913bb"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965989dd85d3bb92b5ef09ff8f0a1331f509bc44576396a3c4d6f83b526cd592"
+checksum = "b8843bd4396ecf1200a902335e32bcf7c52fea963f48b88b1622762571fd1f21"
 dependencies = [
  "convert_case",
  "darling",
@@ -4345,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "sim-time"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59b12a1c36f28bc0970e6ad570956e165cdb5a2f1b9a600c572c7f377df537b"
+checksum = "ab2e4ca3ceb124bf798790af02484626317691ffe39643a056f2be8a03e08c0a"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.100",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -298,7 +298,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -459,7 +459,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -657,7 +657,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -680,9 +680,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cala-cel-interpreter"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418929b6fc00a0862cfea589619576e6e1f3f774ddd60733f7355a4f77e8b009"
+checksum = "160b36155bb600490db0660e00614e292708c893f743b7b0d86cd9d734b9567c"
 dependencies = [
  "cala-cel-parser",
  "chrono",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "cala-cel-parser"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e9b993e1b77022187195d1cc52217cfd26ead24401826355d30b8fa02de859"
+checksum = "27c4fb44d2df9cda6b500e3ae73a09f65c3128e5702aa443d7ff57e20ce5b3b3"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8f987a3d4ef95f7435303d43c0721a2b8a6f03a798ddf39e6bf142f6e956b5"
+checksum = "03c752242e907a744f5cc563e1167e0b51822bdc9ce2c6212f695798054e1404"
 dependencies = [
  "async-graphql",
  "base64 0.22.1",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger-core-types"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2d17c745f2170c96d18aa39fc46f094b900fd933ea840f56ab4154f02c2bb8"
+checksum = "1d3e694cbe7e25c46f8d2aafcb361e6eb691d79117dcb3a49d0cc2087677d6c3"
 dependencies = [
  "async-graphql",
  "cala-cel-interpreter",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "cala-tracing"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209bcfd6a1165708281208d4fde65db10a8f3d6b053f25684f9d6c189191a8c"
+checksum = "0ed2cb77fa837846808ea72d27d7573874600fc87ee8f3d511581978071e1307"
 dependencies = [
  "anyhow",
  "axum-extra",
@@ -824,9 +824,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -868,7 +868,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1272,7 +1272,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1391,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1435,7 +1435,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ad53dca4b7796714a12c4f08a0eb5835040f87ea588d2f6316965aaab7445c"
+checksum = "2161ec15e33fd097be8dcccfd6f9cd6288cdda42040a7147e81386a5107c62ad"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb0128f4e4257af804c4b57f4c746a0a871ac94dcf9ffd2ce43f6edb459fa0d"
+checksum = "965989dd85d3bb92b5ef09ff8f0a1331f509bc44576396a3c4d6f83b526cd592"
 dependencies = [
  "convert_case",
  "darling",
@@ -1535,7 +1535,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1697,7 +1697,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2463,7 +2463,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3280,7 +3280,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3366,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3403,7 +3403,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -3415,7 +3415,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -3429,7 +3429,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3462,7 +3462,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "prost",
  "prost-build",
  "prost-types",
@@ -3896,7 +3896,7 @@ checksum = "a5a11a05ee1ce44058fa3d5961d05194fdbe3ad6b40f904af764d81b86450e6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3985,7 +3985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6268b74858287e1a062271b988a0c534bf85bbeb567fe09331bf40ed78113d5"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4173,7 +4173,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4237,7 +4237,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4345,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "sim-time"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2499621d0e3f7b7a23a9e6d6626b28c3cb06841072de77c7c525feb432b586"
+checksum = "e59b12a1c36f28bc0970e6ad570956e165cdb5a2f1b9a600c572c7f377df537b"
 dependencies = [
  "chrono",
  "serde",
@@ -4518,7 +4518,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4541,7 +4541,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.100",
+ "syn 2.0.101",
  "tempfile",
  "tokio",
  "url",
@@ -4724,7 +4724,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4746,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4778,7 +4778,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4867,7 +4867,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4878,7 +4878,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4960,9 +4960,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4983,7 +4983,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5105,7 +5105,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5205,7 +5205,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5366,7 +5366,7 @@ checksum = "70b20a22c42c8f1cd23ce5e34f165d4d37038f5b663ad20fb6adbdf029172483"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5589,7 +5589,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -5624,7 +5624,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5718,7 +5718,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6052,7 +6052,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -6108,7 +6108,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6119,7 +6119,7 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6139,7 +6139,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -6168,5 +6168,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ members = [
 # es-entity = { git = "https://github.com/galoymoney/cala.git", branch = "main" }
 # sim-time = { git = "https://github.com/galoymoney/cala.git", branch = "main" }
 # cala-ledger = { git = "https://github.com/galoymoney/cala.git", branch = "main" }
-es-entity = "0.4.6"
-sim-time = "0.4.6"
-cala-ledger = "0.4.6"
+es-entity = "0.5.0"
+sim-time = "0.5.0"
+cala-ledger = "0.5.0"
 
 anyhow = "1.0.98"
 async-graphql = { version = "7.0.11", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ members = [
 # es-entity = { git = "https://github.com/galoymoney/cala.git", branch = "main" }
 # sim-time = { git = "https://github.com/galoymoney/cala.git", branch = "main" }
 # cala-ledger = { git = "https://github.com/galoymoney/cala.git", branch = "main" }
-es-entity = "0.4.5"
-sim-time = "0.4.5"
-cala-ledger = "0.4.5"
+es-entity = "0.4.6"
+sim-time = "0.4.6"
+cala-ledger = "0.4.6"
 
 anyhow = "1.0.98"
 async-graphql = { version = "7.0.11", default-features = false, features = [
@@ -83,7 +83,7 @@ opentelemetry-otlp = { version = "0.17.0", default-features = false, features = 
 ] }
 opentelemetry-http = "0.13"
 opentelemetry-semantic-conventions = "0.16.0"
-tokio = { version = "1.44.2", features = [
+tokio = { version = "1.45.0", features = [
   "rt-multi-thread",
   "macros",
   "time",

--- a/apps/admin-panel/app/balance-sheet/page.tsx
+++ b/apps/admin-panel/app/balance-sheet/page.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/components/date-range-picker"
 
 gql`
-  query BalanceSheet($from: Timestamp!, $until: Timestamp) {
+  query BalanceSheet($from: Date!, $until: Date) {
     balanceSheet(from: $from, until: $until) {
       name
       balance {

--- a/apps/admin-panel/app/profit-and-loss/page.tsx
+++ b/apps/admin-panel/app/profit-and-loss/page.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/components/date-range-picker"
 
 gql`
-  query ProfitAndLossStatement($from: Timestamp!, $until: Timestamp) {
+  query ProfitAndLossStatement($from: Date!, $until: Date) {
     profitAndLossStatement(from: $from, until: $until) {
       name
       total {

--- a/apps/admin-panel/app/trial-balance/page.tsx
+++ b/apps/admin-panel/app/trial-balance/page.tsx
@@ -43,12 +43,7 @@ import PaginatedTable, { Column, PaginatedData } from "@/components/paginated-ta
 const DEFAULT_PAGESIZE = 15
 
 gql`
-  query GetTrialBalance(
-    $from: Timestamp!
-    $until: Timestamp!
-    $first: Int!
-    $after: String
-  ) {
+  query GetTrialBalance($from: Date!, $until: Date!, $first: Int!, $after: String) {
     trialBalance(from: $from, until: $until) {
       name
       total {

--- a/apps/admin-panel/components/date-range-picker/index.tsx
+++ b/apps/admin-panel/components/date-range-picker/index.tsx
@@ -26,8 +26,8 @@ export const getInitialDateRange = (): DateRange => {
   const today = new Date()
   const oneYearAgo = new Date(today.getFullYear() - 1, today.getMonth(), today.getDate())
   return {
-    from: oneYearAgo.toISOString(),
-    until: today.toISOString(),
+    from: oneYearAgo.toISOString().split("T")[0],
+    until: today.toISOString().split("T")[0],
   }
 }
 

--- a/apps/admin-panel/cypress/e2e/balance-sheet.cy.ts
+++ b/apps/admin-panel/cypress/e2e/balance-sheet.cy.ts
@@ -22,8 +22,8 @@ describe("Balance Sheet", () => {
 
   it("should display balance sheet sections and categories", () => {
     cy.graphqlRequest<{ data: BalanceSheetQuery }>(print(BalanceSheetDocument), {
-      from: lastMonthDate.toISOString(),
-      until: currentDate.toISOString(),
+      from: lastMonthDate.toISOString().split('T')[0],
+      until: currentDate.toISOString().split('T')[0],
     }).then((response) => {
       cy.contains(t(BalanceSheet + ".columns.assets")).should("be.visible")
       cy.contains(t(BalanceSheet + ".columns.liabilitiesAndEquity")).should("be.visible")

--- a/apps/admin-panel/cypress/e2e/profit-and-loss.cy.ts
+++ b/apps/admin-panel/cypress/e2e/profit-and-loss.cy.ts
@@ -23,8 +23,8 @@ describe("Profit and Loss Statement", () => {
     cy.graphqlRequest<{ data: ProfitAndLossStatementQuery }>(
       print(ProfitAndLossStatementDocument),
       {
-        from: lastMonthDate.toISOString(),
-        until: currentDate.toISOString(),
+        from: lastMonthDate.toISOString().split('T')[0],
+        until: currentDate.toISOString().split('T')[0],
       },
     ).then((response) => {
       response.data.profitAndLossStatement?.categories.forEach((category) => {

--- a/apps/admin-panel/cypress/e2e/trial-balance.cy.ts
+++ b/apps/admin-panel/cypress/e2e/trial-balance.cy.ts
@@ -21,8 +21,8 @@ describe(t(TB + ".title"), () => {
 
   it("should render trial balance with accounts and their balances", () => {
     cy.graphqlRequest<{ data: GetTrialBalanceQuery }>(print(GetTrialBalanceDocument), {
-      from: lastMonthDate.toISOString(),
-      until: currentDate.toISOString(),
+      from: lastMonthDate.toISOString().split('T')[0],
+      until: currentDate.toISOString().split('T')[0],
       first: 10,
     }).then((response) => {
       response.data.trialBalance?.accounts.edges.forEach(({ node: account }) => {

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -1635,8 +1635,8 @@ export type QueryAuditArgs = {
 
 
 export type QueryBalanceSheetArgs = {
-  from: Scalars['Timestamp']['input'];
-  until?: InputMaybe<Scalars['Timestamp']['input']>;
+  from: Scalars['Date']['input'];
+  until?: InputMaybe<Scalars['Date']['input']>;
 };
 
 
@@ -1760,8 +1760,8 @@ export type QueryPolicyArgs = {
 
 
 export type QueryProfitAndLossStatementArgs = {
-  from: Scalars['Timestamp']['input'];
-  until?: InputMaybe<Scalars['Timestamp']['input']>;
+  from: Scalars['Date']['input'];
+  until?: InputMaybe<Scalars['Date']['input']>;
 };
 
 
@@ -1782,8 +1782,8 @@ export type QueryTransactionTemplatesArgs = {
 
 
 export type QueryTrialBalanceArgs = {
-  from: Scalars['Timestamp']['input'];
-  until: Scalars['Timestamp']['input'];
+  from: Scalars['Date']['input'];
+  until: Scalars['Date']['input'];
 };
 
 
@@ -2199,8 +2199,8 @@ export type AuditLogsQueryVariables = Exact<{
 export type AuditLogsQuery = { __typename?: 'Query', audit: { __typename?: 'AuditEntryConnection', edges: Array<{ __typename?: 'AuditEntryEdge', cursor: string, node: { __typename?: 'AuditEntry', id: string, auditEntryId: any, object: string, action: string, authorized: boolean, recordedAt: any, subject: { __typename?: 'System', name: string } | { __typename?: 'User', userId: string, email: string, roles: Array<Role> } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
 
 export type BalanceSheetQueryVariables = Exact<{
-  from: Scalars['Timestamp']['input'];
-  until?: InputMaybe<Scalars['Timestamp']['input']>;
+  from: Scalars['Date']['input'];
+  until?: InputMaybe<Scalars['Date']['input']>;
 }>;
 
 
@@ -2608,8 +2608,8 @@ export type PoliciesQueryVariables = Exact<{
 export type PoliciesQuery = { __typename?: 'Query', policies: { __typename?: 'PolicyConnection', edges: Array<{ __typename?: 'PolicyEdge', cursor: string, node: { __typename?: 'Policy', id: string, policyId: string, approvalProcessType: ApprovalProcessType, rules: { __typename?: 'CommitteeThreshold', threshold: number, committee: { __typename?: 'Committee', id: string, committeeId: string, createdAt: any, name: string } } | { __typename?: 'SystemApproval', autoApprove: boolean } } }>, pageInfo: { __typename?: 'PageInfo', hasPreviousPage: boolean, hasNextPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type ProfitAndLossStatementQueryVariables = Exact<{
-  from: Scalars['Timestamp']['input'];
-  until?: InputMaybe<Scalars['Timestamp']['input']>;
+  from: Scalars['Date']['input'];
+  until?: InputMaybe<Scalars['Date']['input']>;
 }>;
 
 
@@ -2678,8 +2678,8 @@ export type TransactionTemplatesQueryVariables = Exact<{
 export type TransactionTemplatesQuery = { __typename?: 'Query', transactionTemplates: { __typename?: 'TransactionTemplateConnection', edges: Array<{ __typename?: 'TransactionTemplateEdge', cursor: string, node: { __typename?: 'TransactionTemplate', id: string, code: string } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
 
 export type GetTrialBalanceQueryVariables = Exact<{
-  from: Scalars['Timestamp']['input'];
-  until: Scalars['Timestamp']['input'];
+  from: Scalars['Date']['input'];
+  until: Scalars['Date']['input'];
   first: Scalars['Int']['input'];
   after?: InputMaybe<Scalars['String']['input']>;
 }>;
@@ -3395,7 +3395,7 @@ export type AuditLogsLazyQueryHookResult = ReturnType<typeof useAuditLogsLazyQue
 export type AuditLogsSuspenseQueryHookResult = ReturnType<typeof useAuditLogsSuspenseQuery>;
 export type AuditLogsQueryResult = Apollo.QueryResult<AuditLogsQuery, AuditLogsQueryVariables>;
 export const BalanceSheetDocument = gql`
-    query BalanceSheet($from: Timestamp!, $until: Timestamp) {
+    query BalanceSheet($from: Date!, $until: Date) {
   balanceSheet(from: $from, until: $until) {
     name
     balance {
@@ -6013,7 +6013,7 @@ export type PoliciesLazyQueryHookResult = ReturnType<typeof usePoliciesLazyQuery
 export type PoliciesSuspenseQueryHookResult = ReturnType<typeof usePoliciesSuspenseQuery>;
 export type PoliciesQueryResult = Apollo.QueryResult<PoliciesQuery, PoliciesQueryVariables>;
 export const ProfitAndLossStatementDocument = gql`
-    query ProfitAndLossStatement($from: Timestamp!, $until: Timestamp) {
+    query ProfitAndLossStatement($from: Date!, $until: Date) {
   profitAndLossStatement(from: $from, until: $until) {
     name
     total {
@@ -6461,7 +6461,7 @@ export type TransactionTemplatesLazyQueryHookResult = ReturnType<typeof useTrans
 export type TransactionTemplatesSuspenseQueryHookResult = ReturnType<typeof useTransactionTemplatesSuspenseQuery>;
 export type TransactionTemplatesQueryResult = Apollo.QueryResult<TransactionTemplatesQuery, TransactionTemplatesQueryVariables>;
 export const GetTrialBalanceDocument = gql`
-    query GetTrialBalance($from: Timestamp!, $until: Timestamp!, $first: Int!, $after: String) {
+    query GetTrialBalance($from: Date!, $until: Date!, $first: Int!, $after: String) {
   trialBalance(from: $from, until: $until) {
     name
     total {

--- a/core/accounting/src/balance_sheet/mod.rs
+++ b/core/accounting/src/balance_sheet/mod.rs
@@ -5,7 +5,7 @@ pub mod ledger;
 use audit::AuditSvc;
 use authz::PermissionCheck;
 use cala_ledger::CalaLedger;
-use chrono::{DateTime, Utc};
+use chrono::NaiveDate;
 
 use crate::{
     LedgerAccountId,
@@ -197,8 +197,8 @@ where
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
         reference: String,
-        from: DateTime<Utc>,
-        until: Option<DateTime<Utc>>,
+        from: NaiveDate,
+        until: Option<NaiveDate>,
     ) -> Result<BalanceSheet, BalanceSheetError> {
         self.authz
             .enforce_permission(

--- a/core/accounting/src/ledger_account/ledger/mod.rs
+++ b/core/accounting/src/ledger_account/ledger/mod.rs
@@ -266,8 +266,8 @@ impl LedgerAccountLedger {
         &self,
         id: AccountSetId,
         args: es_entity::PaginatedQueryArgs<LedgerAccountChildrenCursor>,
-        from: chrono::DateTime<chrono::Utc>,
-        until: Option<chrono::DateTime<chrono::Utc>>,
+        from: chrono::NaiveDate,
+        until: Option<chrono::NaiveDate>,
     ) -> Result<
         es_entity::PaginatedQueryRet<LedgerAccount, LedgerAccountChildrenCursor>,
         LedgerAccountLedgerError,
@@ -318,6 +318,7 @@ impl LedgerAccountLedger {
             self.cala.accounts().find_all::<Account>(&account_ids),
             self.cala
                 .balances()
+                .effective()
                 .find_all_in_range(&balance_ids, from, until)
         );
 

--- a/core/accounting/src/ledger_account/mod.rs
+++ b/core/accounting/src/ledger_account/mod.rs
@@ -161,8 +161,8 @@ where
         chart: &Chart,
         id: cala_ledger::AccountSetId,
         mut args: es_entity::PaginatedQueryArgs<LedgerAccountChildrenCursor>,
-        from: chrono::DateTime<chrono::Utc>,
-        until: Option<chrono::DateTime<chrono::Utc>>,
+        from: chrono::NaiveDate,
+        until: Option<chrono::NaiveDate>,
         filter_non_zero: bool,
     ) -> Result<
         es_entity::PaginatedQueryRet<LedgerAccount, LedgerAccountChildrenCursor>,

--- a/core/accounting/src/ledger_account/value.rs
+++ b/core/accounting/src/ledger_account/value.rs
@@ -101,14 +101,14 @@ impl
         let code = values.external_id.and_then(|id| id.parse().ok());
 
         let usd_balance_range = usd_balance_range.map(|range| BalanceRange {
-            start: Some(range.start),
-            end: Some(range.end),
-            diff: Some(range.diff),
+            start: Some(range.open),
+            end: Some(range.close),
+            diff: Some(range.period),
         });
         let btc_balance_range = btc_balance_range.map(|range| BalanceRange {
-            start: Some(range.start),
-            end: Some(range.end),
-            diff: Some(range.diff),
+            start: Some(range.open),
+            end: Some(range.close),
+            diff: Some(range.period),
         });
 
         LedgerAccount {
@@ -182,14 +182,14 @@ impl
         ),
     ) -> Self {
         let usd_balance_range = usd_balance_range.map(|range| BalanceRange {
-            start: Some(range.start),
-            end: Some(range.end),
-            diff: Some(range.diff),
+            start: Some(range.open),
+            end: Some(range.close),
+            diff: Some(range.period),
         });
         let btc_balance_range = btc_balance_range.map(|range| BalanceRange {
-            start: Some(range.start),
-            end: Some(range.end),
-            diff: Some(range.diff),
+            start: Some(range.open),
+            end: Some(range.close),
+            diff: Some(range.period),
         });
 
         let external_id = account.values().external_id.clone();

--- a/core/accounting/src/lib.rs
+++ b/core/accounting/src/lib.rs
@@ -214,8 +214,8 @@ where
         chart_ref: &str,
         id: cala_ledger::AccountSetId,
         args: es_entity::PaginatedQueryArgs<LedgerAccountChildrenCursor>,
-        from: chrono::DateTime<chrono::Utc>,
-        until: Option<chrono::DateTime<chrono::Utc>>,
+        from: chrono::NaiveDate,
+        until: Option<chrono::NaiveDate>,
     ) -> Result<
         es_entity::PaginatedQueryRet<LedgerAccount, LedgerAccountChildrenCursor>,
         CoreAccountingError,

--- a/core/accounting/src/profit_and_loss/mod.rs
+++ b/core/accounting/src/profit_and_loss/mod.rs
@@ -2,7 +2,7 @@ mod chart_of_accounts_integration;
 pub mod error;
 pub mod ledger;
 
-use chrono::{DateTime, Utc};
+use chrono::NaiveDate;
 
 use audit::AuditSvc;
 use authz::PermissionCheck;
@@ -173,8 +173,8 @@ where
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
         reference: String,
-        from: DateTime<Utc>,
-        until: Option<DateTime<Utc>>,
+        from: NaiveDate,
+        until: Option<NaiveDate>,
     ) -> Result<ProfitAndLossStatement, ProfitAndLossStatementError> {
         self.authz
             .enforce_permission(

--- a/core/accounting/src/trial_balance/mod.rs
+++ b/core/accounting/src/trial_balance/mod.rs
@@ -1,7 +1,7 @@
 pub mod error;
 pub mod ledger;
 
-use chrono::{DateTime, Utc};
+use chrono::NaiveDate;
 
 use audit::AuditSvc;
 use authz::PermissionCheck;
@@ -105,8 +105,8 @@ where
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
         name: String,
-        from: DateTime<Utc>,
-        until: DateTime<Utc>,
+        from: NaiveDate,
+        until: NaiveDate,
     ) -> Result<TrialBalanceRoot, TrialBalanceError> {
         self.authz
             .enforce_permission(

--- a/core/accounting/tests/trial_balance.rs
+++ b/core/accounting/tests/trial_balance.rs
@@ -59,8 +59,8 @@ async fn add_chart_to_trial_balance() -> anyhow::Result<()> {
         .trial_balance(
             &DummySubject,
             trial_balance_name.to_string(),
-            Utc::now(),
-            Utc::now(),
+            Utc::now().date_naive(),
+            Utc::now().date_naive(),
         )
         .await?;
 
@@ -70,8 +70,8 @@ async fn add_chart_to_trial_balance() -> anyhow::Result<()> {
             &chart_ref,
             trial_balance.id,
             Default::default(),
-            Utc::now(),
-            Some(Utc::now()),
+            Utc::now().date_naive(),
+            Some(Utc::now().date_naive()),
         )
         .await?;
     assert_eq!(accounts.entities.len(), 0);
@@ -88,8 +88,8 @@ async fn add_chart_to_trial_balance() -> anyhow::Result<()> {
             &chart,
             trial_balance.id,
             Default::default(),
-            Utc::now(),
-            Some(Utc::now()),
+            Utc::now().date_naive(),
+            Some(Utc::now().date_naive()),
             false,
         )
         .await?;

--- a/lana/admin-server/src/graphql/accounting/trial_balance.rs
+++ b/lana/admin-server/src/graphql/accounting/trial_balance.rs
@@ -18,9 +18,9 @@ pub struct TrialBalance {
     name: String,
 
     #[graphql(skip)]
-    from: Timestamp,
+    from: Date,
     #[graphql(skip)]
-    until: Timestamp,
+    until: Date,
     #[graphql(skip)]
     entity: Arc<lana_app::trial_balance::TrialBalanceRoot>,
 }

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -1438,10 +1438,10 @@ type Query {
 	ledgerTransactionsForTemplateCode(templateCode: String!, first: Int!, after: String): LedgerTransactionConnection!
 	journalEntries(first: Int!, after: String): JournalEntryConnection!
 	generalLedgerEntries(first: Int!, after: String): GeneralLedgerEntryConnection!
-	trialBalance(from: Timestamp!, until: Timestamp!): TrialBalance!
+	trialBalance(from: Date!, until: Date!): TrialBalance!
 	chartOfAccounts: ChartOfAccounts!
-	balanceSheet(from: Timestamp!, until: Timestamp): BalanceSheet!
-	profitAndLossStatement(from: Timestamp!, until: Timestamp): ProfitAndLossStatement!
+	balanceSheet(from: Date!, until: Date): BalanceSheet!
+	profitAndLossStatement(from: Date!, until: Date): ProfitAndLossStatement!
 	realtimePrice: RealtimePrice!
 	report(id: UUID!): Report
 	reports: [Report!]!

--- a/lana/admin-server/src/graphql/schema.rs
+++ b/lana/admin-server/src/graphql/schema.rs
@@ -556,8 +556,8 @@ impl Query {
     async fn trial_balance(
         &self,
         ctx: &Context<'_>,
-        from: Timestamp,
-        until: Timestamp,
+        from: Date,
+        until: Date,
     ) -> async_graphql::Result<TrialBalance> {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         let account_summary = app
@@ -587,8 +587,8 @@ impl Query {
     async fn balance_sheet(
         &self,
         ctx: &Context<'_>,
-        from: Timestamp,
-        until: Option<Timestamp>,
+        from: Date,
+        until: Option<Date>,
     ) -> async_graphql::Result<BalanceSheet> {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         let balance_sheet = app
@@ -607,8 +607,8 @@ impl Query {
     async fn profit_and_loss_statement(
         &self,
         ctx: &Context<'_>,
-        from: Timestamp,
-        until: Option<Timestamp>,
+        from: Date,
+        until: Option<Date>,
     ) -> async_graphql::Result<ProfitAndLossStatement> {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         let profit_and_loss = app

--- a/lana/app/src/accounting_init/seed/journal.rs
+++ b/lana/app/src/accounting_init/seed/journal.rs
@@ -8,6 +8,7 @@ pub(crate) async fn init(cala: &CalaLedger) -> Result<JournalInit, AccountingIni
         .name("General Ledger")
         .description("General ledger for Lana")
         .code(LANA_JOURNAL_CODE)
+        .enable_effective_balance(true)
         .build()
         .expect("new journal");
 


### PR DESCRIPTION
`cala.balances().find_all_in_range()` is being removed from Cala and to be replaced by `cala.balances().effective().find_all_in_range()`. This change integrates these changes into Lana. This required to use Date instead of Timestamp in the relevant queries.