### PR TITLE
chore: Allow to pass multiline secret key for Komainu

### DIFF
--- a/apps/admin-panel/app/custodians/create.tsx
+++ b/apps/admin-panel/app/custodians/create.tsx
@@ -111,7 +111,9 @@ export const CreateCustodianDialog: React.FC<CreateCustodianDialogProps> = ({
 
   const [createCustodian, { loading }] = useCustodianCreateMutation()
 
-  const handleKomainuInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleKomainuInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
     const { name, value } = e.target
     setKomainuConfig((prev) => ({ ...prev, [name]: value }))
   }
@@ -254,7 +256,6 @@ export const CreateCustodianDialog: React.FC<CreateCustodianDialogProps> = ({
                 <Textarea
                   id="secretKey"
                   name="secretKey"
-                  type="password"
                   value={komainuConfig.secretKey}
                   onChange={handleKomainuInputChange}
                   placeholder={t("placeholders.secretKey")}

--- a/apps/admin-panel/app/custodians/create.tsx
+++ b/apps/admin-panel/app/custodians/create.tsx
@@ -14,6 +14,7 @@ import {
 } from "@lana/web/ui/dialog"
 import { Button } from "@lana/web/ui/button"
 import { Input } from "@lana/web/ui/input"
+import { Textarea } from "@lana/web/ui/textarea"
 import { Label } from "@lana/web/ui/label"
 import { Checkbox } from "@lana/web/ui/check-box"
 import {
@@ -250,7 +251,7 @@ export const CreateCustodianDialog: React.FC<CreateCustodianDialogProps> = ({
                 <Label htmlFor="secretKey" required>
                   {t("fields.secretKey")}
                 </Label>
-                <Input
+                <Textarea
                   id="secretKey"
                   name="secretKey"
                   type="password"

--- a/core/custody/src/custodian/entity.rs
+++ b/core/custody/src/custodian/entity.rs
@@ -95,10 +95,13 @@ impl Custodian {
         provider_config: &CustodyProviderConfig,
     ) -> Result<Box<dyn CustodianClient>, CustodianClientError> {
         match self.custodian_config(key) {
-            CustodianConfig::Komainu(config) => Ok(Box::new(komainu::KomainuClient::new(
-                config.into(),
-                provider_config.komainu_directory.clone(),
-            ))),
+            CustodianConfig::Komainu(config) => Ok(Box::new(
+                komainu::KomainuClient::try_new(
+                    config.into(),
+                    provider_config.komainu_directory.clone(),
+                )
+                .map_err(CustodianClientError::client)?,
+            )),
             CustodianConfig::Bitgo(config) => Ok(Box::new(bitgo::BitgoClient::new(
                 config.into(),
                 provider_config.bitgo_directory.clone(),

--- a/lib/komainu/src/error.rs
+++ b/lib/komainu/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum KomainuError {
     #[error("KomainuError - ReqwestError: {0}")]
     ReqwestError(#[from] reqwest::Error),
+    #[error("KomainuError - ConfigurationError: Could not parse secret key")]
+    SecretKey,
     #[error("KomainuError - KomainuError: {error_code}")]
     KomainuError {
         error_code: String,


### PR DESCRIPTION
Secret key for Komainu comes in standard DEM format, which contains multiple lines. An input form field joins all lines into one.

This change subsitutes input field with a textarea that preserves lines. Additionally, parsing secret keys fails with more graceful errors.