### PR TITLE
chore: Use balance update time provided by custodian

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "base64 0.22.1",
  "bip32",
  "ccm",
+ "chrono",
  "hex",
  "hmac",
  "pbkdf2",

--- a/core/credit/src/jobs/wallet_collateral_sync.rs
+++ b/core/credit/src/jobs/wallet_collateral_sync.rs
@@ -87,17 +87,19 @@ where
         let mut stream = self.outbox.listen_persisted(Some(state.sequence)).await?;
 
         while let Some(message) = stream.next().await {
-            if let Some(CoreCustodyEvent::WalletBalanceChanged { id, new_balance }) =
-                message.as_ref().as_event()
+            if let Some(CoreCustodyEvent::WalletBalanceChanged {
+                id,
+                new_balance,
+                changed_at,
+            }) = message.as_ref().as_event()
             {
                 let credit_facility = self.facilities.find_by_custody_wallet(*id).await?;
 
-                let effective = crate::time::now().date_naive();
                 self.collaterals
                     .record_collateral_update_via_custodian_sync(
                         &credit_facility,
                         *new_balance,
-                        effective,
+                        changed_at.date_naive(),
                     )
                     .await?;
 

--- a/core/custody/src/custodian/notification.rs
+++ b/core/custody/src/custodian/notification.rs
@@ -1,8 +1,11 @@
+use chrono::{DateTime, Utc};
+
 use core_money::Satoshis;
 
 pub enum CustodianNotification {
     WalletBalanceChanged {
         external_wallet_id: String,
         new_balance: Satoshis,
+        changed_at: DateTime<Utc>,
     },
 }

--- a/core/custody/src/event.rs
+++ b/core/custody/src/event.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use core_money::Satoshis;
@@ -7,6 +8,13 @@ use crate::primitives::WalletId;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum CoreCustodyEvent {
-    WalletAttached { id: WalletId, address: String },
-    WalletBalanceChanged { id: WalletId, new_balance: Satoshis },
+    WalletAttached {
+        id: WalletId,
+        address: String,
+    },
+    WalletBalanceChanged {
+        id: WalletId,
+        new_balance: Satoshis,
+        changed_at: DateTime<Utc>,
+    },
 }

--- a/core/custody/src/publisher.rs
+++ b/core/custody/src/publisher.rs
@@ -36,12 +36,15 @@ where
                     id: entity.id,
                     address: address.to_owned(),
                 }),
-                BalanceChanged { new_balance, .. } => {
-                    Some(CoreCustodyEvent::WalletBalanceChanged {
-                        id: entity.id,
-                        new_balance: *new_balance,
-                    })
-                }
+                BalanceChanged {
+                    new_balance,
+                    changed_at,
+                    ..
+                } => Some(CoreCustodyEvent::WalletBalanceChanged {
+                    id: entity.id,
+                    new_balance: *new_balance,
+                    changed_at: *changed_at,
+                }),
             })
             .collect::<Vec<_>>();
 

--- a/core/custody/src/wallet/entity.rs
+++ b/core/custody/src/wallet/entity.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +26,7 @@ pub enum WalletEvent {
     },
     BalanceChanged {
         new_balance: Satoshis,
+        changed_at: DateTime<Utc>,
         audit_info: AuditInfo,
     },
 }
@@ -68,6 +70,7 @@ impl Wallet {
     pub fn update_balance(
         &mut self,
         new_balance: Satoshis,
+        update_time: DateTime<Utc>,
         audit_info: &AuditInfo,
     ) -> Idempotent<()> {
         idempotency_guard!(
@@ -78,6 +81,7 @@ impl Wallet {
 
         self.events.push(WalletEvent::BalanceChanged {
             new_balance,
+            changed_at: update_time,
             audit_info: audit_info.clone(),
         });
 

--- a/lib/bitgo/Cargo.toml
+++ b/lib/bitgo/Cargo.toml
@@ -14,6 +14,7 @@ aes = { workspace = true }
 base64 = { workspace = true }
 bip32 = { workspace = true }
 ccm = { workspace = true }
+chrono = { workspace = true }
 hex = { workspace = true }
 hmac = { workspace = true }
 pbkdf2 = { workspace = true }

--- a/lib/bitgo/src/wire.rs
+++ b/lib/bitgo/src/wire.rs
@@ -5,6 +5,7 @@ use ccm::{
     aead::{Aead as _, generic_array::GenericArray},
     consts::{U8, U13},
 };
+use chrono::{DateTime, Utc};
 use pbkdf2::pbkdf2_hmac_array;
 use rand::{TryRngCore as _, rngs::OsRng};
 use serde::{Deserialize, Serialize};
@@ -50,6 +51,7 @@ pub struct Transfer {
     pub wallet: String,
     pub txid: String,
     pub confirmations: u32,
+    pub confirmed_time: Option<DateTime<Utc>>,
     pub value: u64,
     #[serde(rename = "type")]
     pub transfer_type: TransferType,


### PR DESCRIPTION
When updating collateral via synchronization with custodians, we provided effective date as the current date (now).

This change replaces this current date with a suitable date provided by custodian, e. g. confirmation time on blockchain or similar.