### PR TITLE
chore: make net balances signed

### DIFF
--- a/core/money/src/lib.rs
+++ b/core/money/src/lib.rs
@@ -199,6 +199,12 @@ impl fmt::Display for SignedUsdCents {
     }
 }
 
+impl Default for SignedUsdCents {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
 impl std::ops::Sub<SignedUsdCents> for SignedUsdCents {
     type Output = SignedUsdCents;
 

--- a/lana/admin-server/src/graphql/accounting/ledger_account.rs
+++ b/lana/admin-server/src/graphql/accounting/ledger_account.rs
@@ -221,21 +221,21 @@ impl From<Option<&cala_ledger::balance::AccountBalance>> for UsdLedgerAccountBal
                         .expect("positive"),
                     credit: UsdCents::try_from_usd(balance.details.settled.cr_balance)
                         .expect("positive"),
-                    net: UsdCents::try_from_usd(balance.settled()).expect("positive"),
+                    net: SignedUsdCents::from_usd(balance.settled()),
                 },
                 pending: UsdBalanceDetails {
                     debit: UsdCents::try_from_usd(balance.details.pending.dr_balance)
                         .expect("positive"),
                     credit: UsdCents::try_from_usd(balance.details.pending.cr_balance)
                         .expect("positive"),
-                    net: UsdCents::try_from_usd(balance.pending()).expect("positive"),
+                    net: SignedUsdCents::from_usd(balance.pending()),
                 },
                 encumbrance: UsdBalanceDetails {
                     debit: UsdCents::try_from_usd(balance.details.encumbrance.dr_balance)
                         .expect("positive"),
                     credit: UsdCents::try_from_usd(balance.details.encumbrance.cr_balance)
                         .expect("positive"),
-                    net: UsdCents::try_from_usd(balance.encumbrance()).expect("positive"),
+                    net: SignedUsdCents::from_usd(balance.encumbrance()),
                 },
             },
         }
@@ -246,7 +246,7 @@ impl From<Option<&cala_ledger::balance::AccountBalance>> for UsdLedgerAccountBal
 struct UsdBalanceDetails {
     debit: UsdCents,
     credit: UsdCents,
-    net: UsdCents,
+    net: SignedUsdCents,
 }
 
 #[derive(SimpleObject, Default)]
@@ -270,21 +270,21 @@ impl From<Option<&cala_ledger::balance::AccountBalance>> for BtcLedgerAccountBal
                         .expect("positive"),
                     credit: Satoshis::try_from_btc(balance.details.settled.cr_balance)
                         .expect("positive"),
-                    net: Satoshis::try_from_btc(balance.settled()).expect("positive"),
+                    net: SignedSatoshis::from_btc(balance.settled()),
                 },
                 pending: BtcBalanceDetails {
                     debit: Satoshis::try_from_btc(balance.details.pending.dr_balance)
                         .expect("positive"),
                     credit: Satoshis::try_from_btc(balance.details.pending.cr_balance)
                         .expect("positive"),
-                    net: Satoshis::try_from_btc(balance.pending()).expect("positive"),
+                    net: SignedSatoshis::from_btc(balance.pending()),
                 },
                 encumbrance: BtcBalanceDetails {
                     debit: Satoshis::try_from_btc(balance.details.encumbrance.dr_balance)
                         .expect("positive"),
                     credit: Satoshis::try_from_btc(balance.details.encumbrance.cr_balance)
                         .expect("positive"),
-                    net: Satoshis::try_from_btc(balance.encumbrance()).expect("positive"),
+                    net: SignedSatoshis::from_btc(balance.encumbrance()),
                 },
             },
         }
@@ -295,7 +295,7 @@ impl From<Option<&cala_ledger::balance::AccountBalance>> for BtcLedgerAccountBal
 struct BtcBalanceDetails {
     debit: Satoshis,
     credit: Satoshis,
-    net: Satoshis,
+    net: SignedSatoshis,
 }
 
 scalar!(AccountCode);

--- a/lana/admin-server/src/graphql/schema.graphql
+++ b/lana/admin-server/src/graphql/schema.graphql
@@ -226,7 +226,7 @@ type BtcAmount {
 type BtcBalanceDetails {
 	debit: Satoshis!
 	credit: Satoshis!
-	net: Satoshis!
+	net: SignedSatoshis!
 }
 
 type BtcLedgerAccountBalance {
@@ -1457,6 +1457,10 @@ enum Role {
 
 scalar Satoshis
 
+scalar SignedSatoshis
+
+scalar SignedUsdCents
+
 enum SortDirection {
 	ASC
 	DESC
@@ -1618,7 +1622,7 @@ type UsdAmount {
 type UsdBalanceDetails {
 	debit: UsdCents!
 	credit: UsdCents!
-	net: UsdCents!
+	net: SignedUsdCents!
 }
 
 scalar UsdCents

--- a/lana/admin-server/src/primitives.rs
+++ b/lana/admin-server/src/primitives.rs
@@ -8,7 +8,8 @@ pub use lana_app::{
         ApprovalProcessId, ChartId, CommitteeId, CreditFacilityId, CustomerId, DepositAccountId,
         DepositId, DisbursalId, DisbursalStatus, DocumentId, LanaRole, LedgerTransactionId,
         ManualTransactionId, PaymentAllocationId, PaymentId, PolicyId, ReportId, ReportProgress,
-        Satoshis, Subject, TermsTemplateId, UsdCents, UserId, WithdrawalId,
+        Satoshis, SignedSatoshis, SignedUsdCents, Subject, TermsTemplateId, UsdCents, UserId,
+        WithdrawalId,
     },
     terms::CollateralizationState,
 };


### PR DESCRIPTION
## Description

This is an artefact of ranged balances where we can correctly have negative net balance amounts depending on the date range selected.