### PR TITLE
chore: update effective date in relevant templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
+ "sim-time",
  "sqlx",
  "strum",
  "thiserror 2.0.12",

--- a/apps/admin-panel/app/credit-facilities/collateral-update.tsx
+++ b/apps/admin-panel/app/credit-facilities/collateral-update.tsx
@@ -62,6 +62,9 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
   const [error, setError] = useState<string | null>(null)
   const [isConfirmed, setIsConfirmed] = useState<boolean>(false)
   const [newCollateral, setNewCollateral] = useState<string>("")
+  const [effectiveDate, setEffectiveDate] = useState<string>(
+    new Date().toISOString().split("T")[0],
+  )
 
   const { data: creditFacilityDetails } = useGetCreditFacilityLayoutDetailsQuery({
     variables: { id: creditFacilityId },
@@ -73,6 +76,10 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
       setError(t("form.errors.emptyCollateral"))
       return
     }
+    if (!effectiveDate) {
+      setError(t("form.errors.emptyEffectiveDate"))
+      return
+    }
     setError(null)
     try {
       const result = await updateCollateral({
@@ -80,6 +87,7 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
           input: {
             creditFacilityId,
             collateral: currencyConverter.btcToSatoshi(Number(newCollateral)),
+            effective: effectiveDate,
           },
         },
       })
@@ -109,6 +117,7 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
     reset()
     setOpenDialog(false)
     setNewCollateral("")
+    setEffectiveDate(new Date().toISOString().split("T")[0])
   }
 
   const currentCollateral =
@@ -150,6 +159,10 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
                       currency="btc"
                     />
                   }
+                />
+                <DetailItem
+                  label={t("form.labels.effectiveDate")}
+                  value={effectiveDate}
                 />
               </DetailsGroup>
               {error && <p className="text-destructive">{error}</p>}
@@ -224,6 +237,16 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
                     {t("units.btc")}
                   </div>
                 </div>
+              </div>
+              <div>
+                <Label>{t("form.labels.effectiveDate")}</Label>
+                <Input
+                  type="date"
+                  value={effectiveDate}
+                  onChange={(e) => setEffectiveDate(e.target.value)}
+                  data-testid="effective-date-input"
+                  required
+                />
               </div>
               {error && <p className="text-destructive">{error}</p>}
               <DialogFooter>

--- a/apps/admin-panel/app/credit-facilities/collateral-update.tsx
+++ b/apps/admin-panel/app/credit-facilities/collateral-update.tsx
@@ -21,7 +21,7 @@ import {
   useGetCreditFacilityLayoutDetailsQuery,
 } from "@/lib/graphql/generated"
 import { DetailItem, DetailsGroup } from "@/components/details"
-import { currencyConverter } from "@/lib/utils"
+import { currencyConverter, getCurrentLocalDate } from "@/lib/utils"
 import Balance from "@/components/balance/balance"
 import { Satoshis } from "@/types"
 
@@ -80,6 +80,7 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
           input: {
             creditFacilityId,
             collateral: currencyConverter.btcToSatoshi(Number(newCollateral)),
+            effective: getCurrentLocalDate(),
           },
         },
       })

--- a/apps/admin-panel/app/credit-facilities/collateral-update.tsx
+++ b/apps/admin-panel/app/credit-facilities/collateral-update.tsx
@@ -62,9 +62,6 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
   const [error, setError] = useState<string | null>(null)
   const [isConfirmed, setIsConfirmed] = useState<boolean>(false)
   const [newCollateral, setNewCollateral] = useState<string>("")
-  const [effectiveDate, setEffectiveDate] = useState<string>(
-    new Date().toISOString().split("T")[0],
-  )
 
   const { data: creditFacilityDetails } = useGetCreditFacilityLayoutDetailsQuery({
     variables: { id: creditFacilityId },
@@ -76,10 +73,6 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
       setError(t("form.errors.emptyCollateral"))
       return
     }
-    if (!effectiveDate) {
-      setError(t("form.errors.emptyEffectiveDate"))
-      return
-    }
     setError(null)
     try {
       const result = await updateCollateral({
@@ -87,7 +80,6 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
           input: {
             creditFacilityId,
             collateral: currencyConverter.btcToSatoshi(Number(newCollateral)),
-            effective: effectiveDate,
           },
         },
       })
@@ -117,7 +109,6 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
     reset()
     setOpenDialog(false)
     setNewCollateral("")
-    setEffectiveDate(new Date().toISOString().split("T")[0])
   }
 
   const currentCollateral =
@@ -159,10 +150,6 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
                       currency="btc"
                     />
                   }
-                />
-                <DetailItem
-                  label={t("form.labels.effectiveDate")}
-                  value={effectiveDate}
                 />
               </DetailsGroup>
               {error && <p className="text-destructive">{error}</p>}
@@ -237,16 +224,6 @@ export const CreditFacilityCollateralUpdateDialog: React.FC<
                     {t("units.btc")}
                   </div>
                 </div>
-              </div>
-              <div>
-                <Label>{t("form.labels.effectiveDate")}</Label>
-                <Input
-                  type="date"
-                  value={effectiveDate}
-                  onChange={(e) => setEffectiveDate(e.target.value)}
-                  data-testid="effective-date-input"
-                  required
-                />
               </div>
               {error && <p className="text-destructive">{error}</p>}
               <DialogFooter>

--- a/apps/admin-panel/app/credit-facilities/partial-payment.tsx
+++ b/apps/admin-panel/app/credit-facilities/partial-payment.tsx
@@ -17,6 +17,7 @@ import { Label } from "@lana/web/ui/label"
 
 import { useCreditFacilityPartialPaymentMutation } from "@/lib/graphql/generated"
 import { UsdCents } from "@/types"
