### PR TITLE
Use formatDate in audit table

### DIFF
--- a/apps/admin-panel/app/audit/list.tsx
+++ b/apps/admin-panel/app/audit/list.tsx
@@ -2,7 +2,7 @@
 import { gql } from "@apollo/client"
 import { useTranslations } from "next-intl"
 
-import DateWithTooltip from "@lana/web/components/date-with-tooltip"
+import { formatDate } from "@lana/web/utils"
 
 import { AuditEntry, useAuditLogsQuery } from "@/lib/graphql/generated"
 import PaginatedTable, {
@@ -72,7 +72,7 @@ const AuditLogsList = () => {
     {
       key: "recordedAt",
       label: t("headers.recordedAt"),
-      render: (date) => <DateWithTooltip value={date} />,
+      render: (date) => formatDate(date),
     },
   ]
 


### PR DESCRIPTION
## Summary
- show full timestamp in admin-panel's audit log list using `formatDate`

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find configuration file)*
- `pnpm -r tsc-check` *(fails: cannot find module `@/public/icons/...`)*

------
https://chatgpt.com/codex/tasks/task_e_684c4cb1c56c832fa937e40ac806eebe