### PR TITLE
chore: In RBAC hierarchy call 'parent' the more powerful role

### DIFF
--- a/lana/app/src/authorization/seed.rs
+++ b/lana/app/src/authorization/seed.rs
@@ -24,10 +24,10 @@ pub(super) async fn execute(authz: &Authorization) -> Result<(), AuthorizationEr
 
 async fn seed_role_hierarchy(authz: &Authorization) -> Result<(), AuthorizationError> {
     authz
-        .add_role_hierarchy(LanaRole::ADMIN, LanaRole::SUPERUSER)
+        .add_role_hierarchy(LanaRole::SUPERUSER, LanaRole::ADMIN)
         .await?;
     authz
-        .add_role_hierarchy(LanaRole::BANK_MANAGER, LanaRole::ADMIN)
+        .add_role_hierarchy(LanaRole::ADMIN, LanaRole::BANK_MANAGER)
         .await?;
 
     Ok(())

--- a/lib/authz/src/lib.rs
+++ b/lib/authz/src/lib.rs
@@ -63,7 +63,7 @@ where
         let mut enforcer = self.enforcer.write().await;
 
         match enforcer
-            .add_grouping_policy(vec![child_role.to_string(), parent_role.to_string()])
+            .add_grouping_policy(vec![parent_role.to_string(), child_role.to_string()])
             .await
         {
             Ok(_) => Ok(()),


### PR DESCRIPTION
In casbin model's group definitions, the first subject is the one that is also a member of the second one. For example 'g, admin, user' means that role admin also has role user and thus admin is the more powerful role. In parent/child naming scheme, it is more natural to call the more powerful role (admin) 'parent' and the less powerful (user) 'child'.

This change brings alignment with this idea. Consequently, the order of roles in `add_role_hierarchy` method conforms to the order in casbin model.