### PR TITLE
chore: removing env var that don't need to change

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -209,7 +209,6 @@
         DATABASE_URL = "postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:5433/pg?sslmode=disable";
         PG_CON = "${DATABASE_URL}";
         CUSTODIAN_ENCRYPTION_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
-        EVENT_SCHEMAS_OUT_DIR = "lana/entity-rollups/schemas";
       };
     in
       with pkgs; {

--- a/lana/entity-rollups/src/lib.rs
+++ b/lana/entity-rollups/src/lib.rs
@@ -30,7 +30,11 @@ enum Commands {
 #[derive(Args)]
 struct UpdateSchemasArgs {
     /// Output directory for schema files
-    #[arg(long, env = "EVENT_SCHEMAS_OUT_DIR", default_value = "./schemas")]
+    #[arg(
+        long,
+        env = "EVENT_SCHEMAS_OUT_DIR",
+        default_value = "lana/entity-rollups/schemas"
+    )]
     schemas_out_dir: String,
 }
 


### PR DESCRIPTION
we already have a lot of env variable we need to dig with. it had a mental overhead to have more (when working on flake.nix or .envrc) so we should remove this, unless there is a specific for why this could be dynamic