### PR TITLE
feat: revert interest cycle and invalidate

### DIFF
--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -59,7 +59,7 @@ pub enum CreditFacilityEvent {
     },
     InterestAccrualCycleConcluded {
         interest_accrual_cycle_idx: InterestAccrualCycleIdx,
-        ledger_tx_id: Option<LedgerTxId>,
+        ledger_tx_id: LedgerTxId,
         obligation_id: Option<ObligationId>,
         audit_info: AuditInfo,
     },
@@ -452,7 +452,7 @@ impl CreditFacility {
             .push(CreditFacilityEvent::InterestAccrualCycleConcluded {
                 interest_accrual_cycle_idx: idx,
                 obligation_id: new_obligation.as_ref().map(|o| o.id),
-                ledger_tx_id: new_obligation.as_ref().map(|o| o.tx_id),
+                ledger_tx_id: accrual_cycle_data.tx_id,
                 audit_info: audit_info.clone(),
             });
 

--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -930,6 +930,13 @@ mod test {
             .extend_entities(new_entities);
     }
 
+    fn start_interest_accrual_cycle(credit_facility: &mut CreditFacility) {
+        credit_facility
+            .start_interest_accrual_cycle(dummy_audit_info())
+            .unwrap();
+        hydrate_accruals_in_facility(credit_facility);
+    }
+
     fn iterate_in_progress_accrual_cycle_to_completion(credit_facility: &mut CreditFacility) {
         let accrual = credit_facility
             .interest_accrual_cycle_in_progress_mut()
@@ -1127,11 +1134,7 @@ mod test {
             });
             let mut credit_facility = facility_from(events);
 
-            credit_facility
-                .start_interest_accrual_cycle(dummy_audit_info())
-                .unwrap()
-                .unwrap();
-            hydrate_accruals_in_facility(&mut credit_facility);
+            start_interest_accrual_cycle(&mut credit_facility);
             let next_cycle_period = credit_facility
                 .next_interest_accrual_cycle_period()
                 .unwrap()
@@ -1243,11 +1246,7 @@ mod test {
             });
             let mut credit_facility = facility_from(events);
 
-            credit_facility
-                .start_interest_accrual_cycle(dummy_audit_info())
-                .unwrap()
-                .unwrap();
-            hydrate_accruals_in_facility(&mut credit_facility);
+            start_interest_accrual_cycle(&mut credit_facility);
 
             let reverted_count = credit_facility
                 .events()
@@ -1284,11 +1283,7 @@ mod test {
             });
             let mut credit_facility = facility_from(events);
 
-            credit_facility
-                .start_interest_accrual_cycle(dummy_audit_info())
-                .unwrap()
-                .unwrap();
-            hydrate_accruals_in_facility(&mut credit_facility);
+            start_interest_accrual_cycle(&mut credit_facility);
 
             let accrual = credit_facility
                 .interest_accrual_cycle_in_progress_mut()
@@ -1330,11 +1325,7 @@ mod test {
             });
             let mut credit_facility = facility_from(events);
 
-            credit_facility
-                .start_interest_accrual_cycle(dummy_audit_info())
-                .unwrap()
-                .unwrap();
-            hydrate_accruals_in_facility(&mut credit_facility);
+            start_interest_accrual_cycle(&mut credit_facility);
             iterate_in_progress_accrual_cycle_to_completion(&mut credit_facility);
 
             let reverted_count = credit_facility
@@ -1372,17 +1363,10 @@ mod test {
             });
             let mut credit_facility = facility_from(events);
 
-            credit_facility
-                .start_interest_accrual_cycle(dummy_audit_info())
-                .unwrap()
-                .unwrap();
-            hydrate_accruals_in_facility(&mut credit_facility);
+            start_interest_accrual_cycle(&mut credit_facility);
             iterate_in_progress_accrual_cycle_to_completion(&mut credit_facility);
-            credit_facility
-                .start_interest_accrual_cycle(dummy_audit_info())
-                .unwrap()
-                .unwrap();
-            hydrate_accruals_in_facility(&mut credit_facility);
+
+            start_interest_accrual_cycle(&mut credit_facility);
 
             let reverted_count = credit_facility
                 .events()

--- a/core/credit/src/credit_facility/entity.rs
+++ b/core/credit/src/credit_facility/entity.rs
@@ -543,7 +543,7 @@ impl CreditFacility {
             .collect::<Vec<_>>()
     }
 