+import { getCurrentLocalDate } from "@/lib/utils"
 
 gql`
   mutation CreditFacilityPartialPayment($input: CreditFacilityPartialPaymentInput!) {
@@ -67,6 +68,7 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
           input: {
             creditFacilityId,
             amount: amountInCents as UsdCents,
+            effective: getCurrentLocalDate(),
           },
         },
         onCompleted: (data) => {

--- a/apps/admin-panel/app/credit-facilities/partial-payment.tsx
+++ b/apps/admin-panel/app/credit-facilities/partial-payment.tsx
@@ -49,9 +49,6 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
     useCreditFacilityPartialPaymentMutation()
   const [error, setError] = useState<string | null>(null)
   const [amount, setAmount] = useState<string>("")
-  const [effectiveDate, setEffectiveDate] = useState<string>(
-    new Date().toISOString().split("T")[0],
-  )
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -64,18 +61,12 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
       return
     }
 
-    if (!effectiveDate) {
-      setError(t("form.errors.emptyEffectiveDate"))
-      return
-    }
-
     try {
       await partialPaymentCreditFacility({
         variables: {
           input: {
             creditFacilityId,
             amount: amountInCents as UsdCents,
-            effective: effectiveDate,
           },
         },
         onCompleted: (data) => {
@@ -99,7 +90,6 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
     setOpenDialog(false)
     setError(null)
     setAmount("")
-    setEffectiveDate(new Date().toISOString().split("T")[0])
     reset()
   }
 
@@ -124,16 +114,6 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
               />
               <div className="p-1.5 bg-input-text rounded-md px-4">USD</div>
             </div>
-          </div>
-          <div>
-            <Label>{t("form.labels.effectiveDate")}</Label>
-            <Input
-              type="date"
-              value={effectiveDate}
-              onChange={(e) => setEffectiveDate(e.target.value)}
-              data-testid="effective-date-input"
-              required
-            />
           </div>
           {error && <p className="text-destructive">{error}</p>}
           <DialogFooter>

--- a/apps/admin-panel/app/credit-facilities/partial-payment.tsx
+++ b/apps/admin-panel/app/credit-facilities/partial-payment.tsx
@@ -49,6 +49,9 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
     useCreditFacilityPartialPaymentMutation()
   const [error, setError] = useState<string | null>(null)
   const [amount, setAmount] = useState<string>("")
+  const [effectiveDate, setEffectiveDate] = useState<string>(
+    new Date().toISOString().split("T")[0],
+  )
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -61,12 +64,18 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
       return
     }
 
+    if (!effectiveDate) {
+      setError(t("form.errors.emptyEffectiveDate"))
+      return
+    }
+
     try {
       await partialPaymentCreditFacility({
         variables: {
           input: {
             creditFacilityId,
             amount: amountInCents as UsdCents,
+            effective: effectiveDate,
           },
         },
         onCompleted: (data) => {
@@ -90,6 +99,7 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
     setOpenDialog(false)
     setError(null)
     setAmount("")
+    setEffectiveDate(new Date().toISOString().split("T")[0])
     reset()
   }
 
@@ -114,6 +124,16 @@ export const CreditFacilityPartialPaymentDialog: React.FC<
               />
               <div className="p-1.5 bg-input-text rounded-md px-4">USD</div>
             </div>
+          </div>
+          <div>
+            <Label>{t("form.labels.effectiveDate")}</Label>
+            <Input
+              type="date"
+              value={effectiveDate}
+              onChange={(e) => setEffectiveDate(e.target.value)}
+              data-testid="effective-date-input"
+              required
+            />
           </div>
           {error && <p className="text-destructive">{error}</p>}
           <DialogFooter>

--- a/apps/admin-panel/i18n.lock
+++ b/apps/admin-panel/i18n.lock
@@ -333,10 +333,8 @@ checksums:
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/dialog/title: 610c610c61d2449a5461972a189996c2
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/dialog/description: fe992630f2de0995b30bd782a29b2927
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/labels/amount: a0ae9c6ff98b57475cdce56f66066aa4
-    CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/labels/effectiveDate: aab6741517742a24eb46f529ebb94bf6
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/placeholders/amount: 507198d1404b6ca44e1a61464c1f1d9d
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/errors/invalidAmount: 2890400e9920b80042fd5c85d569ad84
-    CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/errors/emptyEffectiveDate: 0bd255287327c45c2471a2944a2f1ba5
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/errors/unknownError: 4fa139b42a7b7ed262b07bdda7cd2fb6
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/buttons/cancel: 2e2a849c2223911717de8caa2c71bade
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/buttons/processPayment: abca531a8db82a8f8fc7bbab1d98c29e
@@ -348,10 +346,8 @@ checksums:
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/currentCollateral: b9e9264beabb2b884ef5ea3344948761
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/expectedCollateral: fa16306942fdf5d5c5272dd68e990431
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/newCollateral: af7d8fad03fdaf033d91af006023b448
-    CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/effectiveDate: aab6741517742a24eb46f529ebb94bf6
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/placeholders/newCollateral: f0e3c4e71940d3395ff6ea0e33ac2e53
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/emptyCollateral: 6c7f877740d8d99c8ab2fc936f13b360
-    CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/emptyEffectiveDate: 0bd255287327c45c2471a2944a2f1ba5
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/noData: 15bbd3de8bd8d4529675467807b4427b
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/unknownError: 4fa139b42a7b7ed262b07bdda7cd2fb6
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/buttons/back: f541015a827e37cb3b1234e56bc2aa3c

--- a/apps/admin-panel/i18n.lock
+++ b/apps/admin-panel/i18n.lock
@@ -333,8 +333,10 @@ checksums:
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/dialog/title: 610c610c61d2449a5461972a189996c2
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/dialog/description: fe992630f2de0995b30bd782a29b2927
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/labels/amount: a0ae9c6ff98b57475cdce56f66066aa4
+    CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/labels/effectiveDate: aab6741517742a24eb46f529ebb94bf6
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/placeholders/amount: 507198d1404b6ca44e1a61464c1f1d9d
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/errors/invalidAmount: 2890400e9920b80042fd5c85d569ad84
+    CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/errors/emptyEffectiveDate: 0bd255287327c45c2471a2944a2f1ba5
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/errors/unknownError: 4fa139b42a7b7ed262b07bdda7cd2fb6
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/buttons/cancel: 2e2a849c2223911717de8caa2c71bade
     CreditFacilities/CreditFacilityDetails/CreditFacilityPartialPayment/form/buttons/processPayment: abca531a8db82a8f8fc7bbab1d98c29e
@@ -346,8 +348,10 @@ checksums:
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/currentCollateral: b9e9264beabb2b884ef5ea3344948761
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/expectedCollateral: fa16306942fdf5d5c5272dd68e990431
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/newCollateral: af7d8fad03fdaf033d91af006023b448
+    CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/labels/effectiveDate: aab6741517742a24eb46f529ebb94bf6
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/placeholders/newCollateral: f0e3c4e71940d3395ff6ea0e33ac2e53
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/emptyCollateral: 6c7f877740d8d99c8ab2fc936f13b360
+    CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/emptyEffectiveDate: 0bd255287327c45c2471a2944a2f1ba5
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/noData: 15bbd3de8bd8d4529675467807b4427b
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/errors/unknownError: 4fa139b42a7b7ed262b07bdda7cd2fb6
     CreditFacilities/CreditFacilityDetails/CreditFacilityCollateralUpdate/form/buttons/back: f541015a827e37cb3b1234e56bc2aa3c

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -426,7 +426,6 @@ export type CreditFacilityBalance = {
 export type CreditFacilityCollateralUpdateInput = {
   collateral: Scalars['Satoshis']['input'];
   creditFacilityId: Scalars['UUID']['input'];
-  effective: Scalars['Date']['input'];
 };
 
 export type CreditFacilityCollateralUpdatePayload = {
@@ -566,7 +565,6 @@ export type CreditFacilityOrigination = {
 export type CreditFacilityPartialPaymentInput = {
   amount: Scalars['UsdCents']['input'];
   creditFacilityId: Scalars['UUID']['input'];
-  effective: Scalars['Date']['input'];
 };
 
 export type CreditFacilityPartialPaymentPayload = {

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -426,6 +426,7 @@ export type CreditFacilityBalance = {
 export type CreditFacilityCollateralUpdateInput = {
   collateral: Scalars['Satoshis']['input'];
   creditFacilityId: Scalars['UUID']['input'];
+  effective: Scalars['Date']['input'];
 };
 
 export type CreditFacilityCollateralUpdatePayload = {
@@ -565,6 +566,7 @@ export type CreditFacilityOrigination = {
 export type CreditFacilityPartialPaymentInput = {
   amount: Scalars['UsdCents']['input'];
   creditFacilityId: Scalars['UUID']['input'];
+  effective: Scalars['Date']['input'];
 };
 
 export type CreditFacilityPartialPaymentPayload = {

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -561,7 +561,6 @@ export const mockCreditFacilityCollateralUpdateInput = (overrides?: Partial<Cred
     return {
         collateral: overrides && overrides.hasOwnProperty('collateral') ? overrides.collateral! : generateMockValue.satoshis(),
         creditFacilityId: overrides && overrides.hasOwnProperty('creditFacilityId') ? overrides.creditFacilityId! : generateMockValue.uuid(),
-        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : faker.date.past({ years: 1, refDate: new Date(2022, 0) }).toISOString(),
     };
 };
 
@@ -763,7 +762,6 @@ export const mockCreditFacilityPartialPaymentInput = (overrides?: Partial<Credit
     return {
         amount: overrides && overrides.hasOwnProperty('amount') ? overrides.amount! : generateMockValue.usdCents(),
         creditFacilityId: overrides && overrides.hasOwnProperty('creditFacilityId') ? overrides.creditFacilityId! : generateMockValue.uuid(),
-        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : faker.date.past({ years: 1, refDate: new Date(2022, 0) }).toISOString(),
     };
 };
 

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -561,6 +561,7 @@ export const mockCreditFacilityCollateralUpdateInput = (overrides?: Partial<Cred
     return {
         collateral: overrides && overrides.hasOwnProperty('collateral') ? overrides.collateral! : generateMockValue.satoshis(),
         creditFacilityId: overrides && overrides.hasOwnProperty('creditFacilityId') ? overrides.creditFacilityId! : generateMockValue.uuid(),
+        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : faker.date.past({ years: 1, refDate: new Date(2022, 0) }).toISOString(),
     };
 };
 
@@ -762,6 +763,7 @@ export const mockCreditFacilityPartialPaymentInput = (overrides?: Partial<Credit
     return {
         amount: overrides && overrides.hasOwnProperty('amount') ? overrides.amount! : generateMockValue.usdCents(),
         creditFacilityId: overrides && overrides.hasOwnProperty('creditFacilityId') ? overrides.creditFacilityId! : generateMockValue.uuid(),
+        effective: overrides && overrides.hasOwnProperty('effective') ? overrides.effective! : faker.date.past({ years: 1, refDate: new Date(2022, 0) }).toISOString(),
     };
 };
 

--- a/apps/admin-panel/lib/utils.ts
+++ b/apps/admin-panel/lib/utils.ts
@@ -185,3 +185,9 @@ export const removeUnderscore = (str: string | undefined) => {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ")
 }
+
+export const getCurrentLocalDate = (): string => {
+  const now = new Date()
+  const offset = now.getTimezoneOffset() * 60000
+  return new Date(now.getTime() - offset).toISOString().split("T")[0]
+}

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -523,13 +523,15 @@
         },
         "form": {
           "labels": {
-            "amount": "Amount"
+            "amount": "Amount",
+            "effectiveDate": "Effective Date"
           },
           "placeholders": {
             "amount": "Enter the desired principal amount"
           },
           "errors": {
             "invalidAmount": "Please enter a valid amount",
+            "emptyEffectiveDate": "Please select an effective date",
             "unknownError": "An unknown error occurred"
           },
           "buttons": {
@@ -552,13 +554,15 @@
           "labels": {
             "currentCollateral": "Current Collateral",
             "expectedCollateral": "Expected Collateral",
-            "newCollateral": "New Collateral"
+            "newCollateral": "New Collateral",
+            "effectiveDate": "Effective Date"
           },
           "placeholders": {
             "newCollateral": "Enter new collateral amount"
           },
           "errors": {
             "emptyCollateral": "Please enter a valid collateral amount.",
+            "emptyEffectiveDate": "Please select an effective date",
             "noData": "No data returned from mutation",
             "unknownError": "An unknown error occurred"
           },

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -523,15 +523,13 @@
         },
         "form": {
           "labels": {
-            "amount": "Amount",
-            "effectiveDate": "Effective Date"
+            "amount": "Amount"
           },
           "placeholders": {
             "amount": "Enter the desired principal amount"
           },
           "errors": {
             "invalidAmount": "Please enter a valid amount",
-            "emptyEffectiveDate": "Please select an effective date",
             "unknownError": "An unknown error occurred"
           },
           "buttons": {
@@ -554,15 +552,13 @@
           "labels": {
             "currentCollateral": "Current Collateral",
             "expectedCollateral": "Expected Collateral",
-            "newCollateral": "New Collateral",
-            "effectiveDate": "Effective Date"
+            "newCollateral": "New Collateral"
           },
           "placeholders": {
             "newCollateral": "Enter new collateral amount"
           },
           "errors": {
             "emptyCollateral": "Please enter a valid collateral amount.",
-            "emptyEffectiveDate": "Please select an effective date",
             "noData": "No data returned from mutation",
             "unknownError": "An unknown error occurred"
           },

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -523,13 +523,15 @@
         },
         "form": {
           "labels": {
-            "amount": "Monto"
+            "amount": "Monto",
+            "effectiveDate": "Fecha Efectiva"
           },
           "placeholders": {
             "amount": "Ingrese el monto principal deseado"
           },
           "errors": {
             "invalidAmount": "Por favor ingrese un monto válido",
+            "emptyEffectiveDate": "Por favor seleccione una fecha efectiva",
             "unknownError": "Ocurrió un error desconocido"
           },
           "buttons": {
@@ -552,13 +554,15 @@
           "labels": {
             "currentCollateral": "Garantía Actual",
             "expectedCollateral": "Garantía Esperada",
-            "newCollateral": "Nueva Garantía"
+            "newCollateral": "Nueva Garantía",
+            "effectiveDate": "Fecha Efectiva"
           },
           "placeholders": {
             "newCollateral": "Ingrese nuevo monto de garantía"
           },
           "errors": {
             "emptyCollateral": "Por favor ingrese un monto de garantía válido.",
+            "emptyEffectiveDate": "Por favor seleccione una fecha efectiva",
             "noData": "No se devolvieron datos de la mutación",
             "unknownError": "Ocurrió un error desconocido"
           },

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -523,15 +523,13 @@
         },
         "form": {
           "labels": {
-            "amount": "Monto",
-            "effectiveDate": "Fecha Efectiva"
+            "amount": "Monto"
           },
           "placeholders": {
             "amount": "Ingrese el monto principal deseado"
           },
           "errors": {
             "invalidAmount": "Por favor ingrese un monto válido",
-            "emptyEffectiveDate": "Por favor seleccione una fecha efectiva",
             "unknownError": "Ocurrió un error desconocido"
           },
           "buttons": {
@@ -554,15 +552,13 @@
           "labels": {
             "currentCollateral": "Garantía Actual",
             "expectedCollateral": "Garantía Esperada",
-            "newCollateral": "Nueva Garantía",
-            "effectiveDate": "Fecha Efectiva"
+            "newCollateral": "Nueva Garantía"
           },
           "placeholders": {
             "newCollateral": "Ingrese nuevo monto de garantía"
           },
           "errors": {
             "emptyCollateral": "Por favor ingrese un monto de garantía válido.",
-            "emptyEffectiveDate": "Por favor seleccione una fecha efectiva",
             "noData": "No se devolvieron datos de la mutación",
             "unknownError": "Ocurrió un error desconocido"
           },

--- a/bats/credit-facility.bats
+++ b/bats/credit-facility.bats
@@ -261,11 +261,13 @@ ymd() {
   variables=$(
     jq -n \
       --arg creditFacilityId "$credit_facility_id" \
+      --arg effective "$(naive_now)" \
       --argjson amount "$amount" \
     '{
       input: {
         creditFacilityId: $creditFacilityId,
         amount: $amount,
+        effective: $effective,
       }
     }'
   )

--- a/bats/credit-facility.bats
+++ b/bats/credit-facility.bats
@@ -158,10 +158,12 @@ ymd() {
   variables=$(
     jq -n \
       --arg credit_facility_id "$credit_facility_id" \
+      --arg effective "$(naive_now)" \
     '{
       input: {
         creditFacilityId: $credit_facility_id,
         collateral: 50000000,
+        effective: $effective,
       }
     }'
   )

--- a/bats/dashboard.bats
+++ b/bats/dashboard.bats
@@ -78,10 +78,12 @@ wait_for_total_disbursed() {
   variables=$(
     jq -n \
       --arg credit_facility_id "$credit_facility_id" \
+      --arg effective "$(naive_now)" \
     '{
       input: {
         creditFacilityId: $credit_facility_id,
         collateral: 50000000,
+        effective: $effective,
       }
     }'
 

--- a/bats/helpers.bash
+++ b/bats/helpers.bash
@@ -352,6 +352,9 @@ from_utc() {
   date -u -d @0 +"%Y-%m-%dT%H:%M:%S.%3NZ"
 }
 
+naive_now() {
+  date +"%Y-%m-%d"
+}
 
 wait_for_checking_account() {
   customer_id=$1

--- a/core/credit/src/collateral/entity.rs
+++ b/core/credit/src/collateral/entity.rs
@@ -51,6 +51,7 @@ impl Collateral {
     pub fn record_collateral_update(
         &mut self,
         new_amount: Satoshis,
+        effective: chrono::NaiveDate,
         audit_info: &AuditInfo,
     ) -> Idempotent<CollateralUpdate> {
         let current = self.amount;
@@ -77,6 +78,7 @@ impl Collateral {
             tx_id,
             abs_diff,
             action,
+            effective,
         })
     }
 }

--- a/core/credit/src/jobs/obligation_defaulted.rs
+++ b/core/credit/src/jobs/obligation_defaulted.rs
@@ -11,6 +11,7 @@ use crate::{event::CoreCreditEvent, ledger::CreditLedger, obligation::Obligation
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CreditFacilityJobConfig<Perms, E> {
     pub obligation_id: ObligationId,
+    pub effective: chrono::NaiveDate,
     pub _phantom: std::marker::PhantomData<(Perms, E)>,
 }
 impl<Perms, E> JobConfig for CreditFacilityJobConfig<Perms, E>
@@ -117,7 +118,7 @@ where
             .await?;
 
         let defaulted = if let es_entity::Idempotent::Executed(defaulted) =
-            obligation.record_defaulted(audit_info)?
+            obligation.record_defaulted(self.config.effective, audit_info)?
         {
             defaulted
         } else {

--- a/core/credit/src/jobs/obligation_overdue.rs
+++ b/core/credit/src/jobs/obligation_overdue.rs
@@ -13,6 +13,7 @@ use super::obligation_defaulted;
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CreditFacilityJobConfig<Perms, E> {
     pub obligation_id: ObligationId,
+    pub effective: chrono::NaiveDate,
     pub _phantom: std::marker::PhantomData<(Perms, E)>,
 }
 impl<Perms, E> JobConfig for CreditFacilityJobConfig<Perms, E>
@@ -124,7 +125,7 @@ where
             .await?;
 
         let overdue = if let es_entity::Idempotent::Executed(overdue) =
-            obligation.record_overdue(audit_info)?
+            obligation.record_overdue(self.config.effective, audit_info)?
         {
             overdue
         } else {
@@ -142,6 +143,7 @@ where
                     JobId::new(),
                     obligation_defaulted::CreditFacilityJobConfig::<Perms, E> {
                         obligation_id: obligation.id,
+                        effective: defaulted_at.date_naive(),
                         _phantom: std::marker::PhantomData,
                     },
                     defaulted_at,

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -1180,6 +1180,7 @@ impl CreditLedger {
             amount: outstanding_amount,
             not_yet_due_account_id,
             due_account_id,
+            effective,
             ..
         }: ObligationDueReallocationData,
     ) -> Result<(), CreditLedgerError> {
@@ -1194,6 +1195,7 @@ impl CreditLedger {
                     amount: outstanding_amount.to_usd(),
                     receivable_not_yet_due_account_id: not_yet_due_account_id,
                     receivable_due_account_id: due_account_id,
+                    effective,
                 },
             )
             .await?;
@@ -1209,6 +1211,7 @@ impl CreditLedger {
             amount: outstanding_amount,
             due_account_id,
             overdue_account_id,
+            effective,
             ..
         }: ObligationOverdueReallocationData,
     ) -> Result<(), CreditLedgerError> {
@@ -1223,6 +1226,7 @@ impl CreditLedger {
                     amount: outstanding_amount.to_usd(),
                     receivable_due_account_id: due_account_id,
                     receivable_overdue_account_id: overdue_account_id,
+                    effective,
                 },
             )
             .await?;
@@ -1238,6 +1242,7 @@ impl CreditLedger {
             amount: outstanding_amount,
             receivable_account_id,
             defaulted_account_id,
+            effective,
             ..
         }: ObligationDefaultedReallocationData,
     ) -> Result<(), CreditLedgerError> {
@@ -1252,6 +1257,7 @@ impl CreditLedger {
                     amount: outstanding_amount.to_usd(),
                     receivable_account_id,
                     defaulted_account_id,
+                    effective,
                 },
             )
             .await?;

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -1073,6 +1073,7 @@ impl CreditLedger {
             tx_id,
             abs_diff,
             action,
+            effective,
         }: CollateralUpdate,
         credit_facility_account_ids: CreditFacilityAccountIds,
     ) -> Result<(), CreditLedgerError> {
@@ -1093,6 +1094,7 @@ impl CreditLedger {
                             bank_collateral_account_id: self
                                 .collateral_omnibus_account_ids
                                 .account_id,
+                            effective,
                         },
                     )
                     .await
@@ -1112,6 +1114,7 @@ impl CreditLedger {
                             bank_collateral_account_id: self
                                 .collateral_omnibus_account_ids
                                 .account_id,
+                            effective,
                         },
                     )
                     .await
@@ -1277,6 +1280,7 @@ impl CreditLedger {
                     amount: collateral.to_btc(),
                     collateral_account_id: credit_facility_account_ids.collateral_account_id,
                     bank_collateral_account_id: self.collateral_omnibus_account_ids.account_id,
+                    effective: crate::time::now().date_naive(),
                 },
             )
             .await?;

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -1133,6 +1133,7 @@ impl CreditLedger {
             amount,
             account_to_be_debited_id,
             receivable_account_id,
+            effective,
             ..
         }: PaymentAllocation,
     ) -> Result<(), CreditLedgerError> {
@@ -1143,6 +1144,7 @@ impl CreditLedger {
             receivable_account_id,
             account_to_be_debited_id,
             tx_ref: tx_ref.to_string(),
+            effective,
         };
         self.cala
             .post_transaction_in_op(

--- a/core/credit/src/ledger/templates/activate_credit_facility.rs
+++ b/core/credit/src/ledger/templates/activate_credit_facility.rs
@@ -115,7 +115,7 @@ impl From<ActivateCreditFacilityParams> for Params {
         params.insert("structuring_fee_amount", structuring_fee_amount);
         params.insert("currency", currency);
         params.insert("external_id", external_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
         params
     }
 }

--- a/core/credit/src/ledger/templates/add_collateral.rs
+++ b/core/credit/src/ledger/templates/add_collateral.rs
@@ -17,6 +17,7 @@ pub struct AddCollateralParams {
     pub amount: Decimal,
     pub collateral_account_id: CalaAccountId,
     pub bank_collateral_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 impl AddCollateralParams {
@@ -64,6 +65,7 @@ impl From<AddCollateralParams> for Params {
             amount,
             collateral_account_id,
             bank_collateral_account_id,
+            effective,
         }: AddCollateralParams,
     ) -> Self {
         let mut params = Self::default();
@@ -72,7 +74,7 @@ impl From<AddCollateralParams> for Params {
         params.insert("amount", amount);
         params.insert("collateral_account_id", collateral_account_id);
         params.insert("bank_collateral_account_id", bank_collateral_account_id);
-        params.insert("effective", crate::time::now().date_naive());
+        params.insert("effective", effective);
 
         params
     }

--- a/core/credit/src/ledger/templates/add_collateral.rs
+++ b/core/credit/src/ledger/templates/add_collateral.rs
@@ -72,7 +72,7 @@ impl From<AddCollateralParams> for Params {
         params.insert("amount", amount);
         params.insert("collateral_account_id", collateral_account_id);
         params.insert("bank_collateral_account_id", bank_collateral_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/credit/src/ledger/templates/cancel_disbursal.rs
+++ b/core/credit/src/ledger/templates/cancel_disbursal.rs
@@ -63,7 +63,7 @@ impl From<CancelDisbursalParams> for Params {
         params.insert("credit_omnibus_account", credit_omnibus_account);
         params.insert("credit_facility_account", credit_facility_account);
         params.insert("disbursed_amount", disbursed_amount);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
         params
     }
 }

--- a/core/credit/src/ledger/templates/confirm_disbursal.rs
+++ b/core/credit/src/ledger/templates/confirm_disbursal.rs
@@ -90,7 +90,7 @@ impl From<ConfirmDisbursalParams> for Params {
         params.insert("account_to_be_credited_id", account_to_be_credited_id);
         params.insert("disbursed_amount", disbursed_amount);
         params.insert("external_id", external_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
         params
     }
 }

--- a/core/credit/src/ledger/templates/create_credit_facility.rs
+++ b/core/credit/src/ledger/templates/create_credit_facility.rs
@@ -80,7 +80,7 @@ impl From<CreateCreditFacilityParams> for Params {
         params.insert("facility_amount", facility_amount);
         params.insert("currency", currency);
         params.insert("external_id", external_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
         params
     }
 }

--- a/core/credit/src/ledger/templates/initiate_disbursal.rs
+++ b/core/credit/src/ledger/templates/initiate_disbursal.rs
@@ -64,7 +64,7 @@ impl From<InitiateDisbursalParams> for Params {
         params.insert("credit_omnibus_account", credit_omnibus_account);
         params.insert("credit_facility_account", credit_facility_account);
         params.insert("disbursed_amount", disbursed_amount);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
         params
     }
 }

--- a/core/credit/src/ledger/templates/obligation_defaulted_balance.rs
+++ b/core/credit/src/ledger/templates/obligation_defaulted_balance.rs
@@ -63,7 +63,7 @@ impl From<RecordObligationDefaultedBalanceParams> for Params {
         params.insert("amount", amount);
         params.insert("receivable_account_id", receivable_account_id);
         params.insert("defaulted_account_id", defaulted_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/credit/src/ledger/templates/obligation_defaulted_balance.rs
+++ b/core/credit/src/ledger/templates/obligation_defaulted_balance.rs
@@ -16,6 +16,7 @@ pub struct RecordObligationDefaultedBalanceParams {
     pub amount: Decimal,
     pub receivable_account_id: CalaAccountId,
     pub defaulted_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 impl RecordObligationDefaultedBalanceParams {
@@ -56,6 +57,7 @@ impl From<RecordObligationDefaultedBalanceParams> for Params {
             amount,
             receivable_account_id,
             defaulted_account_id,
+            effective,
         }: RecordObligationDefaultedBalanceParams,
     ) -> Self {
         let mut params = Self::default();
@@ -63,7 +65,7 @@ impl From<RecordObligationDefaultedBalanceParams> for Params {
         params.insert("amount", amount);
         params.insert("receivable_account_id", receivable_account_id);
         params.insert("defaulted_account_id", defaulted_account_id);
-        params.insert("effective", crate::time::now().date_naive());
+        params.insert("effective", effective);
 
         params
     }

--- a/core/credit/src/ledger/templates/obligation_due_balance.rs
+++ b/core/credit/src/ledger/templates/obligation_due_balance.rs
@@ -66,7 +66,7 @@ impl From<RecordObligationDueBalanceParams> for Params {
             receivable_not_yet_due_account_id,
         );
         params.insert("receivable_due_account_id", receivable_due_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/credit/src/ledger/templates/obligation_due_balance.rs
+++ b/core/credit/src/ledger/templates/obligation_due_balance.rs
@@ -16,6 +16,7 @@ pub struct RecordObligationDueBalanceParams {
     pub amount: Decimal,
     pub receivable_not_yet_due_account_id: CalaAccountId,
     pub receivable_due_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 impl RecordObligationDueBalanceParams {
@@ -56,6 +57,7 @@ impl From<RecordObligationDueBalanceParams> for Params {
             amount,
             receivable_not_yet_due_account_id,
             receivable_due_account_id,
+            effective,
         }: RecordObligationDueBalanceParams,
     ) -> Self {
         let mut params = Self::default();
@@ -66,7 +68,7 @@ impl From<RecordObligationDueBalanceParams> for Params {
             receivable_not_yet_due_account_id,
         );
         params.insert("receivable_due_account_id", receivable_due_account_id);
-        params.insert("effective", crate::time::now().date_naive());
+        params.insert("effective", effective);
 
         params
     }

--- a/core/credit/src/ledger/templates/obligation_overdue_balance.rs
+++ b/core/credit/src/ledger/templates/obligation_overdue_balance.rs
@@ -16,6 +16,7 @@ pub struct RecordObligationOverdueBalanceParams {
     pub amount: Decimal,
     pub receivable_due_account_id: CalaAccountId,
     pub receivable_overdue_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 impl RecordObligationOverdueBalanceParams {
@@ -56,6 +57,7 @@ impl From<RecordObligationOverdueBalanceParams> for Params {
             amount,
             receivable_due_account_id,
             receivable_overdue_account_id,
+            effective,
         }: RecordObligationOverdueBalanceParams,
     ) -> Self {
         let mut params = Self::default();
@@ -66,7 +68,7 @@ impl From<RecordObligationOverdueBalanceParams> for Params {
             "receivable_overdue_account_id",
             receivable_overdue_account_id,
         );
-        params.insert("effective", crate::time::now().date_naive());
+        params.insert("effective", effective);
 
         params
     }

--- a/core/credit/src/ledger/templates/obligation_overdue_balance.rs
+++ b/core/credit/src/ledger/templates/obligation_overdue_balance.rs
@@ -66,7 +66,7 @@ impl From<RecordObligationOverdueBalanceParams> for Params {
             "receivable_overdue_account_id",
             receivable_overdue_account_id,
         );
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/credit/src/ledger/templates/payment_allocation.rs
+++ b/core/credit/src/ledger/templates/payment_allocation.rs
@@ -79,7 +79,7 @@ impl From<RecordPaymentAllocationParams> for Params {
         params.insert("amount", amount);
         params.insert("account_to_be_debited_id", account_to_be_debited_id);
         params.insert("receivable_account_id", receivable_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/credit/src/ledger/templates/payment_allocation.rs
+++ b/core/credit/src/ledger/templates/payment_allocation.rs
@@ -18,6 +18,7 @@ pub struct RecordPaymentAllocationParams {
     pub account_to_be_debited_id: CalaAccountId,
     pub receivable_account_id: CalaAccountId,
     pub tx_ref: String,
+    pub effective: chrono::NaiveDate,
 }
 
 impl RecordPaymentAllocationParams {
@@ -70,6 +71,7 @@ impl From<RecordPaymentAllocationParams> for Params {
             account_to_be_debited_id,
             receivable_account_id,
             tx_ref,
+            effective,
         }: RecordPaymentAllocationParams,
     ) -> Self {
         let mut params = Self::default();
@@ -79,7 +81,7 @@ impl From<RecordPaymentAllocationParams> for Params {
         params.insert("amount", amount);
         params.insert("account_to_be_debited_id", account_to_be_debited_id);
         params.insert("receivable_account_id", receivable_account_id);
-        params.insert("effective", crate::time::now().date_naive());
+        params.insert("effective", effective);
 
         params
     }

--- a/core/credit/src/ledger/templates/remove_collateral.rs
+++ b/core/credit/src/ledger/templates/remove_collateral.rs
@@ -72,7 +72,7 @@ impl From<RemoveCollateralParams> for Params {
         params.insert("amount", amount);
         params.insert("collateral_account_id", collateral_account_id);
         params.insert("bank_collateral_account_id", bank_collateral_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/credit/src/ledger/templates/remove_collateral.rs
+++ b/core/credit/src/ledger/templates/remove_collateral.rs
@@ -17,6 +17,7 @@ pub struct RemoveCollateralParams {
     pub amount: Decimal,
     pub collateral_account_id: CalaAccountId,
     pub bank_collateral_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 impl RemoveCollateralParams {
@@ -64,6 +65,7 @@ impl From<RemoveCollateralParams> for Params {
             amount,
             collateral_account_id,
             bank_collateral_account_id,
+            effective,
         }: RemoveCollateralParams,
     ) -> Self {
         let mut params = Self::default();
@@ -72,7 +74,7 @@ impl From<RemoveCollateralParams> for Params {
         params.insert("amount", amount);
         params.insert("collateral_account_id", collateral_account_id);
         params.insert("bank_collateral_account_id", bank_collateral_account_id);
-        params.insert("effective", crate::time::now().date_naive());
+        params.insert("effective", effective);
 
         params
     }

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -679,9 +679,13 @@ where
     pub async fn update_collateral(
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
-        credit_facility_id: CreditFacilityId,
+        credit_facility_id: impl Into<CreditFacilityId> + std::fmt::Debug + Copy,
         updated_collateral: Satoshis,
+        effective: impl Into<chrono::NaiveDate> + std::fmt::Debug + Copy,
     ) -> Result<CreditFacility, CoreCreditError> {
+        let credit_facility_id = credit_facility_id.into();
+        let effective = effective.into();
+
         let audit_info = self
             .subject_can_update_collateral(sub, true)
             .await?
@@ -698,7 +702,7 @@ where
             .await?;
 
         let collateral_update =
-            match collateral.record_collateral_update(updated_collateral, &audit_info) {
+            match collateral.record_collateral_update(updated_collateral, effective, &audit_info) {
                 Idempotent::Executed(update) => update,
                 Idempotent::Ignored => {
                     return Ok(credit_facility);
@@ -1015,7 +1019,11 @@ where
             .collaterals()
             .find_by_id(credit_facility.collateral_id)
             .await?;
-        let _ = collateral.record_collateral_update(Satoshis::ZERO, &audit_info);
+        let _ = collateral.record_collateral_update(
+            Satoshis::ZERO,
+            crate::time::now().date_naive(),
+            &audit_info,
+        );
         let mut db = self.credit_facility_repo.begin_op().await?;
         self.collaterals()
             .update_in_op(&mut db, &mut collateral)

--- a/core/credit/src/obligation/entity.rs
+++ b/core/credit/src/obligation/entity.rs
@@ -385,6 +385,7 @@ impl Obligation {
         &mut self,
         amount: UsdCents,
         payment_id: PaymentId,
+        effective: chrono::NaiveDate,
         audit_info: &AuditInfo,
     ) -> Idempotent<Option<NewPaymentAllocation>> {
         idempotency_guard!(
@@ -418,6 +419,7 @@ impl Obligation {
                 self.account_to_be_credited_id()
                     .expect("Obligation was already paid"),
             )
+            .effective(effective)
             .amount(payment_amount)
             .audit_info(audit_info.clone())
             .build()

--- a/core/credit/src/obligation/entity.rs
+++ b/core/credit/src/obligation/entity.rs
@@ -282,6 +282,7 @@ impl Obligation {
 
     pub(crate) fn record_due(
         &mut self,
+        effective: chrono::NaiveDate,
         audit_info: AuditInfo,
     ) -> Idempotent<ObligationDueReallocationData> {
         idempotency_guard!(
@@ -299,6 +300,7 @@ impl Obligation {
             amount: self.outstanding(),
             not_yet_due_account_id: self.not_yet_due_accounts().receivable_account_id,
             due_account_id: self.due_accounts().receivable_account_id,
+            effective,
         };
 
         self.events.push(ObligationEvent::DueRecorded {
@@ -312,6 +314,7 @@ impl Obligation {
 
     pub(crate) fn record_overdue(
         &mut self,
+        effective: chrono::NaiveDate,
         audit_info: AuditInfo,
     ) -> Result<Idempotent<ObligationOverdueReallocationData>, ObligationError> {
         idempotency_guard!(
@@ -332,6 +335,7 @@ impl Obligation {
             amount: self.outstanding(),
             due_account_id: self.due_accounts().receivable_account_id,
             overdue_account_id: self.overdue_accounts().receivable_account_id,
+            effective,
         };
 
         self.events.push(ObligationEvent::OverdueRecorded {
@@ -345,6 +349,7 @@ impl Obligation {
 
     pub(crate) fn record_defaulted(
         &mut self,
+        effective: chrono::NaiveDate,
         audit_info: AuditInfo,
     ) -> Result<Idempotent<ObligationDefaultedReallocationData>, ObligationError> {
         idempotency_guard!(
@@ -365,6 +370,7 @@ impl Obligation {
             amount: self.outstanding(),
             receivable_account_id: self.receivable_account_id().expect("Obligation is Paid"),
             defaulted_account_id: self.defaulted_account(),
+            effective,
         };
 
         self.events.push(ObligationEvent::DefaultedRecorded {
@@ -593,27 +599,29 @@ mod test {
     #[test]
     fn can_record_due() {
         let mut obligation = obligation_from(initial_events());
-        let res = obligation.record_due(dummy_audit_info()).unwrap();
+        let res = obligation
+            .record_due(Utc::now().date_naive(), dummy_audit_info())
+            .unwrap();
         assert_eq!(res.amount, obligation.initial_amount);
     }
 
     #[test]
     fn ignores_due_recorded_if_after_not_yet_due() {
         let mut obligation = obligation_from(initial_events());
-        let _ = obligation.record_due(dummy_audit_info());
+        let _ = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
 
         assert!(obligation
-            .record_overdue(dummy_audit_info())
+            .record_overdue(Utc::now().date_naive(), dummy_audit_info())
             .unwrap()
             .did_execute());
-        let res = obligation.record_due(dummy_audit_info());
+        let res = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
         assert!(matches!(res, Idempotent::Ignored));
 
         assert!(obligation
-            .record_defaulted(dummy_audit_info())
+            .record_defaulted(Utc::now().date_naive(), dummy_audit_info())
             .unwrap()
             .did_execute());
-        let res = obligation.record_due(dummy_audit_info());
+        let res = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
         assert!(matches!(res, Idempotent::Ignored));
 
         let mut events = initial_events();
@@ -623,16 +631,16 @@ mod test {
         });
         let mut obligation = obligation_from(events);
 
-        let res = obligation.record_due(dummy_audit_info());
+        let res = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
         assert!(matches!(res, Idempotent::Ignored));
     }
 
     #[test]
     fn can_record_overdue() {
         let mut obligation = obligation_from(initial_events());
-        let _ = obligation.record_due(dummy_audit_info());
+        let _ = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
         let res = obligation
-            .record_overdue(dummy_audit_info())
+            .record_overdue(Utc::now().date_naive(), dummy_audit_info())
             .unwrap()
             .unwrap();
         assert_eq!(res.amount, obligation.initial_amount);
@@ -641,9 +649,11 @@ mod test {
     #[test]
     fn ignores_overdue_recorded_if_after_due() {
         let mut obligation = obligation_from(initial_events());
-        let _ = obligation.record_due(dummy_audit_info());
-        let _ = obligation.record_defaulted(dummy_audit_info());
-        let res = obligation.record_overdue(dummy_audit_info()).unwrap();
+        let _ = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
+        let _ = obligation.record_defaulted(Utc::now().date_naive(), dummy_audit_info());
+        let res = obligation
+            .record_overdue(Utc::now().date_naive(), dummy_audit_info())
+            .unwrap();
         assert!(matches!(res, Idempotent::Ignored));
 
         let mut events = initial_events();
@@ -652,14 +662,16 @@ mod test {
             audit_info: dummy_audit_info(),
         });
         let mut obligation = obligation_from(events);
-        let res = obligation.record_overdue(dummy_audit_info()).unwrap();
+        let res = obligation
+            .record_overdue(Utc::now().date_naive(), dummy_audit_info())
+            .unwrap();
         assert!(matches!(res, Idempotent::Ignored));
     }
 
     #[test]
     fn errors_if_overdue_recorded_before_due() {
         let mut obligation = obligation_from(initial_events());
-        let res = obligation.record_overdue(dummy_audit_info());
+        let res = obligation.record_overdue(Utc::now().date_naive(), dummy_audit_info());
         assert!(matches!(
             res,
             Err(ObligationError::InvalidStatusTransitionToOverdue)
@@ -669,18 +681,18 @@ mod test {
     #[test]
     fn can_record_defaulted() {
         let mut obligation = obligation_from(initial_events());
-        let _ = obligation.record_due(dummy_audit_info());
+        let _ = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
         let res = obligation
-            .record_defaulted(dummy_audit_info())
+            .record_defaulted(Utc::now().date_naive(), dummy_audit_info())
             .unwrap()
             .unwrap();
         assert_eq!(res.amount, obligation.initial_amount);
 
         let mut obligation = obligation_from(initial_events());
-        let _ = obligation.record_due(dummy_audit_info());
-        let _ = obligation.record_overdue(dummy_audit_info());
+        let _ = obligation.record_due(Utc::now().date_naive(), dummy_audit_info());
+        let _ = obligation.record_overdue(Utc::now().date_naive(), dummy_audit_info());
         let res = obligation
-            .record_defaulted(dummy_audit_info())
+            .record_defaulted(Utc::now().date_naive(), dummy_audit_info())
             .unwrap()
             .unwrap();
         assert_eq!(res.amount, obligation.initial_amount);
@@ -694,14 +706,16 @@ mod test {
             audit_info: dummy_audit_info(),
         });
         let mut obligation = obligation_from(events);
-        let res = obligation.record_defaulted(dummy_audit_info()).unwrap();
+        let res = obligation
+            .record_defaulted(Utc::now().date_naive(), dummy_audit_info())
+            .unwrap();
         assert!(matches!(res, Idempotent::Ignored));
     }
 
     #[test]
     fn errors_if_default_recorded_before_due() {
         let mut obligation = obligation_from(initial_events());
-        let res = obligation.record_defaulted(dummy_audit_info());
+        let res = obligation.record_defaulted(Utc::now().date_naive(), dummy_audit_info());
         assert!(matches!(
             res,
             Err(ObligationError::InvalidStatusTransitionToDefaulted)

--- a/core/credit/src/obligation/mod.rs
+++ b/core/credit/src/obligation/mod.rs
@@ -90,6 +90,7 @@ where
                 JobId::new(),
                 obligation_due::CreditFacilityJobConfig::<Perms, E> {
                     obligation_id: obligation.id,
+                    effective: obligation.due_at().date_naive(),
                     _phantom: std::marker::PhantomData,
                 },
                 obligation.due_at(),

--- a/core/credit/src/obligation/mod.rs
+++ b/core/credit/src/obligation/mod.rs
@@ -119,6 +119,7 @@ where
         credit_facility_id: CreditFacilityId,
         payment_id: PaymentId,
         amount: UsdCents,
+        effective: chrono::NaiveDate,
         audit_info: &AuditInfo,
     ) -> Result<PaymentAllocationResult, ObligationError> {
         let mut obligations = self.facility_obligations(credit_facility_id).await?;
@@ -129,7 +130,7 @@ where
         let mut new_allocations = Vec::new();
         for obligation in obligations.iter_mut() {
             if let es_entity::Idempotent::Executed(Some(new_allocation)) =
-                obligation.allocate_payment(remaining, payment_id, audit_info)
+                obligation.allocate_payment(remaining, payment_id, effective, audit_info)
             {
                 self.repo.update_in_op(db, obligation).await?;
                 remaining -= new_allocation.amount;

--- a/core/credit/src/obligation/primitives.rs
+++ b/core/credit/src/obligation/primitives.rs
@@ -12,6 +12,7 @@ pub struct ObligationDueReallocationData {
     pub amount: UsdCents,
     pub not_yet_due_account_id: CalaAccountId,
     pub due_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 pub struct ObligationOverdueReallocationData {
@@ -19,6 +20,7 @@ pub struct ObligationOverdueReallocationData {
     pub amount: UsdCents,
     pub due_account_id: CalaAccountId,
     pub overdue_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 pub struct ObligationDefaultedReallocationData {
@@ -26,6 +28,7 @@ pub struct ObligationDefaultedReallocationData {
     pub amount: UsdCents,
     pub receivable_account_id: CalaAccountId,
     pub defaulted_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/core/credit/src/payment_allocation/entity.rs
+++ b/core/credit/src/payment_allocation/entity.rs
@@ -21,6 +21,7 @@ pub enum PaymentAllocationEvent {
         amount: UsdCents,
         receivable_account_id: CalaAccountId,
         account_to_be_debited_id: CalaAccountId,
+        effective: chrono::NaiveDate,
         audit_info: AuditInfo,
     },
 }
@@ -36,6 +37,7 @@ pub struct PaymentAllocation {
     pub amount: UsdCents,
     pub account_to_be_debited_id: CalaAccountId,
     pub receivable_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
 
     events: EntityEvents<PaymentAllocationEvent>,
 }
@@ -56,6 +58,7 @@ impl TryFromEvents<PaymentAllocationEvent> for PaymentAllocation {
                     amount,
                     account_to_be_debited_id,
                     receivable_account_id,
+                    effective,
                     ..
                 } => {
                     builder = builder
@@ -67,6 +70,7 @@ impl TryFromEvents<PaymentAllocationEvent> for PaymentAllocation {
                         .amount(*amount)
                         .account_to_be_debited_id(*account_to_be_debited_id)
                         .receivable_account_id(*receivable_account_id)
+                        .effective(*effective)
                 }
             }
         }
@@ -102,6 +106,7 @@ pub struct NewPaymentAllocation {
     pub(crate) credit_facility_id: CreditFacilityId,
     pub(crate) receivable_account_id: CalaAccountId,
     pub(crate) account_to_be_debited_id: CalaAccountId,
+    pub(crate) effective: chrono::NaiveDate,
     #[builder(setter(into))]
     pub(crate) amount: UsdCents,
     #[builder(setter(into))]
@@ -126,6 +131,7 @@ impl IntoEvents<PaymentAllocationEvent> for NewPaymentAllocation {
                 credit_facility_id: self.credit_facility_id,
                 amount: self.amount,
                 account_to_be_debited_id: self.account_to_be_debited_id,
+                effective: self.effective,
                 receivable_account_id: self.receivable_account_id,
                 audit_info: self.audit_info,
             }],

--- a/core/credit/src/primitives/mod.rs
+++ b/core/credit/src/primitives/mod.rs
@@ -409,6 +409,7 @@ pub struct CollateralUpdate {
     pub tx_id: LedgerTxId,
     pub abs_diff: Satoshis,
     pub action: CollateralAction,
+    pub effective: chrono::NaiveDate,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]

--- a/core/deposit/Cargo.toml
+++ b/core/deposit/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 [features]
 
 fail-on-warnings = []
-graphql = [ "dep:async-graphql", "cala-ledger/graphql" ]
+graphql = ["dep:async-graphql", "cala-ledger/graphql"]
+sim-time = ["dep:sim-time", "es-entity/sim-time"]
 
 [dependencies]
 core-money = { path = "../money" }
@@ -36,6 +37,7 @@ rust_decimal = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 async-graphql = { workspace = true, optional = true }
+sim-time = { workspace = true, optional = true }
 base64 = { workspace = true }
 
 [dev-dependencies]

--- a/core/deposit/src/ledger/templates/cancel_withdraw.rs
+++ b/core/deposit/src/ledger/templates/cancel_withdraw.rs
@@ -72,7 +72,7 @@ impl From<CancelWithdrawParams> for Params {
         params.insert("amount", amount);
         params.insert("deposit_omnibus_account_id", deposit_omnibus_account_id);
         params.insert("credit_account_id", credit_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/deposit/src/ledger/templates/confirm_withdraw.rs
+++ b/core/deposit/src/ledger/templates/confirm_withdraw.rs
@@ -89,7 +89,7 @@ impl From<ConfirmWithdrawParams> for Params {
         params.insert("credit_account_id", credit_account_id);
         params.insert("correlation_id", correlation_id);
         params.insert("external_id", external_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/deposit/src/ledger/templates/initiate_withdraw.rs
+++ b/core/deposit/src/ledger/templates/initiate_withdraw.rs
@@ -73,7 +73,7 @@ impl From<InitiateWithdrawParams> for Params {
         params.insert("amount", amount);
         params.insert("deposit_omnibus_account_id", deposit_omnibus_account_id);
         params.insert("credit_account_id", credit_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/deposit/src/ledger/templates/record_deposit.rs
+++ b/core/deposit/src/ledger/templates/record_deposit.rs
@@ -72,7 +72,7 @@ impl From<RecordDepositParams> for Params {
         params.insert("amount", amount);
         params.insert("deposit_omnibus_account_id", deposit_omnibus_account_id);
         params.insert("credit_account_id", credit_account_id);
-        params.insert("effective", chrono::Utc::now().date_naive());
+        params.insert("effective", crate::time::now().date_naive());
 
         params
     }

--- a/core/deposit/src/lib.rs
+++ b/core/deposit/src/lib.rs
@@ -13,6 +13,7 @@ mod ledger;
 mod primitives;
 mod processes;
 mod publisher;
+mod time;
 mod withdrawal;
 
 use deposit_account_cursor::DepositAccountsByCreatedAtCursor;

--- a/core/deposit/src/time.rs
+++ b/core/deposit/src/time.rs
@@ -1,0 +1,12 @@
+use chrono::{DateTime, Utc};
+
+#[inline(always)]
+pub(crate) fn now() -> DateTime<Utc> {
+    #[cfg(feature = "sim-time")]
+    let res = { sim_time::now() };
+
+    #[cfg(not(feature = "sim-time"))]
+    let res = { Utc::now() };
+
+    res
+}

--- a/lana/admin-server/src/graphql/credit_facility/mod.rs
+++ b/lana/admin-server/src/graphql/credit_facility/mod.rs
@@ -207,6 +207,7 @@ crate::mutation_payload! { CreditFacilityCreatePayload, credit_facility: CreditF
 pub struct CreditFacilityCollateralUpdateInput {
     pub credit_facility_id: UUID,
     pub collateral: Satoshis,
+    pub effective: Date,
 }
 crate::mutation_payload! { CreditFacilityCollateralUpdatePayload, credit_facility: CreditFacility }
 

--- a/lana/admin-server/src/graphql/credit_facility/mod.rs
+++ b/lana/admin-server/src/graphql/credit_facility/mod.rs
@@ -215,6 +215,7 @@ crate::mutation_payload! { CreditFacilityCollateralUpdatePayload, credit_facilit
 pub struct CreditFacilityPartialPaymentInput {
     pub credit_facility_id: UUID,
     pub amount: UsdCents,
+    pub effective: Date,
 }
 crate::mutation_payload! { CreditFacilityPartialPaymentPayload, credit_facility: CreditFacility }
 

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -412,6 +412,7 @@ type CreditFacilityBalance {
 input CreditFacilityCollateralUpdateInput {
 	creditFacilityId: UUID!
 	collateral: Satoshis!
+	effective: Date!
 }
 
 type CreditFacilityCollateralUpdatePayload {

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -561,6 +561,7 @@ type CreditFacilityOrigination {
 input CreditFacilityPartialPaymentInput {
 	creditFacilityId: UUID!
 	amount: UsdCents!
+	effective: Date!
 }
 
 type CreditFacilityPartialPaymentPayload {

--- a/lana/admin-server/src/graphql/schema.rs
+++ b/lana/admin-server/src/graphql/schema.rs
@@ -1261,8 +1261,12 @@ impl Mutation {
             CreditFacilityPartialPaymentPayload,
             CreditFacility,
             ctx,
-            app.credit()
-                .record_payment(sub, input.credit_facility_id.into(), input.amount)
+            app.credit().record_payment(
+                sub,
+                input.credit_facility_id,
+                input.amount,
+                input.effective
+            )
         )
     }
 

--- a/lana/admin-server/src/graphql/schema.rs
+++ b/lana/admin-server/src/graphql/schema.rs
@@ -1240,13 +1240,14 @@ impl Mutation {
         let CreditFacilityCollateralUpdateInput {
             credit_facility_id,
             collateral,
+            effective,
         } = input;
         exec_mutation!(
             CreditFacilityCollateralUpdatePayload,
             CreditFacility,
             ctx,
             app.credit()
-                .update_collateral(sub, credit_facility_id.into(), collateral)
+                .update_collateral(sub, credit_facility_id, collateral, effective)
         )
     }
 

--- a/lana/admin-server/src/primitives.rs
+++ b/lana/admin-server/src/primitives.rs
@@ -46,13 +46,18 @@ impl Timestamp {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Date(chrono::NaiveDate);
 scalar!(Date);
 impl From<chrono::NaiveDate> for Date {
     fn from(value: chrono::NaiveDate) -> Self {
         Self(value)
+    }
+}
+impl From<Date> for chrono::NaiveDate {
+    fn from(value: Date) -> Self {
+        value.0
     }
 }
 impl Date {

--- a/lana/sim-bootstrap/src/lib.rs
+++ b/lana/sim-bootstrap/src/lib.rs
@@ -101,7 +101,10 @@ async fn create_and_process_facility(
                 amount,
                 ..
             })) if { cf.id == *id && amount > &UsdCents::ZERO } => {
-                let _ = app.credit().record_payment(&sub, *id, *amount).await;
+                let _ = app
+                    .credit()
+                    .record_payment(&sub, *id, *amount, sim_time::now().date_naive())
+                    .await;
                 let facility = app
                     .credit()
                     .find_by_id(&sub, *id)
@@ -110,7 +113,12 @@ async fn create_and_process_facility(
                 if facility.interest_accrual_cycle_in_progress().is_none() {
                     let total_outstanding_amount = app.credit().outstanding(&facility).await?;
                     app.credit()
-                        .record_payment(&sub, facility.id, total_outstanding_amount)
+                        .record_payment(
+                            &sub,
+                            facility.id,
+                            total_outstanding_amount,
+                            sim_time::now().date_naive(),
+                        )
                         .await?;
                     app.credit().complete_facility(&sub, facility.id).await?;
                 }

--- a/lana/sim-bootstrap/src/lib.rs
+++ b/lana/sim-bootstrap/src/lib.rs
@@ -81,7 +81,12 @@ async fn create_and_process_facility(
         match &msg.payload {
             Some(LanaEvent::Credit(CoreCreditEvent::FacilityApproved { id })) if cf.id == *id => {
                 app.credit()
-                    .update_collateral(&sub, cf.id, Satoshis::try_from_btc(dec!(230))?)
+                    .update_collateral(
+                        &sub,
+                        cf.id,
+                        Satoshis::try_from_btc(dec!(230))?,
+                        sim_time::now().date_naive(),
+                    )
                     .await?;
             }
             Some(LanaEvent::Credit(CoreCreditEvent::FacilityActivated { id, .. }))

--- a/lana/sim-bootstrap/src/scenarios/timely_payments.rs
+++ b/lana/sim-bootstrap/src/scenarios/timely_payments.rs
@@ -27,7 +27,12 @@ pub async fn timely_payments_scenario(sub: Subject, app: &LanaApp) -> anyhow::Re
         match &msg.payload {
             Some(LanaEvent::Credit(CoreCreditEvent::FacilityApproved { id })) if cf.id == *id => {
                 app.credit()
-                    .update_collateral(&sub, cf.id, Satoshis::try_from_btc(dec!(230))?)
+                    .update_collateral(
+                        &sub,
+                        cf.id,
+                        Satoshis::try_from_btc(dec!(230))?,
+                        sim_time::now().date_naive(),
+                    )
                     .await?;
             }
             Some(LanaEvent::Credit(CoreCreditEvent::FacilityActivated { id, .. }))

--- a/lana/sim-bootstrap/src/scenarios/timely_payments.rs
+++ b/lana/sim-bootstrap/src/scenarios/timely_payments.rs
@@ -47,7 +47,9 @@ pub async fn timely_payments_scenario(sub: Subject, app: &LanaApp) -> anyhow::Re
                 amount,
                 ..
             })) if { cf.id == *id && amount > &UsdCents::ZERO } => {
-                app.credit().record_payment(&sub, *id, *amount).await?;
+                app.credit()
+                    .record_payment(&sub, *id, *amount, sim_time::now().date_naive())
+                    .await?;
                 let facility = app
                     .credit()
                     .find_by_id(&sub, *id)
@@ -59,7 +61,12 @@ pub async fn timely_payments_scenario(sub: Subject, app: &LanaApp) -> anyhow::Re
                     let total_outstanding_amount = app.credit().outstanding(&facility).await?;
                     if !total_outstanding_amount.is_zero() {
                         app.credit()
-                            .record_payment(&sub, facility.id, total_outstanding_amount)
+                            .record_payment(
+                                &sub,
+                                facility.id,
+                                total_outstanding_amount,
+                                sim_time::now().date_naive(),
+                            )
                             .await?;
                     }
                     app.credit().complete_facility(&sub, facility.id).await?;


### PR DESCRIPTION
## Description

This PR standardizes on using crate::time::now() for template effective dates, and it specifies dates where necessary  for credit module templates