### PR TITLE
chore: remove stop_server force kill

### DIFF
--- a/bats/helpers.bash
+++ b/bats/helpers.bash
@@ -119,9 +119,6 @@ stop_server() {
   if [[ -f "$SERVER_PID_FILE" ]]; then
     kill -9 $(cat "$SERVER_PID_FILE") || true
   fi
-
-  lsof -i :5253 | tail -n 1 | awk '{print $2}' | xargs -r kill -9 || true
-  lsof -i :5254 | tail -n 1 | awk '{print $2}' | xargs -r kill -9 || true
 }
 
 gql_query() {


### PR DESCRIPTION
## Description

We have a conditional server kill where it is only killed if the server was started inside the test suite. If there was already a running server instance then we'd like to leave it running after the test for local workflow purposes.

### Note

The change that prompted this is that we're not starting test in suite anymore because we're now using the `--setup-suite-file` flag with a global server start in there. Needs to be investigated whether this can be removed