-    pub(crate) fn revert_interest_accruals_after(
+    pub(crate) fn revert_interest_accruals_on_or_after(
         &mut self,
         effective: chrono::NaiveDate,
         audit_info: &AuditInfo,
@@ -556,7 +556,7 @@ impl CreditFacility {
                 .expect("Accrual Cycle not found");
 
             if let Idempotent::Executed(res) =
-                accrual_cycle.revert_after(effective, audit_info.clone())
+                accrual_cycle.revert_on_or_after(effective, audit_info.clone())
             {
                 data.extend(res);
             };
@@ -1141,7 +1141,7 @@ mod test {
                 .unwrap();
             assert_eq!(next_cycle_period, expected_second_cycle_period);
 
-            credit_facility.revert_interest_accruals_after(
+            credit_facility.revert_interest_accruals_on_or_after(
                 expected_first_cycle_period.end.date_naive(),
                 &dummy_audit_info(),
             );
@@ -1231,7 +1231,7 @@ mod test {
         }
     }
 
-    mod revert_interest_accruals_after {
+    mod revert_interest_accruals_on_or_after {
 
         use super::*;
 
@@ -1258,8 +1258,10 @@ mod test {
                 .count();
             assert_eq!(reverted_count, 0);
 
-            credit_facility
-                .revert_interest_accruals_after(activated_at.date_naive(), &dummy_audit_info());
+            credit_facility.revert_interest_accruals_on_or_after(
+                activated_at.date_naive(),
+                &dummy_audit_info(),
+            );
 
             let reverted_count = credit_facility
                 .events()
@@ -1300,8 +1302,10 @@ mod test {
                 .count();
             assert_eq!(reverted_count, 0);
 
-            credit_facility
-                .revert_interest_accruals_after(activated_at.date_naive(), &dummy_audit_info());
+            credit_facility.revert_interest_accruals_on_or_after(
+                activated_at.date_naive(),
+                &dummy_audit_info(),
+            );
 
             let reverted_count = credit_facility
                 .events()
@@ -1338,8 +1342,10 @@ mod test {
                 .count();
             assert_eq!(reverted_count, 0);
 
-            credit_facility
-                .revert_interest_accruals_after(activated_at.date_naive(), &dummy_audit_info());
+            credit_facility.revert_interest_accruals_on_or_after(
+                activated_at.date_naive(),
+                &dummy_audit_info(),
+            );
 
             let reverted_count = credit_facility
                 .events()
@@ -1378,8 +1384,10 @@ mod test {
                 .count();
             assert_eq!(reverted_count, 0);
 
-            credit_facility
-                .revert_interest_accruals_after(activated_at.date_naive(), &dummy_audit_info());
+            credit_facility.revert_interest_accruals_on_or_after(
+                activated_at.date_naive(),
+                &dummy_audit_info(),
+            );
 
             let reverted_count = credit_facility
                 .events()

--- a/core/credit/src/credit_facility/error.rs
+++ b/core/credit/src/credit_facility/error.rs
@@ -42,6 +42,8 @@ pub enum CreditFacilityError {
     OutstandingAmount,
     #[error("CreditFacilityError - InterestAccrualCycleWithInvalidFutureStartDate")]
     InterestAccrualCycleWithInvalidFutureStartDate,
+    #[error("CreditFacilityError - InProgressInterestAccrualCycleNotCompletedYet")]
+    InProgressInterestAccrualCycleNotCompletedYet,
     #[error(
         "CreditFacilityError - DisbursalAmountTooLarge: amount '{0}' is larger than facility balance '{1}'"
     )]

--- a/core/credit/src/credit_facility/mod.rs
+++ b/core/credit/src/credit_facility/mod.rs
@@ -268,7 +268,7 @@ where
     ) -> Result<Vec<RevertedInterestEventData>, CreditFacilityError> {
         let mut credit_facility = self.repo.find_by_id(id).await?;
         let reverted_interest_data =
-            credit_facility.revert_interest_accruals_after(effective, audit_info);
+            credit_facility.revert_interest_accruals_on_or_after(effective, audit_info);
         self.repo.update_in_op(db, &mut credit_facility).await?;
 
         Ok(reverted_interest_data)

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -562,6 +562,7 @@ impl InterestAccrualCycle {
         audit_info: AuditInfo,
     ) -> Idempotent<Vec<RevertedInterestEventData>> {
         let mut all_reverted_data = vec![];
+        dbg!(effective);
 
         let posted_entry_after_effective_exists = self
             .last_unreverted_accrual_cycle()
@@ -1241,7 +1242,7 @@ mod test {
                         ledger_tx_id: LedgerTxId::new(),
                         tx_ref: "".to_string(),
                         obligation_id: Some(ObligationId::new()),
-                        total: UsdCents::from(3),
+                        total: UsdCents::from(2),
                         effective: second_accrual_at.date_naive(),
                         audit_info: dummy_audit_info(),
                     },

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -344,14 +344,6 @@ impl InterestAccrualCycle {
             None => return Idempotent::Ignored,
         };
 
-        idempotency_guard!(
-            self.events.iter_all().rev(),
-            InterestAccrualCycleEvent::AccruedInterestReverted {
-                accrued_ledger_tx_id: found_accrued_ledger_tx_id,
-                ..
-            } if accrued_ledger_tx_id == *found_accrued_ledger_tx_id
-        );
-
         let reverted_interest_accrual = RevertedInterestAccrualData {
             tx_id: LedgerTxId::new(),
             tx_ref: format!(

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -215,6 +215,10 @@ impl InterestAccrualCycle {
         .truncate(self.accrual_cycle_ends_at())
     }
 
+    fn is_reverted_event(&self, ledger_tx_id: &LedgerTxId) -> bool {
+        self.reverted_ledger_tx_ids.contains(ledger_tx_id)
+    }
+
     pub fn count_accrued(&self) -> usize {
         self.events
             .iter_all()

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -63,6 +63,7 @@ pub enum InterestAccrualCycleEvent {
         tx_ref: String,
         amount: UsdCents,
         accrued_at: DateTime<Utc>,
+        effective: chrono::NaiveDate,
         audit_info: AuditInfo,
     },
     InterestAccrualsPosted {
@@ -235,6 +236,7 @@ impl InterestAccrualCycle {
                 tx_ref: interest_accrual.tx_ref.to_string(),
                 amount: interest_accrual.interest,
                 accrued_at: interest_accrual.period.end,
+                effective: interest_accrual.period.end.date_naive(),
                 audit_info,
             });
 
@@ -491,6 +493,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
+            effective: first_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         });
         let accrual = accrual_from(events.clone());
@@ -506,6 +509,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: second_accrual_at,
+            effective: second_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         });
         let accrual = accrual_from(events);
@@ -534,6 +538,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
+            effective: first_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         });
         let accrual = accrual_from(events.clone());
@@ -546,6 +551,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: second_accrual_at,
+            effective: second_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         });
         let accrual = accrual_from(events);
@@ -574,6 +580,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
+            effective: first_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         }]);
         let accrual = accrual_from(events);
@@ -601,6 +608,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: final_accrual_at,
+            effective: final_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         }]);
         let accrual = accrual_from(events);
