### PR TITLE
fix: customer server audience default

### DIFF
--- a/lana/customer-server/src/config.rs
+++ b/lana/customer-server/src/config.rs
@@ -29,5 +29,5 @@ fn default_jwks_url() -> String {
 }
 
 fn aud() -> String {
-    "https://admin-api/graphql".to_string()
+    "https://customer-api/graphql".to_string()
 }


### PR DESCRIPTION
## Summary
- update customer server config so `aud()` returns `"https://customer-api/graphql"`

## Testing
- `make check-code` *(fails: could not download Rust stable toolchain)*