### PR TITLE
feat!: reapply interests/payments when recording payment

### DIFF
--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -760,6 +760,7 @@ where
 
         let mut db = self.facilities.begin_op().await?;
 
+        // TODO: add revert/reapply steps here
         let payment = self
             .payments
             .record_in_op(&mut db, credit_facility_id, amount, &audit_info)


### PR DESCRIPTION
## Description

_Feature branch for merging smaller PRs into_

This branch is to collect the work for applying a payment's effective date properly in a credit facility. The complexity here comes from:
- daily interest calculations based outstanding disbursed amount
- the ordering of other payments made against the facility

To implement this we will need to:
- roll back interest cycles up to the payment's date
- roll-back any payment allocations that were applied to obligations after the current payment's effective date
- replay all payments and interest accruals and recalculate interest-accrues and payment-allocations as we play forward

#### Heuristics
- Always cancel and recreate any entity that has reversions in it. This is to avoid having to add special cases to the read models to handle different reversion events in different entities


### PRs
- [ ] https://github.com/GaloyMoney/lana-bank/pull/2472
  Sets up the use-case in `lib.rs` with empty functions that will represent the different module use-cases we will use to orchestrate rollback/replay

- [ ] https://github.com/GaloyMoney/lana-bank/pull/2476 (supercedes ~https://github.com/GaloyMoney/lana-bank/pull/2468~)
  Rolls back interest accrual cycle events in entity

- [ ] _Not yet started_
  Rolls back interest obligations by canceling

- [ ] _Not yet started_
  Rolls back payment allocations in `PaymentAllocation` and (not-yet-canceled) obligations that were previously touched by these allocations. Some obligations would have already been cancelled from the interest rollback. Can consider making the 2 obligations cancellations idempotent so that the order of rollback (payment vs interest) does not matter

- [ ] _Not yet started_
  Play forward interest accruals up to a given effective date