@@ -621,6 +629,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
+            effective: first_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         });
 
@@ -631,6 +640,7 @@ mod test {
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: second_accrual_at,
+            effective: second_accrual_at.date_naive(),
             audit_info: dummy_audit_info(),
         });
 

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -422,6 +422,22 @@ mod test {
         "2024-01-15T12:00:00Z".parse::<DateTime<Utc>>().unwrap()
     }
 
+    fn end_of_month(start_date: DateTime<Utc>) -> DateTime<Utc> {
+        let current_year = start_date.year();
+        let current_month = start_date.month();
+
+        let (year, month) = if current_month == 12 {
+            (current_year + 1, 1)
+        } else {
+            (current_year, current_month + 1)
+        };
+
+        Utc.with_ymd_and_hms(year, month, 1, 0, 0, 0)
+            .single()
+            .expect("should return a valid date time")
+            - chrono::Duration::seconds(1)
+    }
+
     fn default_period() -> InterestPeriod {
         InterestInterval::EndOfDay.period_from(default_started_at())
     }
@@ -500,6 +516,43 @@ mod test {
     }
 
     #[test]
+    fn count_accrued_period_at_start() {
+        let accrual = accrual_from(initial_events());
+        assert_eq!(accrual.count_accrued(), 0);
+    }
+
+    #[test]
+    fn count_multiple_accrued() {
+        let mut events = initial_events();
+
+        let first_accrual_cycle_period = default_terms()
+            .accrual_interval
+            .period_from(default_started_at());
+        let first_accrual_at = first_accrual_cycle_period.end;
+        events.push(InterestAccrualCycleEvent::InterestAccrued {
+            ledger_tx_id: LedgerTxId::new(),
+            tx_ref: "".to_string(),
+            amount: UsdCents::ONE,
+            accrued_at: first_accrual_at,
+            audit_info: dummy_audit_info(),
+        });
+        let accrual = accrual_from(events.clone());
+        assert_eq!(accrual.count_accrued(), 1);
+
+        let second_accrual_period = first_accrual_cycle_period.next();
+        let second_accrual_at = second_accrual_period.end;
+        events.push(InterestAccrualCycleEvent::InterestAccrued {
+            ledger_tx_id: LedgerTxId::new(),
+            tx_ref: "".to_string(),
+            amount: UsdCents::ONE,
+            accrued_at: second_accrual_at,
+            audit_info: dummy_audit_info(),
+        });
+        let accrual = accrual_from(events);
+        assert_eq!(accrual.count_accrued(), 2);
+    }
+
+    #[test]
     fn next_accrual_period_at_start() {
         let accrual = accrual_from(initial_events());
         assert_eq!(
@@ -556,6 +609,36 @@ mod test {
     }
 
     #[test]
+    fn total_accrued() {
+        let mut events = initial_events();
+
+        let first_accrual_cycle_period = default_terms()
+            .accrual_interval
+            .period_from(default_started_at());
+        let first_accrual_at = first_accrual_cycle_period.end;
+        events.push(InterestAccrualCycleEvent::InterestAccrued {
+            ledger_tx_id: LedgerTxId::new(),
+            tx_ref: "".to_string(),
+            amount: UsdCents::ONE,
+            accrued_at: first_accrual_at,
+            audit_info: dummy_audit_info(),
+        });
+
+        let second_accrual_period = first_accrual_cycle_period.next();
+        let second_accrual_at = second_accrual_period.end;
+        events.push(InterestAccrualCycleEvent::InterestAccrued {
+            ledger_tx_id: LedgerTxId::new(),
+            tx_ref: "".to_string(),
+            amount: UsdCents::ONE,
+            accrued_at: second_accrual_at,
+            audit_info: dummy_audit_info(),
+        });
+
+        let accrual = accrual_from(events);
+        assert_eq!(accrual.total_accrued(), UsdCents::from(2));
+    }
+
+    #[test]
     fn zero_amount_accrual() {
         let mut accrual = accrual_from(initial_events());
         let InterestAccrualData {
@@ -571,22 +654,6 @@ mod test {
         assert_eq!(period.end, end_of_day);
 
         assert!(accrual.accrual_cycle_data().is_none());
-    }
-
-    fn end_of_month(start_date: DateTime<Utc>) -> DateTime<Utc> {
-        let current_year = start_date.year();
-        let current_month = start_date.month();
-
-        let (year, month) = if current_month == 12 {
-            (current_year + 1, 1)
-        } else {
-            (current_year, current_month + 1)
-        };
-
-        Utc.with_ymd_and_hms(year, month, 1, 0, 0, 0)
-            .single()
-            .expect("should return a valid date time")
-            - chrono::Duration::seconds(1)
     }
 
     #[test]
@@ -624,6 +691,47 @@ mod test {
     }
 
     #[test]
+    fn record_accrual_returns_correct_period() {
+        let mut accrual = accrual_from(initial_events());
+
+        let start = default_started_at();
+        let end = end_of_month(start);
+        let start_day = start.day();
+        let end_day = end.day();
+
+        let mut expected_end_of_day = Utc
+            .with_ymd_and_hms(start.year(), start.month(), start.day(), 23, 59, 59)
+            .unwrap();
+        for _ in start_day..(end_day + 1) {
+            let InterestAccrualData { period, .. } =
+                accrual.record_accrual(UsdCents::ONE, dummy_audit_info());
+            assert_eq!(period.end, expected_end_of_day);
+
+            expected_end_of_day += chrono::Duration::days(1);
+        }
+    }
+
+    #[test]
+    fn accrual_cycle_data_exists_at_end_of_cycle() {
+        let mut accrual = accrual_from(initial_events());
+
+        let start = default_started_at();
+        let end = end_of_month(start);
+        let start_day = start.day();
+        let end_day = end.day();
+
+        let mut accrual_cycle_data: Option<InterestAccrualCycleData> = None;
+        for _ in start_day..(end_day + 1) {
+            assert!(accrual_cycle_data.is_none());
+
+            accrual.record_accrual(UsdCents::ONE, dummy_audit_info());
+
+            accrual_cycle_data = accrual.accrual_cycle_data();
+        }
+        assert!(accrual_cycle_data.is_some());
+    }
+
+    #[test]
     fn accrual_is_sum_of_all_interest() {
         let disbursed_outstanding_amount = UsdCents::from(1_000_000_00);
         let expected_daily_interest = default_terms()
@@ -633,32 +741,18 @@ mod test {
         let mut accrual = accrual_from(initial_events());
 
         let start = default_started_at();
-        let start_day = start.day();
         let end = end_of_month(start);
+        let start_day = start.day();
         let end_day = end.day();
-        let mut expected_end_of_day = Utc
-            .with_ymd_and_hms(start.year(), start.month(), start.day(), 23, 59, 59)
-            .unwrap();
-        let mut accrual_cycle_data: Option<InterestAccrualCycleData> = None;
+
         for _ in start_day..(end_day + 1) {
-            assert!(accrual_cycle_data.is_none());
-
-            let InterestAccrualData {
-                interest, period, ..
-            } = accrual.record_accrual(disbursed_outstanding_amount, dummy_audit_info());
+            let InterestAccrualData { interest, .. } =
+                accrual.record_accrual(disbursed_outstanding_amount, dummy_audit_info());
             assert_eq!(interest, expected_daily_interest);
-            assert_eq!(period.end, expected_end_of_day);
-
-            accrual_cycle_data = accrual.accrual_cycle_data();
-            expected_end_of_day += chrono::Duration::days(1);
         }
 
         let expected_accrual_sum = expected_daily_interest * (end_day + 1 - start_day).into();
-        match accrual_cycle_data {
-            Some(InterestAccrualCycleData { interest, .. }) => {
-                assert_eq!(interest, expected_accrual_sum);
-            }
-            _ => panic!("Expected accrual to be returned"),
-        }
+        let InterestAccrualCycleData { interest, .. } = accrual.accrual_cycle_data().unwrap();
+        assert_eq!(interest, expected_accrual_sum);
     }
 }

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -340,10 +340,7 @@ impl InterestAccrualCycle {
             .unwrap_or(false)
     }
 
-    pub(crate) fn revert_accrual(
-        &mut self,
-        audit_info: AuditInfo,
-    ) -> Idempotent<RevertedInterestAccrualData> {
+    fn revert_accrual(&mut self, audit_info: AuditInfo) -> Idempotent<RevertedInterestAccrualData> {
         if self.has_unreverted_cycle_posting() {
             return Idempotent::Ignored;
         }
@@ -504,7 +501,7 @@ impl InterestAccrualCycle {
         })
     }
 
-    pub(crate) fn revert_accrual_cycle(
+    fn revert_accrual_cycle(
         &mut self,
         audit_info: AuditInfo,
     ) -> Idempotent<RevertedInterestCycleData> {
@@ -539,6 +536,40 @@ impl InterestAccrualCycle {
         self.reverted_ledger_tx_ids.push(posted_ledger_tx_id);
 
         Idempotent::Executed(reverted_interest_accrual_cycle)
+    }
+
+    pub(crate) fn revert_after(
+        &mut self,
+        effective: chrono::NaiveDate,
+        audit_info: AuditInfo,
+    ) -> Idempotent<(
+        Option<RevertedInterestCycleData>,
+        Vec<RevertedInterestAccrualData>,
+    )> {
+        let reverted_cycle_data = self
+            .last_unreverted_accrual_cycle()
+            .filter(|cycle| cycle.effective > effective)
+            .and_then(|_| {
+                if let Idempotent::Executed(data) = self.revert_accrual_cycle(audit_info.clone()) {
+                    Some(data)
+                } else {
+                    None
+                }
+            });
+
+        let mut reverted_accruals_data = vec![];
+        while let Some(event) = self.last_unreverted_accrual() {
+            if event.effective <= effective {
+                break;
+            }
+
+            match self.revert_accrual(audit_info.clone()) {
+                Idempotent::Executed(data) => reverted_accruals_data.push(data),
+                _ => break,
+            }
+        }
+
+        Idempotent::Executed((reverted_cycle_data, reverted_accruals_data))
     }
 }
 
@@ -1145,6 +1176,428 @@ mod test {
                 .revert_accrual_cycle(dummy_audit_info())
                 .was_ignored()
         );
+    }
+
+    mod revert_after {
+        use super::*;
+
+        mod with_posted {
+            use super::*;
+
+            fn events_and_effective_dates() -> (
+                Vec<InterestAccrualCycleEvent>,
+                DateTime<Utc>,
+                DateTime<Utc>,
+                DateTime<Utc>,
+            ) {
+                let mut events = initial_events();
+
+                let first_accrual_period = default_terms()
+                    .accrual_interval
+                    .period_from(default_started_at());
+                let first_accrual_at = first_accrual_period.end;
+                let second_accrual_period = first_accrual_period.next();
+                let second_accrual_at = second_accrual_period.end;
+                let third_accrual_period = second_accrual_period.next();
+                let third_accrual_at = third_accrual_period.end;
+
+                events.extend([
+                    InterestAccrualCycleEvent::InterestAccrued {
+                        ledger_tx_id: LedgerTxId::new(),
+                        accrual_idx: 0,
+                        tx_ref: "".to_string(),
+                        amount: UsdCents::ONE,
+                        accrued_at: first_accrual_at,
+                        effective: first_accrual_at.date_naive(),
+                        audit_info: dummy_audit_info(),
+                    },
+                    InterestAccrualCycleEvent::InterestAccrued {
+                        ledger_tx_id: LedgerTxId::new(),
+                        accrual_idx: 0,
+                        tx_ref: "".to_string(),
+                        amount: UsdCents::ONE,
+                        accrued_at: second_accrual_at,
+                        effective: second_accrual_at.date_naive(),
+                        audit_info: dummy_audit_info(),
+                    },
+                    InterestAccrualCycleEvent::InterestAccrued {
+                        ledger_tx_id: LedgerTxId::new(),
+                        accrual_idx: 0,
+                        tx_ref: "".to_string(),
+                        amount: UsdCents::ONE,
+                        accrued_at: third_accrual_at,
+                        effective: third_accrual_at.date_naive(),
+                        audit_info: dummy_audit_info(),
+                    },
+                    InterestAccrualCycleEvent::InterestAccrualsPosted {
+                        ledger_tx_id: LedgerTxId::new(),
+                        tx_ref: "".to_string(),
+                        obligation_id: Some(ObligationId::new()),
+                        total: UsdCents::from(3),
+                        effective: third_accrual_at.date_naive(),
+                        audit_info: dummy_audit_info(),
+                    },
+                ]);
+
+                (
+                    events,
+                    first_accrual_at,
+                    second_accrual_at,
+                    third_accrual_at,
+                )
+            }
+
+            #[test]
+            fn can_revert_after() {
+                let (events, first_accrual_at, _, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_before_first_accrual =
+                    first_accrual_at.date_naive() - chrono::Duration::days(1);
+                let (posted_data, accruals_data) = accrual
+                    .revert_after(date_before_first_accrual, dummy_audit_info())
+                    .unwrap();
+                assert!(posted_data.is_some());
+                assert_eq!(accruals_data.len(), 3);
+            }
+
+            #[test]
+            fn before_all_accruals() {
+                let (events, first_accrual_at, _, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_before_first_accrual =
+                    first_accrual_at.date_naive() - chrono::Duration::days(1);
+                accrual
+                    .revert_after(date_before_first_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 1);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 3);
+            }
+
+            #[test]
+            fn on_first_accrual() {
+                let (events, first_accrual_at, _, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_on_first_accrual = first_accrual_at.date_naive();
+                accrual
+                    .revert_after(date_on_first_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 1);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 2);
+            }
+
+            #[test]
+            fn on_second_accrual() {
+                let (events, _, second_accrual_at, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_on_second_accrual = second_accrual_at.date_naive();
+                accrual
+                    .revert_after(date_on_second_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 1);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 1);
+            }
+
+            #[test]
+            fn on_third_accrual() {
+                let (events, _, _, third_accrual_at) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_on_third_accrual = third_accrual_at.date_naive();
+                accrual
+                    .revert_after(date_on_third_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 0);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 0);
+            }
+
+            #[test]
+            fn after_all_accruals() {
+                let (events, _, _, third_accrual_at) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_after_third_accrual =
+                    third_accrual_at.date_naive() + chrono::Duration::days(1);
+                accrual
+                    .revert_after(date_after_third_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 0);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 0);
+            }
+        }
+
+        mod no_posted {
+
+            use super::*;
+
+            fn events_and_effective_dates()
+            -> (Vec<InterestAccrualCycleEvent>, DateTime<Utc>, DateTime<Utc>) {
+                let mut events = initial_events();
+
+                let first_accrual_period = default_terms()
+                    .accrual_interval
+                    .period_from(default_started_at());
+                let first_accrual_at = first_accrual_period.end;
+                let second_accrual_period = first_accrual_period.next();
+                let second_accrual_at = second_accrual_period.end;
+
+                events.extend([
+                    InterestAccrualCycleEvent::InterestAccrued {
+                        ledger_tx_id: LedgerTxId::new(),
+                        accrual_idx: 0,
+                        tx_ref: "".to_string(),
+                        amount: UsdCents::ONE,
+                        accrued_at: first_accrual_at,
+                        effective: first_accrual_at.date_naive(),
+                        audit_info: dummy_audit_info(),
+                    },
+                    InterestAccrualCycleEvent::InterestAccrued {
+                        ledger_tx_id: LedgerTxId::new(),
+                        accrual_idx: 0,
+                        tx_ref: "".to_string(),
+                        amount: UsdCents::ONE,
+                        accrued_at: second_accrual_at,
+                        effective: second_accrual_at.date_naive(),
+                        audit_info: dummy_audit_info(),
+                    },
+                ]);
+
+                (events, first_accrual_at, second_accrual_at)
+            }
+
+            #[test]
+            fn can_revert_after() {
+                let (events, first_accrual_at, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_before_first_accrual =
+                    first_accrual_at.date_naive() - chrono::Duration::days(1);
+                let (posted_data, accruals_data) = accrual
+                    .revert_after(date_before_first_accrual, dummy_audit_info())
+                    .unwrap();
+                assert!(posted_data.is_none());
+                assert_eq!(accruals_data.len(), 2);
+            }
+
+            #[test]
+            fn before_all_accruals() {
+                let (events, first_accrual_at, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_before_first_accrual =
+                    first_accrual_at.date_naive() - chrono::Duration::days(1);
+                accrual
+                    .revert_after(date_before_first_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 0);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 2);
+            }
+
+            #[test]
+            fn on_first_accrual() {
+                let (events, first_accrual_at, _) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_on_first_accrual = first_accrual_at.date_naive();
+                accrual
+                    .revert_after(date_on_first_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 0);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 1);
+            }
+
+            #[test]
+            fn on_second_accrual() {
+                let (events, _, second_accrual_at) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_on_second_accrual = second_accrual_at.date_naive();
+                accrual
+                    .revert_after(date_on_second_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 0);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 0);
+            }
+
+            #[test]
+            fn after_all_accruals() {
+                let (events, _, second_accrual_at) = events_and_effective_dates();
+                let mut accrual = accrual_from(events);
+
+                let date_after_second_accrual =
+                    second_accrual_at.date_naive() + chrono::Duration::days(1);
+                accrual
+                    .revert_after(date_after_second_accrual, dummy_audit_info())
+                    .did_execute();
+
+                let n_posted_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_posted_reverted, 0);
+
+                let n_accrued_reverted = accrual
+                    .events()
+                    .iter_all()
+                    .filter(|event| match event {
+                        InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                        _ => false,
+                    })
+                    .count();
+                assert_eq!(n_accrued_reverted, 0);
+            }
+        }
     }
 
     #[test]

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -250,6 +250,19 @@ impl InterestAccrualCycle {
         .truncate(self.accrual_cycle_ends_at())
     }
 
+    pub(crate) fn is_completed(&self) -> bool {
+        self.events
+            .iter_all()
+            .rev()
+            .find(|event| match event {
+                InterestAccrualCycleEvent::InterestAccrualsPosted { .. }
+                | InterestAccrualCycleEvent::PostedInterestAccrualsReverted { .. }
+                | InterestAccrualCycleEvent::AccruedInterestReverted { .. } => true,
+                _ => false,
+            })
+            .is_some()
+    }
+
     fn is_reverted_event(&self, ledger_tx_id: &LedgerTxId) -> bool {
         self.reverted_ledger_tx_ids.contains(ledger_tx_id)
     }

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -140,9 +140,9 @@ struct InterestAccruedEventData {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RevertedInterestAccrualData {
-    pub(crate) interest: UsdCents,
-    pub(crate) tx_ref: String,
     pub(crate) tx_id: LedgerTxId,
+    pub(crate) tx_ref: String,
+    pub(crate) interest: UsdCents,
     pub(crate) effective: chrono::NaiveDate,
 }
 
@@ -154,10 +154,15 @@ struct PostedCycleEventData {
 }
 
 pub(crate) struct RevertedInterestCycleData {
-    pub(crate) total: UsdCents,
-    pub(crate) tx_ref: String,
     pub(crate) tx_id: LedgerTxId,
+    pub(crate) tx_ref: String,
+    pub(crate) total: UsdCents,
     pub(crate) effective: chrono::NaiveDate,
+}
+
+pub(crate) enum RevertedInterestEventData {
+    Accrued(RevertedInterestAccrualData),
+    PostedCycle(RevertedInterestCycleData),
 }
 
 impl TryFromEvents<InterestAccrualCycleEvent> for InterestAccrualCycle {
@@ -542,34 +547,39 @@ impl InterestAccrualCycle {
         &mut self,
         effective: chrono::NaiveDate,
         audit_info: AuditInfo,
-    ) -> Idempotent<(
-        Option<RevertedInterestCycleData>,
-        Vec<RevertedInterestAccrualData>,
-    )> {
-        let reverted_cycle_data = self
+    ) -> Idempotent<Vec<RevertedInterestEventData>> {
+        let mut all_reverted_data = vec![];
+
+        let posted_entry_after_effective_exists = self
             .last_unreverted_accrual_cycle()
             .filter(|cycle| cycle.effective > effective)
-            .and_then(|_| {
-                if let Idempotent::Executed(data) = self.revert_accrual_cycle(audit_info.clone()) {
-                    Some(data)
-                } else {
-                    None
-                }
-            });
+            .is_some();
+        if posted_entry_after_effective_exists {
+            if let Idempotent::Executed(reverted_cycle_data) =
+                self.revert_accrual_cycle(audit_info.clone())
+            {
+                all_reverted_data.push(RevertedInterestEventData::PostedCycle(reverted_cycle_data))
+            }
+        }
 
-        let mut reverted_accruals_data = vec![];
         while let Some(event) = self.last_unreverted_accrual() {
             if event.effective <= effective {
                 break;
             }
 
             match self.revert_accrual(audit_info.clone()) {
-                Idempotent::Executed(data) => reverted_accruals_data.push(data),
+                Idempotent::Executed(accrued_data) => {
+                    all_reverted_data.push(RevertedInterestEventData::Accrued(accrued_data))
+                }
                 _ => break,
             }
         }
 
-        Idempotent::Executed((reverted_cycle_data, reverted_accruals_data))
+        if all_reverted_data.is_empty() {
+            Idempotent::Ignored
+        } else {
+            Idempotent::Executed(all_reverted_data)
+        }
     }
 }
 
@@ -1254,11 +1264,18 @@ mod test {
 
                 let date_before_first_accrual =
                     first_accrual_at.date_naive() - chrono::Duration::days(1);
-                let (posted_data, accruals_data) = accrual
+                let res = accrual
                     .revert_after(date_before_first_accrual, dummy_audit_info())
                     .unwrap();
-                assert!(posted_data.is_some());
-                assert_eq!(accruals_data.len(), 3);
+
+                let (n_posted, n_accrued) =
+                    res.iter()
+                        .fold((0, 0), |(posted, accrued), event| match event {
+                            RevertedInterestEventData::PostedCycle(_) => (posted + 1, accrued),
+                            RevertedInterestEventData::Accrued(_) => (posted, accrued + 1),
+                        });
+                assert_eq!(n_posted, 1);
+                assert_eq!(n_accrued, 3);
             }
 
             #[test]
@@ -1465,11 +1482,18 @@ mod test {
 
                 let date_before_first_accrual =
                     first_accrual_at.date_naive() - chrono::Duration::days(1);
-                let (posted_data, accruals_data) = accrual
+                let res = accrual
                     .revert_after(date_before_first_accrual, dummy_audit_info())
                     .unwrap();
-                assert!(posted_data.is_none());
-                assert_eq!(accruals_data.len(), 2);
+
+                let (n_posted, n_accrued) =
+                    res.iter()
+                        .fold((0, 0), |(posted, accrued), event| match event {
+                            RevertedInterestEventData::PostedCycle(_) => (posted + 1, accrued),
+                            RevertedInterestEventData::Accrued(_) => (posted, accrued + 1),
+                        });
+                assert_eq!(n_posted, 0);
+                assert_eq!(n_accrued, 2);
             }
 
             #[test]

--- a/core/credit/src/interest_accrual_cycle/entity.rs
+++ b/core/credit/src/interest_accrual_cycle/entity.rs
@@ -60,6 +60,7 @@ pub enum InterestAccrualCycleEvent {
     },
     InterestAccrued {
         ledger_tx_id: LedgerTxId,
+        accrual_idx: usize,
         tx_ref: String,
         amount: UsdCents,
         accrued_at: DateTime<Utc>,
@@ -252,7 +253,8 @@ impl InterestAccrualCycle {
             .annual_rate
             .interest_for_time_period(amount, days_in_interest_period);
 
-        let accrual_tx_ref = format!("{}-interest-accrual-{}", self.id, self.count_accrued() + 1);
+        let accrual_idx = self.count_accrued() + 1;
+        let accrual_tx_ref = format!("{}-interest-accrual-{}", self.id, accrual_idx);
         let interest_accrual = InterestAccrualData {
             interest: interest_for_period,
             period: accrual_period,
@@ -263,6 +265,7 @@ impl InterestAccrualCycle {
         self.events
             .push(InterestAccrualCycleEvent::InterestAccrued {
                 ledger_tx_id: interest_accrual.tx_id,
+                accrual_idx,
                 tx_ref: interest_accrual.tx_ref.to_string(),
                 amount: interest_accrual.interest,
                 accrued_at: interest_accrual.period.end,
@@ -520,6 +523,7 @@ mod test {
         let first_accrual_at = first_accrual_cycle_period.end;
         events.push(InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 0,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
@@ -536,6 +540,7 @@ mod test {
         let second_accrual_at = second_accrual_period.end;
         events.push(InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 0,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: second_accrual_at,
@@ -565,6 +570,7 @@ mod test {
         let first_accrual_at = first_accrual_cycle_period.end;
         events.push(InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 0,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
@@ -578,6 +584,7 @@ mod test {
         let second_accrual_at = second_accrual_period.end;
         events.push(InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 1,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: second_accrual_at,
@@ -607,6 +614,7 @@ mod test {
         let first_accrual_at = first_accrual_cycle_period.end;
         events.extend([InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 0,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
@@ -635,6 +643,7 @@ mod test {
 
         events.extend([InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 0,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: final_accrual_at,
@@ -656,6 +665,7 @@ mod test {
         let first_accrual_at = first_accrual_cycle_period.end;
         events.push(InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 0,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: first_accrual_at,
@@ -667,6 +677,7 @@ mod test {
         let second_accrual_at = second_accrual_period.end;
         events.push(InterestAccrualCycleEvent::InterestAccrued {
             ledger_tx_id: LedgerTxId::new(),
+            accrual_idx: 1,
             tx_ref: "".to_string(),
             amount: UsdCents::ONE,
             accrued_at: second_accrual_at,


### PR DESCRIPTION
## Description

This takes over from #2468 (see description for documentation).

It is to revert txns in interest cycle and then invalidate the cycle and replace it with a new version of the cycle.