### PR TITLE
Fix RescheduleAt tracing label

### DIFF
--- a/lib/job/src/executor.rs
+++ b/lib/job/src/executor.rs
@@ -330,7 +330,7 @@ impl JobExecutor {
                 Self::reschedule_job(op, id, t).await?;
             }
             JobCompletion::RescheduleAt(t) => {
-                span.record("conclusion", "RescheduleAtAt");
+                span.record("conclusion", "RescheduleAt");
                 let op = repo.begin_op().await?;
                 Self::reschedule_job(op, id, t).await?;
             }


### PR DESCRIPTION
## Summary
- correct the trace message for `JobCompletion::RescheduleAt`

## Testing
- `cargo test -p job` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684451fe5c84832397f1e50969a70c4f