### PR TITLE
feat: Add Komainu integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,7 @@ dependencies = [
  "p256",
  "pkcs8",
  "reqwest",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1214,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,12 +1475,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1571,6 +1623,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1804,6 +1866,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1937,6 +2000,17 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2478,6 +2552,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "komainu"
+version = "0.3.568-dev"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "p256",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "kratos-admin"
 version = "0.3.568-dev"
 dependencies = [
@@ -3013,6 +3104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,6 +3309,15 @@ checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3643,6 +3755,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -3668,6 +3781,16 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tower-service",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3915,6 +4038,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -4746,6 +4883,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +900,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -2451,6 +2490,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2607,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "p256",
+ "pkcs8",
  "reqwest",
  "serde",
  "serde_json",
@@ -3145,6 +3195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,12 +3309,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -4004,6 +4081,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,6 +4112,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sdd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,7 +2615,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ google-cloud-storage = { version = "0.24.0", default-features = false, features 
 rand = "0.9"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 p256 = "0.13.2"
+pkcs8 = { version = "0.10.2", features = ["encryption"] }
 
 # Note: The workspace uses resolver = "2" which should unify features across all dependencies.
 # The reqwest dependency is configured with rustls-tls to prevent OpenSSL dependencies in CI builds.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "lib/outbox",
   "lib/jwks-utils",
   "lib/kratos-admin",
+  "lib/komainu",
   "lib/cloud-storage",
 ]
 
@@ -96,7 +97,7 @@ serde_yaml = "0.9.32"
 serde_json = "1.0.133"
 serde_with = "3.12.0"
 futures = "0.3.29"
-reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls", "charset", "http2", "macos-system-configuration", "multipart"] }
+reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls", "charset", "http2", "macos-system-configuration", "multipart", "socks"] }
 rust_decimal_macros = "1.37.1"
 rust_decimal = "1.37.1"
 rusty-money = { version = "0.4", features = ["iso", "crypto"] }
@@ -121,6 +122,7 @@ google-cloud-storage = { version = "0.24.0", default-features = false, features 
 ] }
 rand = "0.9"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
+p256 = "0.13.2"
 
 # Note: The workspace uses resolver = "2" which should unify features across all dependencies.
 # The reqwest dependency is configured with rustls-tls to prevent OpenSSL dependencies in CI builds.

--- a/deny.toml
+++ b/deny.toml
@@ -224,6 +224,11 @@ expression = "LicenseRef-FSL-1.1-ALv2"
 license-files = []
 
 [[licenses.clarify]]
+crate = "komainu"
+expression = "LicenseRef-FSL-1.1-ALv2"
+license-files = []
+
+[[licenses.clarify]]
 crate = "lana-app"
 expression = "LicenseRef-FSL-1.1-ALv2"
 license-files = []

--- a/lib/komainu/Cargo.toml
+++ b/lib/komainu/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "komainu"
+version = "0.3.568-dev"
+license = "FSL-1.1-ALv2"
+edition = "2021"
+
+[features]
+
+fail-on-warnings = []
+
+[dependencies]
+
+uuid = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
+p256 = { workspace = true }
+tokio = { workspace = true }
+chrono = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }

--- a/lib/komainu/Cargo.toml
+++ b/lib/komainu/Cargo.toml
@@ -17,7 +17,9 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
 p256 = { workspace = true }
+pkcs8 = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
+

--- a/lib/komainu/Cargo.toml
+++ b/lib/komainu/Cargo.toml
@@ -21,3 +21,4 @@ tokio = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
+rust_decimal = { workspace = true }

--- a/lib/komainu/Cargo.toml
+++ b/lib/komainu/Cargo.toml
@@ -10,7 +10,6 @@ fail-on-warnings = []
 
 [dependencies]
 
-uuid = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -22,4 +21,3 @@ tokio = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
-

--- a/lib/komainu/src/bin/test.rs
+++ b/lib/komainu/src/bin/test.rs
@@ -1,0 +1,23 @@
+use komainu::{KomainuClient, KomainuConfig, KomainuProxy, KomainuSecretKey};
+
+#[tokio::main]
+async fn main() {
+    let config = KomainuConfig {
+        api_user: "".to_string(),
+        api_secret: "".to_string(),
+        secret_key: KomainuSecretKey::Plain {
+            dem: r#"-----BEGIN PRIVATE KEY-----
+
+-----END PRIVATE KEY-----"#
+                .to_string(),
+        },
+        proxy: Some(KomainuProxy::Socks5("localhost:9915".to_string())),
+        komainu_test: true,
+    };
+
+    let client = KomainuClient::new(config);
+
+    let wallets = client.list_wallets().await;
+
+    println!("{:#?}", wallets);
+}

