### PR TITLE
chore: Swap parts in webhook URL

### DIFF
--- a/bats/credit-facility-custody.bats
+++ b/bats/credit-facility-custody.bats
@@ -120,7 +120,7 @@ wait_for_collateral() {
   [[ "$collateral" -eq 0 ]] || exit 1
 
   # external wallet ID 123 is hard coded in mock custodian
-  curl -s -X POST --json '{"wallet": "123", "balance": 1000}' http://localhost:5253/mock/webhook
+  curl -s -X POST --json '{"wallet": "123", "balance": 1000}' http://localhost:5253/webhook/mock
 
   retry 10 1 wait_for_collateral "$credit_facility_id"
 }

--- a/lana/admin-server/src/custodian_webhooks.rs
+++ b/lana/admin-server/src/custodian_webhooks.rs
@@ -24,6 +24,6 @@ async fn handle_webhook(
 
 pub fn webhook_routes() -> Router<JwtDecoderState> {
     Router::new()
-        .route("/{provider}/webhook", post(handle_webhook))
+        .route("/webhook/{provider}", post(handle_webhook))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
 }


### PR DESCRIPTION
We previously used webhook URL in form /PROVIDER/webhook but decided to swap the two parts into /webhook/PROVIDER.