### PR TITLE
ci: remove redundant setup-db step

### DIFF
--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Start server with logs
         run: |
-          nohup nix develop -c make reset-deps setup-db run-server-with-bootstrap \
+          nohup nix develop -c make reset-deps run-server-with-bootstrap \
             2>&1 | tee server.log &
           echo "PID=$!" > .server.pid
 


### PR DESCRIPTION
## Description

This redundant `setup-db` call was initially added because the call from `reset-deps` would sometimes fail. We now have a postgresql wait with `wait4x` that solves this.