### PR TITLE
chore: In tests, read 'PGHOST' env var instead of 'PG_HOST'

### DIFF
--- a/core/accounting/tests/helpers.rs
+++ b/core/accounting/tests/helpers.rs
@@ -1,7 +1,7 @@
 use cala_ledger::CalaLedger;
 
 pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
-    let pg_host = std::env::var("PG_HOST").unwrap_or("localhost".to_string());
+    let pg_host = std::env::var("PGHOST").unwrap_or("localhost".to_string());
     let pg_con = format!("postgres://user:password@{pg_host}:5433/pg");
     let pool = sqlx::PgPool::connect(&pg_con).await?;
     Ok(pool)

--- a/core/credit/tests/helpers.rs
+++ b/core/credit/tests/helpers.rs
@@ -1,7 +1,7 @@
 use cala_ledger::CalaLedger;
 
 pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
-    let pg_host = std::env::var("PG_HOST").unwrap_or("localhost".to_string());
+    let pg_host = std::env::var("PGHOST").unwrap_or("localhost".to_string());
     let pg_con = format!("postgres://user:password@{pg_host}:5433/pg");
     let pool = sqlx::PgPool::connect(&pg_con).await?;
     Ok(pool)

--- a/core/deposit/tests/helpers.rs
+++ b/core/deposit/tests/helpers.rs
@@ -1,7 +1,7 @@
 use cala_ledger::CalaLedger;
 
 pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
-    let pg_host = std::env::var("PG_HOST").unwrap_or("localhost".to_string());
+    let pg_host = std::env::var("PGHOST").unwrap_or("localhost".to_string());
     let pg_con = format!("postgres://user:password@{pg_host}:5433/pg");
     let pool = sqlx::PgPool::connect(&pg_con).await?;
     Ok(pool)

--- a/core/governance/src/policy/repo.rs
+++ b/core/governance/src/policy/repo.rs
@@ -45,7 +45,7 @@ mod tests {
     }
 
     pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
-        let pg_host = std::env::var("PG_HOST").unwrap_or("localhost".to_string());
+        let pg_host = std::env::var("PGHOST").unwrap_or("localhost".to_string());
         let pg_con = format!("postgres://user:password@{pg_host}:5433/pg");
         let pool = sqlx::PgPool::connect(&pg_con).await?;
         Ok(pool)

--- a/lana/app/tests/helpers.rs
+++ b/lana/app/tests/helpers.rs
@@ -10,7 +10,7 @@ use lana_app::{
 };
 
 pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
-    let pg_host = std::env::var("PG_HOST").unwrap_or("localhost".to_string());
+    let pg_host = std::env::var("PGHOST").unwrap_or("localhost".to_string());
     let pg_con = format!("postgres://user:password@{pg_host}:5433/pg");
     let pool = sqlx::PgPool::connect(&pg_con).await?;
     Ok(pool)

--- a/lib/job/src/repo.rs
+++ b/lib/job/src/repo.rs
@@ -29,7 +29,7 @@ mod tests {
     use super::*;
 
     pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
-        let pg_host = std::env::var("PG_HOST").unwrap_or("localhost".to_string());
+        let pg_host = std::env::var("PGHOST").unwrap_or("localhost".to_string());
         let pg_con = format!("postgres://user:password@{pg_host}:5433/pg");
         let pool = sqlx::PgPool::connect(&pg_con).await?;
         Ok(pool)


### PR DESCRIPTION
We use the name `PGHOST`:

https://github.com/GaloyMoney/lana-bank/blob/e6a3c16a837c5ae5e48eb719c381636442148ff2/flake.nix#L327