### PR TITLE
feat: add 'reserve for liquidation' ledger template

### DIFF
--- a/core/credit/src/ledger/constants.rs
+++ b/core/credit/src/ledger/constants.rs
@@ -23,6 +23,11 @@ pub const CREDIT_FACILITY_REMAINING_ACCOUNT_SET_REF: &str = "credit-facility-rem
 pub const CREDIT_COLLATERAL_ACCOUNT_SET_NAME: &str = "Credit Collateral Account Set";
 pub const CREDIT_COLLATERAL_ACCOUNT_SET_REF: &str = "credit-collateral-account-set";
 
+pub const CREDIT_FACILITY_IN_LIQUIDATION_ACCOUNT_SET_NAME: &str =
+    "Credit Facility In-Liquidation Account Set";
+pub const CREDIT_FACILITY_IN_LIQUIDATION_ACCOUNT_SET_REF: &str =
+    "credit-facility-in-liquidation-account-set";
+
 pub const SHORT_TERM_CREDIT_INDIVIDUAL_DISBURSED_RECEIVABLE_ACCOUNT_SET_NAME: &str =
     "Short Term Credit Individual Disbursed Receivable Account Set";
 pub const SHORT_TERM_CREDIT_INDIVIDUAL_DISBURSED_RECEIVABLE_ACCOUNT_SET_REF: &str =

--- a/core/credit/src/ledger/constants.rs
+++ b/core/credit/src/ledger/constants.rs
@@ -8,6 +8,13 @@ pub const CREDIT_FACILITY_OMNIBUS_ACCOUNT_SET_NAME: &str = "Credit Facility Omni
 pub const CREDIT_FACILITY_OMNIBUS_ACCOUNT_SET_REF: &str = "credit-facility-omnibus-account-set";
 pub const CREDIT_FACILITY_OMNIBUS_ACCOUNT_REF: &str = "credit-facility-omnibus-account";
 
+pub const CREDIT_FACILITY_IN_LIQUIDATION_OMNIBUS_ACCOUNT_SET_NAME: &str =
+    "Credit Facility In-Liquidation Omnibus Account Set";
+pub const CREDIT_FACILITY_IN_LIQUIDATION_OMNIBUS_ACCOUNT_SET_REF: &str =
+    "credit-facility-in-liquidation-omnibus-account-set";
+pub const CREDIT_FACILITY_IN_LIQUIDATION_OMNIBUS_ACCOUNT_REF: &str =
+    "credit-facility-in-liquidation-omnibus-account";
+
 // Summary Accounts
 pub const CREDIT_FACILITY_REMAINING_ACCOUNT_SET_NAME: &str =
     "Credit Facility Remaining Account Set";

