### PR TITLE
fix(reporting): filter stale rows from raw tables

### DIFF
--- a/meltano/transform/models/sources.yml
+++ b/meltano/transform/models/sources.yml
@@ -138,3 +138,5 @@ sources:
           error_after:
             count: 7
             period: day
+
+      - name: public_core_chart_events_view

--- a/meltano/transform/models/staging/stg_account_balances.sql
+++ b/meltano/transform/models/staging/stg_account_balances.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = 'account_id',
-) }}
-
 with ordered as (
 
     select
@@ -21,10 +16,11 @@ with ordered as (
 
     from {{ source("lana", "public_cala_balance_history_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_account_sets.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = 'account_set_id',
-) }}
-
 with ordered as (
 
     select
@@ -20,10 +15,11 @@ with ordered as (
     from
         {{ source("lana", "public_cala_account_set_member_account_sets_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_account_set_member_accounts.sql
+++ b/meltano/transform/models/staging/stg_account_set_member_accounts.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = ['account_set_id', 'member_account_id'],
-) }}
-
 with ordered as (
 
     select
@@ -20,10 +15,11 @@ with ordered as (
 
     from {{ source("lana", "public_cala_account_set_member_accounts_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_account_sets.sql
+++ b/meltano/transform/models/staging/stg_account_sets.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized='incremental',
-    unique_key= 'id',
-) }}
-
 with ordered as (
 
     select
@@ -20,10 +15,11 @@ with ordered as (
 
     from {{ source("lana", "public_cala_account_sets_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_accounts.sql
+++ b/meltano/transform/models/staging/stg_accounts.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = 'id',
-) }}
-
 with ordered as (
 
     select
@@ -22,10 +17,11 @@ with ordered as (
 
     from {{ source("lana", "public_cala_accounts_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_core_chart_events.sql
+++ b/meltano/transform/models/staging/stg_core_chart_events.sql
@@ -1,3 +1,8 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['id', 'sequence'],
+) }}
+
 with ordered as (
 
     select
@@ -14,13 +19,12 @@ with ordered as (
             )
             as order_received_desc
 
-    from {{ source("lana", "public_customer_events_view") }}
+    from {{ source("lana", "public_core_chart_events_view") }}
 
-    where _sdc_batched_at >= (
-        select coalesce(max(_sdc_batched_at), '1900-01-01')
-        from {{ ref('stg_core_chart_events') }}
-        where event_type = 'initialized'
-    )
+    {% if is_incremental() %}
+        where
+            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
+    {% endif %}
 
 )
 

--- a/meltano/transform/models/staging/stg_credit_facility_events.sql
+++ b/meltano/transform/models/staging/stg_credit_facility_events.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
-) }}
-
 with ordered as (
 
     select
@@ -21,10 +16,11 @@ with ordered as (
 
     from {{ source("lana", "public_core_credit_facility_events_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_deposit_accounts.sql
+++ b/meltano/transform/models/staging/stg_deposit_accounts.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = ['id', 'account_holder_id'],
-) }}
-
 with ordered as (
 
     select
@@ -19,10 +14,11 @@ with ordered as (
 
     from {{ source("lana", "public_core_deposit_accounts_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_deposit_events.sql
+++ b/meltano/transform/models/staging/stg_deposit_events.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
-) }}
-
 with ordered as (
 
     select
@@ -21,10 +16,11 @@ with ordered as (
 
     from {{ source("lana", "public_core_deposit_events_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_sumsub_applicants.sql
+++ b/meltano/transform/models/staging/stg_sumsub_applicants.sql
@@ -11,11 +11,9 @@ with ordered as (
             )
             as order_recorded_at_desc
 
-
     from {{ source("lana", "sumsub_applicants_view") }}
 
 )
-
 
 select
     * except (order_recorded_at_desc),

--- a/meltano/transform/models/staging/stg_withdrawal_events.sql
+++ b/meltano/transform/models/staging/stg_withdrawal_events.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
-) }}
-
 with ordered as (
 
     select
@@ -21,10 +16,11 @@ with ordered as (
 
     from {{ source("lana", "public_core_withdrawal_events_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 

--- a/meltano/transform/models/staging/stg_withdrawals.sql
+++ b/meltano/transform/models/staging/stg_withdrawals.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = ['id', 'deposit_account_id'],
-) }}
-
 with ordered as (
 
     select
@@ -22,10 +17,11 @@ with ordered as (
 
     from {{ source("lana", "public_core_withdrawals_view") }}
 
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
+    where _sdc_batched_at >= (
+        select coalesce(max(_sdc_batched_at), '1900-01-01')
+        from {{ ref('stg_core_chart_events') }}
+        where event_type = 'initialized'
+    )
 
 )
 


### PR DESCRIPTION
This is a hack to fix an issue with reports where rows from prior rollouts persist in tables and create records that should not be there and do not match the state in the runtime.

The hack works by recognizing that the chart of accounts is only initialized once so we can use it to know when the database was reset.