### PR TITLE
fix: swap pg image to official one

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,16 +43,16 @@ services:
 
   #! Databases
   core-pg:
-    image: ghcr.io/cloudnative-pg/postgresql:17.5
+    image: postgres:17.5
     ports: [ 5433:5432 ]
     environment: [ POSTGRES_USER=user, POSTGRES_PASSWORD=password, POSTGRES_DB=pg ]
 
   kratos-admin-pg:
-    image: ghcr.io/cloudnative-pg/postgresql:17.5
+    image: postgres:17.5
     ports: [ 5434:5432 ]
     environment: [ POSTGRES_USER=dbuser, POSTGRES_PASSWORD=secret, POSTGRES_DB=default ]
 
   kratos-customer-pg:
-    image: ghcr.io/cloudnative-pg/postgresql:17.5
+    image: postgres:17.5
     ports: [ 5435:5432 ]
     environment: [ POSTGRES_USER=dbuser, POSTGRES_PASSWORD=secret, POSTGRES_DB=default ]


### PR DESCRIPTION
Fixes an issue that prevented the app from working properly in the local env.

The PR swaps the Postgres images used in `docker-compose.yml`. We stop using cloudnative-pg's ones and go for the official ones from docker hub.

See this for more context: https://gist.github.com/pmartincalvo/62591fe5b1536a155dce3387a8c5cd2c.