### PR TITLE
chore: adjust facility due date

### DIFF
--- a/apps/admin-panel/app/credit-facilities/[credit-facility-id]/repayment-plan/list.tsx
+++ b/apps/admin-panel/app/credit-facilities/[credit-facility-id]/repayment-plan/list.tsx
@@ -92,6 +92,8 @@ const getStatusVariant = (status: RepaymentPlan["status"]): BadgeProps["variant"
   switch (status) {
     case "UPCOMING":
       return "default"
+    case "NOT_YET_DUE":
+      return "outline"
     case "DUE":
       return "warning"
     case "OVERDUE":

--- a/apps/admin-panel/i18n.lock
+++ b/apps/admin-panel/i18n.lock
@@ -232,6 +232,7 @@ checksums:
     CreditFacilities/CreditFacilityDetails/RepaymentPlan/repaymentTypes/principal: e20184128f2c57ee03dfe700de56afeb
     CreditFacilities/CreditFacilityDetails/RepaymentPlan/repaymentTypes/interest: 74aee9268e3b6f89d89a4252b29864cc
     CreditFacilities/CreditFacilityDetails/RepaymentPlan/status/upcoming: 960febe0c0af09408917d55a0dc032ee
+    CreditFacilities/CreditFacilityDetails/RepaymentPlan/status/not_yet_due: 5610cbe51dcb79a9eba7b5ea20945fe3
     CreditFacilities/CreditFacilityDetails/RepaymentPlan/status/due: f68d8596e02773955b31c98a23ecbd95
     CreditFacilities/CreditFacilityDetails/RepaymentPlan/status/overdue: a63e7496e60dfa38beffe0b1d40d7b51
     CreditFacilities/CreditFacilityDetails/RepaymentPlan/status/paid: 57d83a58e2cfe732ed864f5155156033

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -362,6 +362,7 @@
         },
         "status": {
           "upcoming": "UPCOMING",
+          "not_yet_due": "NOT YET DUE",
           "due": "DUE",
           "overdue": "OVERDUE",
           "paid": "PAID"

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -362,6 +362,7 @@
         },
         "status": {
           "upcoming": "PRÓXIMO",
+          "not_yet_due": "AÚN NO VENCIDO",
           "due": "POR PAGAR",
           "overdue": "ATRASADO",
           "paid": "PAGADO"

--- a/apps/customer-portal/app/credit-facilities/[credit-facility-id]/repayment-plan.tsx
+++ b/apps/customer-portal/app/credit-facilities/[credit-facility-id]/repayment-plan.tsx
@@ -76,6 +76,8 @@ const getStatusVariant = (status: RepaymentPlan["status"]): BadgeProps["variant"
   switch (status) {
     case "UPCOMING":
       return "default"
+    case "NOT_YET_DUE":
+      return "outline"
     case "DUE":
       return "warning"
     case "OVERDUE":

--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -183,13 +183,6 @@ impl CreditFacility {
             .expect("entity_first_persisted_at not found")
     }
 
-    pub fn activated_at(&self) -> Option<DateTime<Utc>> {
-        self.events.iter_all().find_map(|event| match event {
-            CreditFacilityEvent::Activated { activated_at, .. } => Some(*activated_at),
-            _ => None,
-        })
-    }
-
     pub fn structuring_fee(&self) -> UsdCents {
         self.terms.one_time_fee_rate.apply(self.amount)
     }
@@ -331,7 +324,7 @@ impl CreditFacility {
         let full_period = match last_accrual_start_date {
             Some(last_accrual_start_date) => interval.period_from(last_accrual_start_date).next(),
             None => interval.period_from(
-                self.activated_at()
+                self.activated_at
                     .ok_or(CreditFacilityError::NotActivatedYet)?,
             ),
         };
@@ -861,7 +854,7 @@ mod test {
         let mut accrual_period = credit_facility
             .terms
             .accrual_cycle_interval
-            .period_from(credit_facility.activated_at().expect("Not activated"));
+            .period_from(credit_facility.activated_at.expect("Not activated"));
         let mut next_accrual_period = credit_facility
             .next_interest_accrual_cycle_period()
             .unwrap();

--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -209,7 +209,7 @@ impl CreditFacility {
         Err(CreditFacilityError::ApprovalInProgress)
     }
 
-    fn is_activated(&self) -> bool {
+    pub fn is_activated(&self) -> bool {
         for event in self.events.iter_all() {
             match event {
                 CreditFacilityEvent::Activated { .. } => return true,

--- a/core/credit/src/disbursal/entity.rs
+++ b/core/credit/src/disbursal/entity.rs
@@ -213,7 +213,6 @@ impl Disbursal {
                 })
                 .defaulted_account_id(self.account_ids.disbursed_defaulted_account_id)
                 .due_date(self.disbursal_due_date)
-                .overdue_date(self.disbursal_due_date)
                 .recorded_at(now)
                 .audit_info(audit_info)
                 .build()

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -544,7 +544,7 @@ where
             return Err(CoreCreditError::CustomerNotActive);
         }
 
-        if facility.activated_at.is_none() {
+        if !facility.is_activated() {
             return Err(CreditFacilityError::NotActivatedYet.into());
         }
         let now = crate::time::now();

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -570,7 +570,7 @@ where
             .amount(amount)
             .account_ids(facility.account_ids)
             .disbursal_credit_account_id(facility.disbursal_credit_account_id)
-            .disbursal_due_date(facility.activated_at.expect("Facility is not active"))
+            .disbursal_due_date(facility.matures_at.expect("Facility is not active"))
             .audit_info(audit_info)
             .build()
             .expect("could not build new disbursal");

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -544,7 +544,7 @@ where
             return Err(CoreCreditError::CustomerNotActive);
         }
 
-        if facility.activated_at().is_none() {
+        if facility.activated_at.is_none() {
             return Err(CreditFacilityError::NotActivatedYet.into());
         }
         let now = crate::time::now();
@@ -570,7 +570,7 @@ where
             .amount(amount)
             .account_ids(facility.account_ids)
             .disbursal_credit_account_id(facility.disbursal_credit_account_id)
-            .disbursal_due_date(facility.activated_at().expect("Facility is not active"))
+            .disbursal_due_date(facility.activated_at.expect("Facility is not active"))
             .audit_info(audit_info)
             .build()
             .expect("could not build new disbursal");

--- a/core/credit/src/processes/activate_credit_facility/mod.rs
+++ b/core/credit/src/processes/activate_credit_facility/mod.rs
@@ -121,7 +121,7 @@ where
             .disbursal_credit_account_id(credit_facility.disbursal_credit_account_id)
             .disbursal_due_date(
                 credit_facility
-                    .activated_at()
+                    .activated_at
                     .expect("Facility is not active"),
             )
             .audit_info(audit_info.clone())

--- a/core/credit/src/processes/activate_credit_facility/mod.rs
+++ b/core/credit/src/processes/activate_credit_facility/mod.rs
@@ -119,11 +119,7 @@ where
             .amount(credit_facility.structuring_fee())
             .account_ids(credit_facility.account_ids)
             .disbursal_credit_account_id(credit_facility.disbursal_credit_account_id)
-            .disbursal_due_date(
-                credit_facility
-                    .activated_at
-                    .expect("Facility is not active"),
-            )
+            .disbursal_due_date(credit_facility.matures_at.expect("Facility is not active"))
             .audit_info(audit_info.clone())
             .build()
             .expect("could not build new disbursal");

--- a/core/credit/src/repayment_plan/entry.rs
+++ b/core/credit/src/repayment_plan/entry.rs
@@ -32,17 +32,27 @@ impl PartialOrd for CreditFacilityRepaymentPlanEntry {
 
 impl Ord for CreditFacilityRepaymentPlanEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let self_due_at = match self {
-            CreditFacilityRepaymentPlanEntry::Disbursal(o) => o.due_at,
-            CreditFacilityRepaymentPlanEntry::Interest(o) => o.due_at,
+        let ord = {
+            let self_due_at = match self {
+                Self::Disbursal(o) | Self::Interest(o) => o.due_at,
+            };
+            let other_due_at = match other {
+                Self::Disbursal(o) | Self::Interest(o) => o.due_at,
+            };
+            self_due_at.cmp(&other_due_at)
         };
 
-        let other_due_at = match other {
-            CreditFacilityRepaymentPlanEntry::Disbursal(o) => o.due_at,
-            CreditFacilityRepaymentPlanEntry::Interest(o) => o.due_at,
-        };
-
-        self_due_at.cmp(&other_due_at)
+        ord.then_with(|| match (self, other) {
+            (
+                CreditFacilityRepaymentPlanEntry::Interest(_),
+                CreditFacilityRepaymentPlanEntry::Disbursal(_),
+            ) => std::cmp::Ordering::Less,
+            (
+                CreditFacilityRepaymentPlanEntry::Disbursal(_),
+                CreditFacilityRepaymentPlanEntry::Interest(_),
+            ) => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal,
+        })
     }
 }
 


### PR DESCRIPTION
## Description

The current state of facility disbursals is:
- disbursals are created as `DUE`
- are marked as `OVERDUE` at maturity

This PR is to adjust disbursal due dates on credit facility to reflect that disbursals are:
- `NOT_YET_DUE` until maturity
  (we may also attach early repayment incentives/penalities on this state later on)
- `DUE` at maturity
- never become `OVERDUE` or `DEFAULTED` as of current implementation (se below)

In future we will likely
- introduce `OVERDUE` and use to control liquidation
- introduce `DEFAULTED` as a state that happens after liquidation date and likely never gets called since we should always be able to liquidate