--- a/lib/komainu/src/bin/test.rs
+++ b/lib/komainu/src/bin/test.rs
@@ -5,10 +5,11 @@ async fn main() {
     let config = KomainuConfig {
         api_user: "".to_string(),
         api_secret: "".to_string(),
-        secret_key: KomainuSecretKey::Plain {
-            dem: r#"-----BEGIN PRIVATE KEY-----
+        secret_key: KomainuSecretKey::Encrypted {
+            passphrase: "".to_string(),
+            dem: r#"-----BEGIN ENCRYPTED PRIVATE KEY-----
 
------END PRIVATE KEY-----"#
+-----END ENCRYPTED PRIVATE KEY-----"#
                 .to_string(),
         },
         proxy: Some(KomainuProxy::Socks5("localhost:9915".to_string())),

--- a/lib/komainu/src/config.rs
+++ b/lib/komainu/src/config.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct KomainuConfig {
+    pub api_user: String,
+    pub api_secret: String,
+    pub secret_key: KomainuSecretKey,
+    pub proxy: Option<KomainuProxy>,
+    pub komainu_test: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum KomainuSecretKey {
+    Encrypted { dem: String, passphrase: String },
+    Plain { dem: String },
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum KomainuProxy {
+    Socks5(String),
+}

--- a/lib/komainu/src/error.rs
+++ b/lib/komainu/src/error.rs
@@ -4,4 +4,10 @@ use thiserror::Error;
 pub enum KomainuError {
     #[error("KomainuError - ReqwestError: {0}")]
     ReqwestError(#[from] reqwest::Error),
+    #[error("KomainuError - KomainuError: {error_code}")]
+    KomainuError {
+        error_code: String,
+        errors: Vec<String>,
+        status: u16,
+    },
 }

--- a/lib/komainu/src/error.rs
+++ b/lib/komainu/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum KomainuError {
+    #[error("KomainuError - ReqwestError: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+}

--- a/lib/komainu/src/lib.rs
+++ b/lib/komainu/src/lib.rs
@@ -1,0 +1,141 @@
+use std::time::Duration;
+use std::{sync::Arc, time::Instant};
+
+use base64::{prelude::BASE64_STANDARD, Engine};
+use p256::ecdsa::{signature::Signer as _, Signature, SigningKey};
+use p256::pkcs8::DecodePrivateKey as _;
+use reqwest::{Client, Method, Proxy, RequestBuilder, Url};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+use tokio::sync::Mutex;
+
+mod config;
+mod error;
+mod wire;
+
+pub use config::{KomainuConfig, KomainuProxy, KomainuSecretKey};
+pub use error::KomainuError;
+pub use wire::*;
+
+#[derive(Clone)]
+pub struct KomainuClient {
+    http_client: Client,
+    access_token: Arc<Mutex<Option<AccessToken>>>,
+    signing_key: SigningKey,
+    config: KomainuConfig,
+}
+
+impl KomainuClient {
+    pub fn new(config: KomainuConfig) -> Self {
+        let signing_key = match &config.secret_key {
+            KomainuSecretKey::Encrypted { .. } => todo!(),
+            KomainuSecretKey::Plain { dem } => p256::SecretKey::from_pkcs8_pem(dem).unwrap().into(),
+        };
+
+        let http_client = if let Some(KomainuProxy::Socks5(proxy)) = &config.proxy {
+            Client::builder()
+                .proxy(Proxy::all(format!("socks5://{proxy}")).expect("correct proxy scheme"))
+                .build()
+                .expect("correct client")
+        } else {
+            Client::new()
+        };
+
+        Self {
+            http_client,
+            access_token: Default::default(),
+            signing_key,
+            config,
+        }
+    }
+
+    pub async fn list_wallets(&self) -> Result<Value, KomainuError> {
+        Ok(self.get("v1/custody/wallets").await?)
+    }
+}
+
+impl KomainuClient {
+    async fn get<T: DeserializeOwned>(&self, endpoint: &str) -> Result<T, reqwest::Error> {
+        self.request::<()>(Method::GET, endpoint, None)
+            .await?
+            .send()
+            .await?
+            .json()
+            .await
+    }
+
+    async fn request<T: Serialize>(
+        &self,
+        method: Method,
+        endpoint: &str,
+        _body: Option<T>,
+    ) -> Result<RequestBuilder, reqwest::Error> {
+        let url: Url = format!("https://api-uat.komainu.io/{endpoint}")
+            .parse()
+            .expect("valid URL");
+
+        let access_token = self.get_access_token().await?;
+        let timestamp = chrono::Utc::now().timestamp_millis();
+
+        let canonical_string = format!(
+            "{},{},{},sha256={},sha256={},{}",
+            url.host_str().expect("URL with host"),
+            method.as_str().to_lowercase(),
+            url.path(),
+            BASE64_STANDARD.encode(Sha256::digest("")),
+            BASE64_STANDARD.encode(Sha256::digest(&access_token)),
+            timestamp
+        );
+
+        let signature: Signature = self.signing_key.sign(canonical_string.as_bytes());
+
+        Ok(self
+            .http_client
+            .get(url)
+            .bearer_auth(access_token)
+            .header("X-Timestamp", timestamp)
+            .header(
+                "X-Signature",
+                BASE64_STANDARD.encode(signature.to_der().to_bytes()),
+            ))
+    }
+
+    async fn get_access_token(&self) -> Result<String, reqwest::Error> {
+        let mut access_token = self.access_token.lock().await;
+        match access_token.as_ref() {
+            Some(token) if token.expires_at > Instant::now() => Ok(token.access_token.clone()),
+            _ => {
+                let new_token = self.refresh_token().await?;
+                let token = new_token.access_token.clone();
+                *access_token = Some(new_token);
+                Ok(token)
+            }
+        }
+    }
+
+    async fn refresh_token(&self) -> Result<AccessToken, reqwest::Error> {
+        let response: GetTokenResponse = self
+            .http_client
+            .post("https://api-uat.komainu.io/v1/auth/token")
+            .json(&GetToken {
+                api_user: &self.config.api_user,
+                api_secret: &self.config.api_secret,
+            })
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(AccessToken {
+            access_token: response.access_token,
+            expires_at: Instant::now() + Duration::from_secs(response.expires_in),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct AccessToken {
+    access_token: String,
+    expires_at: Instant,
+}

--- a/lib/komainu/src/lib.rs
+++ b/lib/komainu/src/lib.rs
@@ -139,11 +139,17 @@ impl KomainuClient {
             .map(|payload| serde_json::to_vec(&payload).expect("encode to JSON"))
             .unwrap_or_default();
 
+        let mut path_query = url.path().to_string();
+        if let Some(query) = url.query() {
+            path_query.push('?');
+            path_query.push_str(query);
+        }
+
         let canonical_string = format!(
             "{},{},{},sha256={},sha256={},{}",
             url.host_str().expect("URL with host"),
             method.as_str().to_lowercase(),
-            url.path(),
+            path_query,
             BASE64_STANDARD.encode(Sha256::digest(&payload)),
             BASE64_STANDARD.encode(Sha256::digest(&access_token)),
             timestamp

--- a/lib/komainu/src/lib.rs
+++ b/lib/komainu/src/lib.rs
@@ -72,9 +72,24 @@ impl KomainuClient {
         }
     }
 
-    pub async fn get_wallet(&self, wallet_id: String) -> Result<Wallet, KomainuError> {
-        self.get_one(&format!("v1/custody/wallets/{wallet_id}"))
-            .await
+    pub async fn get_request(&self, id: &str) -> Result<Request, KomainuError> {
+        self.get_one(&format!("v1/custody/requests/{id}")).await
+    }
+
+    pub async fn list_requests(&self) -> Result<Vec<Request>, KomainuError> {
+        self.get_many("v1/custody/requests").await
+    }
+
+    pub async fn get_transaction(&self, id: &str) -> Result<Transaction, KomainuError> {
+        self.get_one(&format!("v1/custody/transactions/{id}")).await
+    }
+
+    pub async fn list_transactions(&self) -> Result<Vec<Transaction>, KomainuError> {
+        self.get_many("v1/custody/transactions").await
+    }
+
+    pub async fn get_wallet(&self, id: &str) -> Result<Wallet, KomainuError> {
+        self.get_one(&format!("v1/custody/wallets/{id}")).await
     }
 
     pub async fn list_wallets(&self) -> Result<Vec<Wallet>, KomainuError> {

--- a/lib/komainu/src/lib.rs
+++ b/lib/komainu/src/lib.rs
@@ -1,3 +1,7 @@
+mod config;
+mod error;
+mod wire;
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -15,13 +19,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use sha2::{Digest as _, Sha256};
 use tokio::sync::Mutex;
 
-mod config;
-mod error;
-mod wire;
-
 pub use config::{KomainuConfig, KomainuProxy, KomainuSecretKey};
 pub use error::KomainuError;
-pub use wire::*;
+use wire::{Fallible, GetToken, GetTokenResponse, Many};
+pub use wire::{Request, Transaction, Wallet};
 
 #[derive(Clone)]
 pub struct KomainuClient {

--- a/lib/komainu/src/lib.rs
+++ b/lib/komainu/src/lib.rs
@@ -72,26 +72,32 @@ impl KomainuClient {
         }
     }
 
+    #[tracing::instrument(name = "komainu.get_request", skip(self))]
     pub async fn get_request(&self, id: &str) -> Result<Request, KomainuError> {
         self.get_one(&format!("v1/custody/requests/{id}")).await
     }
 
+    #[tracing::instrument(name = "komainu.list_requests", skip(self))]
     pub async fn list_requests(&self) -> Result<Vec<Request>, KomainuError> {
         self.get_many("v1/custody/requests").await
     }
 
+    #[tracing::instrument(name = "komainu.get_transaction", skip(self))]
     pub async fn get_transaction(&self, id: &str) -> Result<Transaction, KomainuError> {
         self.get_one(&format!("v1/custody/transactions/{id}")).await
     }
 
+    #[tracing::instrument(name = "komainu.list_transactions", skip(self))]
     pub async fn list_transactions(&self) -> Result<Vec<Transaction>, KomainuError> {
         self.get_many("v1/custody/transactions").await
     }
 
+    #[tracing::instrument(name = "komainu.get_wallet", skip(self))]
     pub async fn get_wallet(&self, id: &str) -> Result<Wallet, KomainuError> {
         self.get_one(&format!("v1/custody/wallets/{id}")).await
     }
 
+    #[tracing::instrument(name = "komainu.list_wallets", skip(self))]
     pub async fn list_wallets(&self) -> Result<Vec<Wallet>, KomainuError> {
         self.get_many("v1/custody/wallets").await
     }
@@ -195,6 +201,7 @@ impl KomainuClient {
         }
     }
 
+    #[tracing::instrument(name = "komainu.refresh_token", skip(self))]
     async fn refresh_token(&self) -> Result<AccessToken, reqwest::Error> {
         let response: GetTokenResponse = self
             .http_client

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize)]
@@ -6,6 +7,87 @@ pub struct Wallet {
     pub address: String,
     pub asset: String,
     pub status: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RequestType {
+    CreateTransaction,
+    CollateralOperation,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RequestStatus {
+    Created,
+    Pending,
+    Approved,
+    Rejected,
+    Cancelled,
+    Expired,
+    Blocked,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RequestEntity {
+    Transaction,
+    Collateral,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Request {
+    pub id: String,
+    pub request_type: RequestType,
+    pub status: RequestStatus,
+    pub entity: RequestEntity,
+    pub entity_id: String,
+    pub requested_by: String,
+    pub requested_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub workspace: String,
+    pub organization: String,
+    pub account: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransactionDirection {
+    In,
+    Out,
+    Flat,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransactionStatus {
+    Pending,
+    Broadcasted,
+    Confirmed,
+    Failed,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Transaction {
+    pub id: String,
+    pub wallet_id: String,
+    pub direction: TransactionDirection,
+    pub asset: String,
+    pub amount: String,
+    pub fees: String,
+    pub created_at: DateTime<Utc>,
+    pub transaction_type: String,
+    pub status: TransactionStatus,
+    pub tx_hash: String,
+    pub sender_address: String,
+    pub receiver_address: String,
+    pub note: String,
+    pub created_by: String,
+    pub workspace: String,
+    pub external_reference: String,
+    pub organization: String,
+    pub account: String,
 }
 
 #[derive(Clone, Serialize)]

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -1,12 +1,87 @@
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Wallet {
+    pub id: String,
     pub name: String,
-    pub address: String,
     pub asset: String,
-    pub status: String,
+    pub address: String,
+    pub balance: WalletBalance,
+    pub workspace: String,
+    pub external_reference: String,
+    pub account: String,
+    pub organization: String,
+    pub wallet_category: WalletCategory,
+    pub status: WalletStatus,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Request {
+    pub id: String,
+    pub request_type: RequestType,
+    pub status: RequestStatus,
+    pub entity: RequestEntity,
+    pub entity_id: String,
+    pub requested_by: String,
+    pub requested_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub workspace: String,
+    pub organization: String,
+    pub account: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Transaction {
+    pub id: String,
+    pub wallet_id: String,
+    pub direction: TransactionDirection,
+    pub asset: String,
+    pub amount: Decimal,
+    pub fees: Decimal,
+    pub created_at: DateTime<Utc>,
+    pub transaction_type: String,
+    pub status: TransactionStatus,
+    pub tx_hash: String,
+    pub sender_address: String,
+    pub receiver_address: String,
+    pub note: String,
+    pub created_by: String,
+    pub workspace: String,
+    pub external_reference: String,
+    pub organization: String,
+    pub account: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct WalletBalance {
+    pub total: Decimal,
+    pub available: Decimal,
+    pub staked: Decimal,
+    pub locked: Decimal,
+    pub balance_updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub enum WalletCategory {
+    Custody,
+    Staking,
+    Collateral,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub enum WalletStatus {
+    Active,
+    Inactive,
+    Approved,
+    HsmCoinUpdated,
+    Pending,
+    PendingCreateInHsm,
+    PendingViewOnly,
+    Rejected,
+    ViewOnly,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -36,22 +111,6 @@ pub enum RequestEntity {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct Request {
-    pub id: String,
-    pub request_type: RequestType,
-    pub status: RequestStatus,
-    pub entity: RequestEntity,
-    pub entity_id: String,
-    pub requested_by: String,
-    pub requested_at: DateTime<Utc>,
-    pub expires_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    pub workspace: String,
-    pub organization: String,
-    pub account: String,
-}
-
-#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionDirection {
     In,
@@ -66,28 +125,6 @@ pub enum TransactionStatus {
     Broadcasted,
     Confirmed,
     Failed,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Transaction {
-    pub id: String,
-    pub wallet_id: String,
-    pub direction: TransactionDirection,
-    pub asset: String,
-    pub amount: String,
-    pub fees: String,
-    pub created_at: DateTime<Utc>,
-    pub transaction_type: String,
-    pub status: TransactionStatus,
-    pub tx_hash: String,
-    pub sender_address: String,
-    pub receiver_address: String,
-    pub note: String,
-    pub created_by: String,
-    pub workspace: String,
-    pub external_reference: String,
-    pub organization: String,
-    pub account: String,
 }
 
 #[derive(Clone, Serialize)]

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -141,10 +141,8 @@ pub struct GetTokenResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct Many<T> {
-    pub count: u64,
     pub data: Vec<T>,
     pub has_next: bool,
-    pub page: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -8,10 +8,10 @@ pub struct Wallet {
     pub status: String,
 }
 
-#[derive(Serialize)]
-pub struct GetToken<'a> {
-    pub api_user: &'a str,
-    pub api_secret: &'a str,
+#[derive(Clone, Serialize)]
+pub struct GetToken {
+    pub api_user: String,
+    pub api_secret: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -22,8 +22,8 @@ pub struct GetTokenResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct Many<T> {
-    count: u64,
-    data: Vec<T>,
-    has_next: bool,
-    page: u64,
+    pub count: u64,
+    pub data: Vec<T>,
+    pub has_next: bool,
+    pub page: u64,
 }

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Wallet {
+    pub name: String,
+    pub address: String,
+    pub asset: String,
+    pub status: String,
+}
+
+#[derive(Serialize)]
+pub struct GetToken<'a> {
+    pub api_user: &'a str,
+    pub api_secret: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GetTokenResponse {
+    pub access_token: String,
+    pub expires_in: u64,
+}

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -19,3 +19,11 @@ pub struct GetTokenResponse {
     pub access_token: String,
     pub expires_in: u64,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct Many<T> {
+    count: u64,
+    data: Vec<T>,
+    has_next: bool,
+    page: u64,
+}

--- a/lib/komainu/src/wire.rs
+++ b/lib/komainu/src/wire.rs
@@ -146,3 +146,14 @@ pub struct Many<T> {
     pub has_next: bool,
     pub page: u64,
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Fallible<T> {
+    Error {
+        error_code: String,
+        errors: Vec<String>,
+        status: u16,
+    },
+    Ok(T),
+}


### PR DESCRIPTION
**Implemented**:

- [x] get wallet
- [x] list wallets
- [x] get transaction
- [x] list transactions
- [x] get request
- [x] list requests
- [ ] create request
- [ ] notifications

**Issues**:

- documentation only lists notifications for requests, not for incoming transactions
- how to expose notification HTTP server?
- only mainnet, even on testing environment?
- test account does not allow list wallet addresses or get wallet address by index
- test account does not allow creating requests
- it seems we need to keep track of address indices (e. g. what indices have been used and what indices are assigned to what credit facitilities)