### PR TITLE
chore: bump schemars and fix feature flag names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "es-entity",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "sqlx",
  "thiserror 2.0.12",
@@ -355,7 +355,7 @@ dependencies = [
  "async-trait",
  "audit",
  "es-entity",
- "schemars",
+ "schemars 0.9.0",
  "sqlx",
  "sqlx-adapter",
  "thiserror 2.0.12",
@@ -796,7 +796,7 @@ dependencies = [
  "es-entity",
  "rust_decimal",
  "rusty-money",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sqlx",
@@ -1051,7 +1051,7 @@ dependencies = [
  "es-entity",
  "governance",
  "outbox",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -1081,7 +1081,7 @@ dependencies = [
  "rand 0.9.1",
  "rust_decimal",
  "rust_decimal_macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -1117,7 +1117,7 @@ dependencies = [
  "rand 0.9.1",
  "rust_decimal",
  "rust_decimal_macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1141,7 +1141,7 @@ dependencies = [
  "derive_builder",
  "es-entity",
  "hex",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -1162,7 +1162,7 @@ dependencies = [
  "es-entity",
  "governance",
  "outbox",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "sqlx",
  "strum",
@@ -1195,7 +1195,7 @@ dependencies = [
  "rand 0.9.1",
  "rust_decimal",
  "rust_decimal_macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sim-time",
@@ -1230,7 +1230,7 @@ dependencies = [
  "async-graphql",
  "rust_decimal",
  "rust_decimal_macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -1245,7 +1245,7 @@ dependencies = [
  "reqwest",
  "rust_decimal",
  "rust_decimal_macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1433,7 +1433,7 @@ dependencies = [
  "job",
  "lana-events",
  "outbox",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sim-time",
@@ -1556,7 +1556,7 @@ dependencies = [
  "cloud-storage",
  "derive_builder",
  "es-entity",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -1635,7 +1635,7 @@ dependencies = [
  "core-deposit",
  "document-storage",
  "governance",
- "schemars",
+ "schemars 0.9.0",
  "serde_json",
  "similar",
  "tempfile",
@@ -1679,7 +1679,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "es-entity-macros",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sim-time",
@@ -2097,7 +2097,7 @@ dependencies = [
  "derive_builder",
  "es-entity",
  "outbox",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "sqlx",
  "strum",
@@ -2618,7 +2618,7 @@ dependencies = [
  "derive_builder",
  "es-entity",
  "rand 0.9.1",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2753,7 +2753,7 @@ dependencies = [
  "reqwest",
  "rust_decimal",
  "rust_decimal_macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -2809,7 +2809,7 @@ dependencies = [
  "es-entity",
  "governance",
  "job",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "sqlx",
 ]
@@ -3302,7 +3302,7 @@ dependencies = [
  "chrono",
  "es-entity",
  "futures",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -3914,7 +3914,7 @@ dependencies = [
  "es-entity",
  "governance",
  "lana-ids",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "sqlx",
  "strum",
@@ -3940,6 +3940,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4291,13 +4311,26 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
- "chrono",
  "dyn-clone",
- "rust_decimal",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "rust_decimal",
+ "schemars_derive 0.9.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4305,6 +4338,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ rand = "0.9"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 chacha20poly1305 = "0.10.1"
 handlebars = "6.3.2"
-schemars = { version = "0.8", features = ["derive", "chrono", "rust_decimal"] }
+schemars = { version = "0.9", features = ["derive", "chrono04", "rust_decimal1"] }
 
 # Note: The workspace uses resolver = "2" which should unify features across all dependencies.
 # The reqwest dependency is configured with rustls-tls to prevent OpenSSL dependencies in CI builds.


### PR DESCRIPTION
schemars has changed the feature flag names starting in version 0.9. This was causing a dependabot failure - https://github.com/GaloyMoney/lana-bank/network/updates/1037230698
