### PR TITLE
build: fix nix build break on network call to github

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,12 +88,6 @@
 
           # Environment variables for protoc
           PROTOC = "${pkgs.protobuf}/bin/protoc";
-
-          # Ensure protoc is in PATH during build
-          configurePhase = ''
-            export PATH="${pkgs.protobuf}/bin:$PATH"
-            export PROTOC="${pkgs.protobuf}/bin/protoc"
-          '';
         };
 
       # Function to build lana-cli for a specific profile
@@ -124,12 +118,6 @@
 
           # Environment variables for protoc
           PROTOC = "${pkgs.protobuf}/bin/protoc";
-
-          # Ensure protoc is in PATH during build
-          configurePhase = ''
-            export PATH="${pkgs.protobuf}/bin:$PATH"
-            export PROTOC="${pkgs.protobuf}/bin/protoc"
-          '';
         };
 
       # Function to build static lana-cli (musl target for containers)
@@ -163,12 +151,6 @@
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc";
           CC_x86_64_unknown_linux_musl = "${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc";
           TARGET_CC = "${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc";
-
-          # Ensure protoc is in PATH during build
-          configurePhase = ''
-            export PATH="${pkgs.protobuf}/bin:$PATH"
-            export PROTOC="${pkgs.protobuf}/bin/protoc"
-          '';
         };
       in
         craneLibMusl.buildPackage {
@@ -204,12 +186,6 @@
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc";
           CC_x86_64_unknown_linux_musl = "${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc";
           TARGET_CC = "${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc";
-
-          # Ensure protoc is in PATH during build
-          configurePhase = ''
-            export PATH="${pkgs.protobuf}/bin:$PATH"
-            export PROTOC="${pkgs.protobuf}/bin/protoc"
-          '';
         };
 
       # Build artifacts and packages for both profiles


### PR DESCRIPTION
## Description

This is to fix the build issue we see with not being able to reach github. Found by replicating the issue on a linux system and git bisecting through the `main` branch commits.