### PR TITLE
refactor: Rename balance range fields to align with Cala

### DIFF
--- a/apps/admin-panel/app/balance-sheet/page.tsx
+++ b/apps/admin-panel/app/balance-sheet/page.tsx
@@ -100,25 +100,25 @@ gql`
   }
 
   fragment UsdLedgerBalanceRangeFragment on UsdLedgerAccountBalanceRange {
-    usdStart: start {
+    usdStart: open {
       ...UsdBalanceFragment
     }
-    usdDiff: diff {
+    usdDiff: periodActivity {
       ...UsdBalanceFragment
     }
-    usdEnd: end {
+    usdEnd: close {
       ...UsdBalanceFragment
     }
   }
 
   fragment BtcLedgerBalanceRangeFragment on BtcLedgerAccountBalanceRange {
-    btcStart: start {
+    btcStart: open {
       ...BtcBalanceFragment
     }
-    btcDiff: diff {
+    btcDiff: periodActivity {
       ...BtcBalanceFragment
     }
-    btcEnd: end {
+    btcEnd: close {
       ...BtcBalanceFragment
     }
   }

--- a/apps/admin-panel/app/ledger-account/[ledger-account-ref]/page.tsx
+++ b/apps/admin-panel/app/ledger-account/[ledger-account-ref]/page.tsx
@@ -61,7 +61,7 @@ gql`
     balanceRange {
       __typename
       ... on UsdLedgerAccountBalanceRange {
-        end {
+        close {
           usdSettled: settled {
             debit
             credit
@@ -70,7 +70,7 @@ gql`
         }
       }
       ... on BtcLedgerAccountBalanceRange {
-        end {
+        close {
           btcSettled: settled {
             debit
             credit
@@ -240,13 +240,13 @@ const LedgerAccountPage: React.FC<LedgerAccountPageProps> = ({ params }) => {
                         "UsdLedgerAccountBalanceRange" ? (
                           <Balance
                             currency="usd"
-                            amount={ledgerAccount?.balanceRange?.end?.usdSettled.net}
+                            amount={ledgerAccount?.balanceRange?.close?.usdSettled.net}
                           />
                         ) : ledgerAccount?.balanceRange.__typename ===
                           "BtcLedgerAccountBalanceRange" ? (
                           <Balance
                             currency="btc"
-                            amount={ledgerAccount?.balanceRange?.end?.btcSettled.net}
+                            amount={ledgerAccount?.balanceRange?.close?.btcSettled.net}
                           />
                         ) : (
                           "-"

--- a/apps/admin-panel/app/profit-and-loss/page.tsx
+++ b/apps/admin-panel/app/profit-and-loss/page.tsx
@@ -102,25 +102,25 @@ gql`
   }
 
   fragment UsdLedgerBalanceRangeFragment on UsdLedgerAccountBalanceRange {
-    usdStart: start {
+    usdStart: open {
       ...UsdBalanceFragment
     }
-    usdDiff: diff {
+    usdDiff: periodActivity {
       ...UsdBalanceFragment
     }
-    usdEnd: end {
+    usdEnd: close {
       ...UsdBalanceFragment
     }
   }
 
   fragment BtcLedgerBalanceRangeFragment on BtcLedgerAccountBalanceRange {
-    btcStart: start {
+    btcStart: open {
       ...BtcBalanceFragment
     }
-    btcDiff: diff {
+    btcDiff: periodActivity {
       ...BtcBalanceFragment
     }
-    btcEnd: end {
+    btcEnd: close {
       ...BtcBalanceFragment
     }
   }

--- a/apps/admin-panel/app/trial-balance/page.tsx
+++ b/apps/admin-panel/app/trial-balance/page.tsx
@@ -125,25 +125,25 @@ gql`
   }
 
   fragment UsdLedgerBalanceRangeFragment on UsdLedgerAccountBalanceRange {
-    usdStart: start {
+    usdStart: open {
       ...UsdBalanceFragment
     }
-    usdDiff: diff {
+    usdDiff: periodActivity {
       ...UsdBalanceFragment
     }
-    usdEnd: end {
+    usdEnd: close {
       ...UsdBalanceFragment
     }
   }
 
   fragment BtcLedgerBalanceRangeFragment on BtcLedgerAccountBalanceRange {
-    btcStart: start {
+    btcStart: open {
       ...BtcBalanceFragment
     }
-    btcDiff: diff {
+    btcDiff: periodActivity {
       ...BtcBalanceFragment
     }
-    btcEnd: end {
+    btcEnd: close {
       ...BtcBalanceFragment
     }
   }

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -260,9 +260,9 @@ export type BtcLedgerAccountBalance = {
 
 export type BtcLedgerAccountBalanceRange = {
   __typename?: 'BtcLedgerAccountBalanceRange';
-  diff: BtcLedgerAccountBalance;
-  end: BtcLedgerAccountBalance;
-  start: BtcLedgerAccountBalance;
+  close: BtcLedgerAccountBalance;
+  open: BtcLedgerAccountBalance;
+  periodActivity: BtcLedgerAccountBalance;
 };
 
 export type CancelledWithdrawalEntry = {
@@ -2034,9 +2034,9 @@ export type UsdLedgerAccountBalance = {
 
 export type UsdLedgerAccountBalanceRange = {
   __typename?: 'UsdLedgerAccountBalanceRange';
-  diff: UsdLedgerAccountBalance;
-  end: UsdLedgerAccountBalance;
-  start: UsdLedgerAccountBalance;
+  close: UsdLedgerAccountBalance;
+  open: UsdLedgerAccountBalance;
+  periodActivity: UsdLedgerAccountBalance;
 };
 
 export type User = {
@@ -2510,7 +2510,7 @@ export type AccountingCsvDownloadLinkGenerateMutationVariables = Exact<{
 
 export type AccountingCsvDownloadLinkGenerateMutation = { __typename?: 'Mutation', accountingCsvDownloadLinkGenerate: { __typename?: 'AccountingCsvDownloadLinkGeneratePayload', link: { __typename?: 'AccountingCsvDownloadLink', url: string, csvId: string } } };
 
-export type LedgerAccountDetailsFragment = { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', end: { __typename?: 'BtcLedgerAccountBalance', btcSettled: { __typename?: 'BtcBalanceDetails', debit: Satoshis, credit: Satoshis, net: Satoshis } } } | { __typename: 'UsdLedgerAccountBalanceRange', end: { __typename?: 'UsdLedgerAccountBalance', usdSettled: { __typename?: 'UsdBalanceDetails', debit: UsdCents, credit: UsdCents, net: UsdCents } } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
+export type LedgerAccountDetailsFragment = { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', close: { __typename?: 'BtcLedgerAccountBalance', btcSettled: { __typename?: 'BtcBalanceDetails', debit: Satoshis, credit: Satoshis, net: Satoshis } } } | { __typename: 'UsdLedgerAccountBalanceRange', close: { __typename?: 'UsdLedgerAccountBalance', usdSettled: { __typename?: 'UsdBalanceDetails', debit: UsdCents, credit: UsdCents, net: UsdCents } } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
 
 export type LedgerAccountByCodeQueryVariables = Exact<{
   code: Scalars['String']['input'];
@@ -2519,7 +2519,7 @@ export type LedgerAccountByCodeQueryVariables = Exact<{
 }>;
 
 
-export type LedgerAccountByCodeQuery = { __typename?: 'Query', ledgerAccountByCode?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', end: { __typename?: 'BtcLedgerAccountBalance', btcSettled: { __typename?: 'BtcBalanceDetails', debit: Satoshis, credit: Satoshis, net: Satoshis } } } | { __typename: 'UsdLedgerAccountBalanceRange', end: { __typename?: 'UsdLedgerAccountBalance', usdSettled: { __typename?: 'UsdBalanceDetails', debit: UsdCents, credit: UsdCents, net: UsdCents } } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } } | null };
+export type LedgerAccountByCodeQuery = { __typename?: 'Query', ledgerAccountByCode?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', close: { __typename?: 'BtcLedgerAccountBalance', btcSettled: { __typename?: 'BtcBalanceDetails', debit: Satoshis, credit: Satoshis, net: Satoshis } } } | { __typename: 'UsdLedgerAccountBalanceRange', close: { __typename?: 'UsdLedgerAccountBalance', usdSettled: { __typename?: 'UsdBalanceDetails', debit: UsdCents, credit: UsdCents, net: UsdCents } } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } } | null };
 
 export type LedgerAccountQueryVariables = Exact<{
   id: Scalars['UUID']['input'];
@@ -2528,7 +2528,7 @@ export type LedgerAccountQueryVariables = Exact<{
 }>;
 
 
-export type LedgerAccountQuery = { __typename?: 'Query', ledgerAccount?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', end: { __typename?: 'BtcLedgerAccountBalance', btcSettled: { __typename?: 'BtcBalanceDetails', debit: Satoshis, credit: Satoshis, net: Satoshis } } } | { __typename: 'UsdLedgerAccountBalanceRange', end: { __typename?: 'UsdLedgerAccountBalance', usdSettled: { __typename?: 'UsdBalanceDetails', debit: UsdCents, credit: UsdCents, net: UsdCents } } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } } | null };
+export type LedgerAccountQuery = { __typename?: 'Query', ledgerAccount?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', close: { __typename?: 'BtcLedgerAccountBalance', btcSettled: { __typename?: 'BtcBalanceDetails', debit: Satoshis, credit: Satoshis, net: Satoshis } } } | { __typename: 'UsdLedgerAccountBalanceRange', close: { __typename?: 'UsdLedgerAccountBalance', usdSettled: { __typename?: 'UsdBalanceDetails', debit: UsdCents, credit: UsdCents, net: UsdCents } } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } } | null };
 
 export type LedgerTransactionQueryVariables = Exact<{
   id: Scalars['UUID']['input'];
@@ -2793,13 +2793,13 @@ export const UsdBalanceFragmentFragmentDoc = gql`
     `;
 export const UsdLedgerBalanceRangeFragmentFragmentDoc = gql`
     fragment UsdLedgerBalanceRangeFragment on UsdLedgerAccountBalanceRange {
-  usdStart: start {
+  usdStart: open {
     ...UsdBalanceFragment
   }
-  usdDiff: diff {
+  usdDiff: periodActivity {
     ...UsdBalanceFragment
   }
-  usdEnd: end {
+  usdEnd: close {
     ...UsdBalanceFragment
   }
 }
@@ -2825,13 +2825,13 @@ export const BtcBalanceFragmentFragmentDoc = gql`
     `;
 export const BtcLedgerBalanceRangeFragmentFragmentDoc = gql`
     fragment BtcLedgerBalanceRangeFragment on BtcLedgerAccountBalanceRange {
-  btcStart: start {
+  btcStart: open {
     ...BtcBalanceFragment
   }
-  btcDiff: diff {
+  btcDiff: periodActivity {
     ...BtcBalanceFragment
   }
-  btcEnd: end {
+  btcEnd: close {
     ...BtcBalanceFragment
   }
 }
@@ -3055,7 +3055,7 @@ export const LedgerAccountDetailsFragmentDoc = gql`
   balanceRange {
     __typename
     ... on UsdLedgerAccountBalanceRange {
-      end {
+      close {
         usdSettled: settled {
           debit
           credit
@@ -3064,7 +3064,7 @@ export const LedgerAccountDetailsFragmentDoc = gql`
       }
     }
     ... on BtcLedgerAccountBalanceRange {
-      end {
+      close {
         btcSettled: settled {
           debit
           credit

--- a/apps/admin-panel/lib/graphql/generated/mocks.ts
+++ b/apps/admin-panel/lib/graphql/generated/mocks.ts
@@ -343,9 +343,9 @@ export const mockBtcLedgerAccountBalanceRange = (overrides?: Partial<BtcLedgerAc
     relationshipsToOmit.add('BtcLedgerAccountBalanceRange');
     return {
         __typename: 'BtcLedgerAccountBalanceRange',
-        diff: overrides && overrides.hasOwnProperty('diff') ? overrides.diff! : relationshipsToOmit.has('BtcLedgerAccountBalance') ? {} as BtcLedgerAccountBalance : mockBtcLedgerAccountBalance({}, relationshipsToOmit),
-        end: overrides && overrides.hasOwnProperty('end') ? overrides.end! : relationshipsToOmit.has('BtcLedgerAccountBalance') ? {} as BtcLedgerAccountBalance : mockBtcLedgerAccountBalance({}, relationshipsToOmit),
-        start: overrides && overrides.hasOwnProperty('start') ? overrides.start! : relationshipsToOmit.has('BtcLedgerAccountBalance') ? {} as BtcLedgerAccountBalance : mockBtcLedgerAccountBalance({}, relationshipsToOmit),
+        close: overrides && overrides.hasOwnProperty('close') ? overrides.close! : relationshipsToOmit.has('BtcLedgerAccountBalance') ? {} as BtcLedgerAccountBalance : mockBtcLedgerAccountBalance({}, relationshipsToOmit),
+        open: overrides && overrides.hasOwnProperty('open') ? overrides.open! : relationshipsToOmit.has('BtcLedgerAccountBalance') ? {} as BtcLedgerAccountBalance : mockBtcLedgerAccountBalance({}, relationshipsToOmit),
+        periodActivity: overrides && overrides.hasOwnProperty('periodActivity') ? overrides.periodActivity! : relationshipsToOmit.has('BtcLedgerAccountBalance') ? {} as BtcLedgerAccountBalance : mockBtcLedgerAccountBalance({}, relationshipsToOmit),
     };
 };
 
@@ -2107,9 +2107,9 @@ export const mockUsdLedgerAccountBalanceRange = (overrides?: Partial<UsdLedgerAc
     relationshipsToOmit.add('UsdLedgerAccountBalanceRange');
     return {
         __typename: 'UsdLedgerAccountBalanceRange',
-        diff: overrides && overrides.hasOwnProperty('diff') ? overrides.diff! : relationshipsToOmit.has('UsdLedgerAccountBalance') ? {} as UsdLedgerAccountBalance : mockUsdLedgerAccountBalance({}, relationshipsToOmit),
-        end: overrides && overrides.hasOwnProperty('end') ? overrides.end! : relationshipsToOmit.has('UsdLedgerAccountBalance') ? {} as UsdLedgerAccountBalance : mockUsdLedgerAccountBalance({}, relationshipsToOmit),
-        start: overrides && overrides.hasOwnProperty('start') ? overrides.start! : relationshipsToOmit.has('UsdLedgerAccountBalance') ? {} as UsdLedgerAccountBalance : mockUsdLedgerAccountBalance({}, relationshipsToOmit),
+        close: overrides && overrides.hasOwnProperty('close') ? overrides.close! : relationshipsToOmit.has('UsdLedgerAccountBalance') ? {} as UsdLedgerAccountBalance : mockUsdLedgerAccountBalance({}, relationshipsToOmit),
+        open: overrides && overrides.hasOwnProperty('open') ? overrides.open! : relationshipsToOmit.has('UsdLedgerAccountBalance') ? {} as UsdLedgerAccountBalance : mockUsdLedgerAccountBalance({}, relationshipsToOmit),
+        periodActivity: overrides && overrides.hasOwnProperty('periodActivity') ? overrides.periodActivity! : relationshipsToOmit.has('UsdLedgerAccountBalance') ? {} as UsdLedgerAccountBalance : mockUsdLedgerAccountBalance({}, relationshipsToOmit),
     };
 };
 

--- a/core/accounting/src/balance_sheet/ledger/mod.rs
+++ b/core/accounting/src/balance_sheet/ledger/mod.rs
@@ -544,15 +544,15 @@ impl
         let values = account_set.into_values();
 
         let usd_balance_range = usd_balance.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
 
         let btc_balance_range = btc_balance.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
 
         BalanceSheet {

--- a/core/accounting/src/ledger_account/value.rs
+++ b/core/accounting/src/ledger_account/value.rs
@@ -81,15 +81,15 @@ impl From<(CalaAccountSet, AccountBalances)> for LedgerAccount {
         let code = values.external_id.and_then(|id| id.parse().ok());
 
         let usd_balance_range = usd_balance.map(|balance| BalanceRange {
-            start: None,
-            end: Some(balance.clone()),
-            diff: Some(balance),
+            open: None,
+            close: Some(balance.clone()),
+            period_activity: Some(balance),
         });
 
         let btc_balance_range = btc_balance.map(|balance| BalanceRange {
-            start: None,
-            end: Some(balance.clone()),
-            diff: Some(balance),
+            open: None,
+            close: Some(balance.clone()),
+            period_activity: Some(balance),
         });
 
         LedgerAccount {
@@ -121,14 +121,14 @@ impl From<(CalaAccountSet, BalanceRanges)> for LedgerAccount {
         let code = values.external_id.and_then(|id| id.parse().ok());
 
         let usd_balance_range = usd_balance_range.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
         let btc_balance_range = btc_balance_range.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
 
         LedgerAccount {
@@ -156,15 +156,15 @@ impl From<(CalaAccount, AccountBalances)> for LedgerAccount {
         ): (CalaAccount, AccountBalances),
     ) -> Self {
         let usd_balance_range = usd_balance.map(|balance| BalanceRange {
-            start: None,
-            end: Some(balance.clone()),
-            diff: Some(balance),
+            open: None,
+            close: Some(balance.clone()),
+            period_activity: Some(balance),
         });
 
         let btc_balance_range = btc_balance.map(|balance| BalanceRange {
-            start: None,
-            end: Some(balance.clone()),
-            diff: Some(balance),
+            open: None,
+            close: Some(balance.clone()),
+            period_activity: Some(balance),
         });
 
         let external_id = account.values().external_id.clone();
@@ -194,14 +194,14 @@ impl From<(CalaAccount, BalanceRanges)> for LedgerAccount {
         ): (CalaAccount, BalanceRanges),
     ) -> Self {
         let usd_balance_range = usd_balance_range.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
         let btc_balance_range = btc_balance_range.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
 
         let external_id = account.values().external_id.clone();

--- a/core/accounting/src/primitives.rs
+++ b/core/accounting/src/primitives.rs
@@ -798,20 +798,20 @@ impl From<TrialBalanceAction> for CoreAccountingAction {
 
 #[derive(Debug, Clone)]
 pub struct BalanceRange {
-    pub start: Option<CalaAccountBalance>,
-    pub end: Option<CalaAccountBalance>,
-    pub diff: Option<CalaAccountBalance>,
+    pub open: Option<CalaAccountBalance>,
+    pub close: Option<CalaAccountBalance>,
+    pub period_activity: Option<CalaAccountBalance>,
 }
 
 impl BalanceRange {
     pub(crate) fn has_non_zero_activity(&self) -> bool {
-        if let Some(end) = self.end.as_ref() {
-            end.details.settled.dr_balance != Decimal::ZERO
-                || end.details.settled.cr_balance != Decimal::ZERO
-                || end.details.pending.dr_balance != Decimal::ZERO
-                || end.details.pending.cr_balance != Decimal::ZERO
-                || end.details.encumbrance.dr_balance != Decimal::ZERO
-                || end.details.encumbrance.cr_balance != Decimal::ZERO
+        if let Some(close) = self.close.as_ref() {
+            close.details.settled.dr_balance != Decimal::ZERO
+                || close.details.settled.cr_balance != Decimal::ZERO
+                || close.details.pending.dr_balance != Decimal::ZERO
+                || close.details.pending.cr_balance != Decimal::ZERO
+                || close.details.encumbrance.dr_balance != Decimal::ZERO
+                || close.details.encumbrance.cr_balance != Decimal::ZERO
         } else {
             false
         }

--- a/core/accounting/src/profit_and_loss/ledger/mod.rs
+++ b/core/accounting/src/profit_and_loss/ledger/mod.rs
@@ -448,15 +448,15 @@ impl
         let values = account_set.into_values();
 
         let usd_balance_range = usd_balance.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
 
         let btc_balance_range = btc_balance.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
 
         ProfitAndLossStatement {

--- a/core/accounting/src/trial_balance/ledger/mod.rs
+++ b/core/accounting/src/trial_balance/ledger/mod.rs
@@ -231,14 +231,14 @@ impl
     ) -> Self {
         let values = account_set.into_values();
         let usd_balance_range = usd_balance.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
         let btc_balance_range = btc_balance.map(|range| BalanceRange {
-            start: Some(range.open),
-            end: Some(range.close),
-            diff: Some(range.period),
+            open: Some(range.open),
+            close: Some(range.close),
+            period_activity: Some(range.period),
         });
         TrialBalanceRoot {
             id: values.id,

--- a/core/accounting/tests/ledger_transaction.rs
+++ b/core/accounting/tests/ledger_transaction.rs
@@ -24,7 +24,7 @@ async fn manual_transaction() -> anyhow::Result<()> {
     accounting.execute_manual_transaction(&DummySubject, &chart_ref, None, "Test transaction 1".to_string(), None, entries).await?;
 
     let account = accounting.find_ledger_account_by_code(&DummySubject, &chart_ref, "2".to_string()).await?.unwrap();
-    assert_eq!(account.usd_balance_range.expect("should have balance").end.expect("balance missing").settled(), dec!(100));
+    assert_eq!(account.usd_balance_range.expect("should have balance").close.expect("balance missing").settled(), dec!(100));
 
     Ok(())
 }

--- a/lana/admin-server/src/graphql/accounting/ledger_account.rs
+++ b/lana/admin-server/src/graphql/accounting/ledger_account.rs
@@ -131,7 +131,7 @@ impl From<Option<&lana_app::primitives::BalanceRange>> for LedgerAccountBalanceR
         match balance_range_opt {
             None => LedgerAccountBalanceRange::Usd(UsdLedgerAccountBalanceRange::default()),
             Some(balance_range) => {
-                let currency = match &balance_range.end {
+                let currency = match &balance_range.close {
                     None => Currency::USD,
                     Some(balance) if balance.details.currency == Currency::USD => Currency::USD,
                     Some(balance) if balance.details.currency == Currency::BTC => Currency::BTC,
@@ -154,34 +154,34 @@ impl From<Option<&lana_app::primitives::BalanceRange>> for LedgerAccountBalanceR
 
 #[derive(SimpleObject, Default)]
 pub(super) struct UsdLedgerAccountBalanceRange {
-    start: UsdLedgerAccountBalance,
-    diff: UsdLedgerAccountBalance,
-    end: UsdLedgerAccountBalance,
+    open: UsdLedgerAccountBalance,
+    period_activity: UsdLedgerAccountBalance,
+    close: UsdLedgerAccountBalance,
 }
 
 impl From<&lana_app::primitives::BalanceRange> for UsdLedgerAccountBalanceRange {
     fn from(balance_range: &lana_app::primitives::BalanceRange) -> Self {
         Self {
-            start: UsdLedgerAccountBalance::from(balance_range.start.as_ref()),
-            diff: UsdLedgerAccountBalance::from(balance_range.diff.as_ref()),
-            end: UsdLedgerAccountBalance::from(balance_range.end.as_ref()),
+            open: UsdLedgerAccountBalance::from(balance_range.open.as_ref()),
+            period_activity: UsdLedgerAccountBalance::from(balance_range.period_activity.as_ref()),
+            close: UsdLedgerAccountBalance::from(balance_range.close.as_ref()),
         }
     }
 }
 
 #[derive(SimpleObject, Default)]
 pub(super) struct BtcLedgerAccountBalanceRange {
-    start: BtcLedgerAccountBalance,
-    diff: BtcLedgerAccountBalance,
-    end: BtcLedgerAccountBalance,
+    open: BtcLedgerAccountBalance,
+    period_activity: BtcLedgerAccountBalance,
+    close: BtcLedgerAccountBalance,
 }
 
 impl From<&lana_app::primitives::BalanceRange> for BtcLedgerAccountBalanceRange {
     fn from(balance_range: &lana_app::primitives::BalanceRange) -> Self {
         Self {
-            start: BtcLedgerAccountBalance::from(balance_range.start.as_ref()),
-            diff: BtcLedgerAccountBalance::from(balance_range.diff.as_ref()),
-            end: BtcLedgerAccountBalance::from(balance_range.end.as_ref()),
+            open: BtcLedgerAccountBalance::from(balance_range.open.as_ref()),
+            period_activity: BtcLedgerAccountBalance::from(balance_range.period_activity.as_ref()),
+            close: BtcLedgerAccountBalance::from(balance_range.close.as_ref()),
         }
     }
 }

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -246,9 +246,9 @@ type BtcLedgerAccountBalance {
 }
 
 type BtcLedgerAccountBalanceRange {
-	start: BtcLedgerAccountBalance!
-	diff: BtcLedgerAccountBalance!
-	end: BtcLedgerAccountBalance!
+	open: BtcLedgerAccountBalance!
+	periodActivity: BtcLedgerAccountBalance!
+	close: BtcLedgerAccountBalance!
 }
 
 scalar CVLPct
@@ -1676,9 +1676,9 @@ type UsdLedgerAccountBalance {
 }
 
 type UsdLedgerAccountBalanceRange {
-	start: UsdLedgerAccountBalance!
-	diff: UsdLedgerAccountBalance!
-	end: UsdLedgerAccountBalance!
+	open: UsdLedgerAccountBalance!
+	periodActivity: UsdLedgerAccountBalance!
+	close: UsdLedgerAccountBalance!
 }
 
 type User {


### PR DESCRIPTION
On frontend part, only modifies usage of GraphQL. Names in the application itself are not changed.