--- a/core/credit/src/ledger/credit_facility_accounts.rs
+++ b/core/credit/src/ledger/credit_facility_accounts.rs
@@ -13,6 +13,7 @@ use crate::{
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct CreditFacilityAccountIds {
     pub facility_account_id: CalaAccountId,
+    pub in_liquidation_account_id: CalaAccountId,
     pub disbursed_receivable_not_yet_due_account_id: CalaAccountId,
     pub disbursed_receivable_due_account_id: CalaAccountId,
     pub disbursed_receivable_overdue_account_id: CalaAccountId,
@@ -31,6 +32,7 @@ impl CreditFacilityAccountIds {
     pub fn new() -> Self {
         Self {
             facility_account_id: CalaAccountId::new(),
+            in_liquidation_account_id: CalaAccountId::new(),
             disbursed_receivable_not_yet_due_account_id: CalaAccountId::new(),
             disbursed_receivable_due_account_id: CalaAccountId::new(),
             disbursed_receivable_overdue_account_id: CalaAccountId::new(),

--- a/core/credit/src/ledger/credit_facility_accounts.rs
+++ b/core/credit/src/ledger/credit_facility_accounts.rs
@@ -81,3 +81,12 @@ pub struct CreditFacilityInterestAccrual {
     pub period: InterestPeriod,
     pub credit_facility_account_ids: CreditFacilityAccountIds,
 }
+
+#[derive(Debug, Clone)]
+pub struct ObligationReserveForLiquidation {
+    pub tx_id: LedgerTxId,
+    pub tx_ref: String,
+    pub outstanding: UsdCents,
+    pub credit_facility_account_ids: CreditFacilityAccountIds,
+    pub effective: chrono::NaiveDate,
+}

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -167,6 +167,7 @@ pub struct CreditLedger {
     journal_id: JournalId,
     facility_omnibus_account_ids: LedgerOmnibusAccountIds,
     collateral_omnibus_account_ids: LedgerOmnibusAccountIds,
+    in_liquidation_omnibus_account_ids: LedgerOmnibusAccountIds,
     internal_account_sets: CreditFacilityInternalAccountSets,
     credit_facility_control_id: VelocityControlId,
     usd: Currency,
@@ -208,6 +209,17 @@ impl CreditLedger {
             format!("{journal_id}:{CREDIT_FACILITY_OMNIBUS_ACCOUNT_REF}"),
             CREDIT_FACILITY_OMNIBUS_ACCOUNT_SET_NAME.to_string(),
             facility_omnibus_normal_balance_type,
+        )
+        .await?;
+
+        let in_liquidation_omnibus_normal_balance_type = DebitOrCredit::Debit;
+        let in_liquidation_omnibus_account_ids = Self::find_or_create_omnibus_account(
+            cala,
+            journal_id,
+            format!("{journal_id}:{CREDIT_FACILITY_IN_LIQUIDATION_OMNIBUS_ACCOUNT_SET_REF}"),
+            format!("{journal_id}:{CREDIT_FACILITY_IN_LIQUIDATION_OMNIBUS_ACCOUNT_REF}"),
+            CREDIT_FACILITY_IN_LIQUIDATION_OMNIBUS_ACCOUNT_SET_NAME.to_string(),
+            in_liquidation_omnibus_normal_balance_type,
         )
         .await?;
 
@@ -787,6 +799,7 @@ impl CreditLedger {
             journal_id,
             facility_omnibus_account_ids,
             collateral_omnibus_account_ids,
+            in_liquidation_omnibus_account_ids,
             internal_account_sets,
             credit_facility_control_id,
             usd: Currency::USD,

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -108,6 +108,7 @@ pub struct InterestReceivable {
 pub struct CreditFacilityInternalAccountSets {
     pub facility: InternalAccountSetDetails,
     pub collateral: InternalAccountSetDetails,
+    pub in_liquidation: InternalAccountSetDetails,
     pub disbursed_receivable: DisbursedReceivable,
     pub disbursed_defaulted: InternalAccountSetDetails,
     pub interest_receivable: InterestReceivable,
@@ -121,6 +122,7 @@ impl CreditFacilityInternalAccountSets {
         let Self {
             facility,
             collateral,
+            in_liquidation,
             interest_income,
             fee_income,
 
@@ -142,6 +144,7 @@ impl CreditFacilityInternalAccountSets {
         let mut ids = vec![
             facility.id,
             collateral.id,
+            in_liquidation.id,
             interest_income.id,
             fee_income.id,
             disbursed_defaulted.id,
@@ -240,6 +243,16 @@ impl CreditLedger {
             format!("{journal_id}:{CREDIT_COLLATERAL_ACCOUNT_SET_REF}"),
             CREDIT_COLLATERAL_ACCOUNT_SET_NAME.to_string(),
             collateral_normal_balance_type,
+        )
+        .await?;
+
+        let in_liquidation_normal_balance_type = DebitOrCredit::Credit;
+        let in_liquidation_account_set_id = Self::find_or_create_account_set(
+            cala,
+            journal_id,
+            format!("{journal_id}:{CREDIT_FACILITY_IN_LIQUIDATION_ACCOUNT_SET_REF}"),
+            CREDIT_FACILITY_IN_LIQUIDATION_ACCOUNT_SET_NAME.to_string(),
+            in_liquidation_normal_balance_type,
         )
         .await?;
 
@@ -759,6 +772,10 @@ impl CreditLedger {
             collateral: InternalAccountSetDetails {
                 id: collateral_account_set_id,
                 normal_balance_type: collateral_normal_balance_type,
+            },
+            in_liquidation: InternalAccountSetDetails {
+                id: in_liquidation_account_set_id,
+                normal_balance_type: in_liquidation_normal_balance_type,
             },
             disbursed_receivable,
             disbursed_defaulted: InternalAccountSetDetails {

--- a/core/credit/src/ledger/mod.rs
+++ b/core/credit/src/ledger/mod.rs
@@ -945,6 +945,7 @@ impl CreditLedger {
         CreditFacilityAccountIds {
             facility_account_id,
             collateral_account_id,
+
             disbursed_receivable_not_yet_due_account_id,
             disbursed_receivable_due_account_id,
             disbursed_receivable_overdue_account_id,
@@ -954,6 +955,7 @@ impl CreditLedger {
             interest_receivable_overdue_account_id,
             interest_defaulted_account_id,
 
+            in_liquidation_account_id: _,
             fee_income_account_id: _,
             interest_income_account_id: _,
         }: CreditFacilityAccountIds,
@@ -1723,6 +1725,7 @@ impl CreditLedger {
     ) -> Result<(), CreditLedgerError> {
         let CreditFacilityAccountIds {
             facility_account_id,
+            in_liquidation_account_id,
             disbursed_receivable_not_yet_due_account_id,
             disbursed_receivable_due_account_id,
             disbursed_receivable_overdue_account_id,
@@ -1763,6 +1766,22 @@ impl CreditLedger {
             facility_reference,
             facility_name,
             facility_name,
+        )
+        .await?;
+
+        let in_liquidation_reference =
+            &format!("credit-facility-obs-in-liquidation:{}", credit_facility_id);
+        let in_liquidation_name = &format!(
+            "Off-Balance-Sheet In-Liquidation Account for Credit Facility {}",
+            credit_facility_id
+        );
+        self.create_account_in_op(
+            op,
+            in_liquidation_account_id,
+            self.internal_account_sets.in_liquidation,
+            in_liquidation_reference,
+            in_liquidation_name,
+            in_liquidation_name,
         )
         .await?;
 

--- a/core/credit/src/ledger/templates/mod.rs
+++ b/core/credit/src/ledger/templates/mod.rs
@@ -11,6 +11,7 @@ mod obligation_overdue_balance;
 mod payment_allocation;
 mod post_accrued_interest;
 mod remove_collateral;
+mod reserve_for_liquidation;
 
 pub use accrue_interest::*;
 pub use activate_credit_facility::*;
@@ -25,3 +26,4 @@ pub use obligation_overdue_balance::*;
 pub use payment_allocation::*;
 pub use post_accrued_interest::*;
 pub use remove_collateral::*;
+pub use reserve_for_liquidation::*;

--- a/core/credit/src/ledger/templates/reserve_for_liquidation.rs
+++ b/core/credit/src/ledger/templates/reserve_for_liquidation.rs
@@ -1,0 +1,127 @@
+use rust_decimal::Decimal;
+use tracing::instrument;
+
+use cala_ledger::{
+    tx_template::{Params, error::TxTemplateError, *},
+    *,
+};
+
+use crate::{ledger::error::*, primitives::CalaAccountId};
+
+pub const RESERVE_FOR_LIQUIDATION_CODE: &str = "RESERVE_FOR_LIQUIDATION";
+
+#[derive(Debug)]
+pub struct ReserveForLiquidationParams {
+    pub journal_id: JournalId,
+    pub amount: Decimal,
+    pub liquidation_omnibus_account_id: CalaAccountId,
+    pub facility_liquidation_account_id: CalaAccountId,
+    pub effective: chrono::NaiveDate,
+}
+
+impl ReserveForLiquidationParams {
+    pub fn defs() -> Vec<NewParamDefinition> {
+        vec![
+            NewParamDefinition::builder()
+                .name("journal_id")
+                .r#type(ParamDataType::Uuid)
+                .build()
+                .unwrap(),
+            NewParamDefinition::builder()
+                .name("amount")
+                .r#type(ParamDataType::Decimal)
+                .build()
+                .unwrap(),
+            NewParamDefinition::builder()
+                .name("liquidation_omnibus_account_id")
+                .r#type(ParamDataType::Uuid)
+                .build()
+                .unwrap(),
+            NewParamDefinition::builder()
+                .name("facility_liquidation_account_id")
+                .r#type(ParamDataType::Uuid)
+                .build()
+                .unwrap(),
+            NewParamDefinition::builder()
+                .name("effective")
+                .r#type(ParamDataType::Date)
+                .build()
+                .unwrap(),
+        ]
+    }
+}
+impl From<ReserveForLiquidationParams> for Params {
+    fn from(
+        ReserveForLiquidationParams {
+            journal_id,
+            amount,
+            liquidation_omnibus_account_id,
+            facility_liquidation_account_id,
+            effective,
+        }: ReserveForLiquidationParams,
+    ) -> Self {
+        let mut params = Self::default();
+        params.insert("journal_id", journal_id);
+        params.insert("amount", amount);
+        params.insert(
+            "liquidation_omnibus_account_id",
+            liquidation_omnibus_account_id,
+        );
+        params.insert(
+            "facility_liquidation_account_id",
+            facility_liquidation_account_id,
+        );
+        params.insert("effective", effective);
+
+        params
+    }
+}
+
+pub struct ReserveForLiquidation;
+
+impl ReserveForLiquidation {
+    #[instrument(name = "ledger.reserve_for_liquidation.init", skip_all)]
+    pub async fn init(ledger: &CalaLedger) -> Result<(), CreditLedgerError> {
+        let tx_input = NewTxTemplateTransaction::builder()
+            .journal_id("params.journal_id")
+            .effective("params.effective")
+            .description("'Reserve an outstanding amount to be repaid via liquidation'")
+            .build()
+            .expect("Couldn't build TxInput");
+        let entries = vec![
+            NewTxTemplateEntry::builder()
+                .entry_type("'RESERVE_FOR_LIQUIDATION_CR'")
+                .currency("'USD'")
+                .account_id("params.facility_liquidation_account_id")
+                .direction("CREDIT")
+                .layer("SETTLED")
+                .units("params.amount")
+                .build()
+                .expect("Couldn't build entry"),
+            NewTxTemplateEntry::builder()
+                .entry_type("'RESERVE_FOR_LIQUIDATION_DR'")
+                .currency("'USD'")
+                .account_id("params.liquidation_omnibus_account_id")
+                .direction("DEBIT")
+                .layer("SETTLED")
+                .units("params.amount")
+                .build()
+                .expect("Couldn't build entry"),
+        ];
+
+        let params = ReserveForLiquidationParams::defs();
+        let template = NewTxTemplate::builder()
+            .id(TxTemplateId::new())
+            .code(RESERVE_FOR_LIQUIDATION_CODE)
+            .transaction(tx_input)
+            .entries(entries)
+            .params(params)
+            .build()
+            .expect("Couldn't build template");
+        match ledger.tx_templates().create(template).await {
+            Err(TxTemplateError::DuplicateCode) => Ok(()),
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
+        }
+    }
+}

--- a/lana/entity-rollups/schemas/credit_facility_event_schema.json
+++ b/lana/entity-rollups/schemas/credit_facility_event_schema.json
@@ -58,6 +58,10 @@
           "format": "uuid",
           "type": "string"
         },
+        "in_liquidation_account_id": {
+          "format": "uuid",
+          "type": "string"
+        },
         "interest_defaulted_account_id": {
           "format": "uuid",
           "type": "string"
@@ -81,6 +85,7 @@
       },
       "required": [
         "facility_account_id",
+        "in_liquidation_account_id",
         "disbursed_receivable_not_yet_due_account_id",
         "disbursed_receivable_due_account_id",
         "disbursed_receivable_overdue_account_id",

--- a/lana/entity-rollups/schemas/disbursal_event_schema.json
+++ b/lana/entity-rollups/schemas/disbursal_event_schema.json
@@ -49,6 +49,10 @@
           "format": "uuid",
           "type": "string"
         },
+        "in_liquidation_account_id": {
+          "format": "uuid",
+          "type": "string"
+        },
         "interest_defaulted_account_id": {
           "format": "uuid",
           "type": "string"
@@ -72,6 +76,7 @@
       },
       "required": [
         "facility_account_id",
+        "in_liquidation_account_id",
         "disbursed_receivable_not_yet_due_account_id",
         "disbursed_receivable_due_account_id",
         "disbursed_receivable_overdue_account_id",


### PR DESCRIPTION
## Description

This PR adds a new ledger template for recording when we put an obligation into liquidation.

No existing outstanding amount accounts are touched in the template. This template simply records a new transaction in new memo accounts (memo because of where they'll be attached to the chart) to keep track of amounts reserved to be repaid via liquidation for obligations.

In future, this reserved balance will be:
- reduced, when repayments from liquidated capital are made
- reverted, when the obligation moves out of liquidation 