### PR TITLE
feat: update rollups for running sum events

### DIFF
--- a/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         collateral_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_collateral_events_rollup_sequence') }}
     group by collateral_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (collateral_id, sequence)
+    inner join latest_sequence using (collateral_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup.sql
@@ -1,37 +1,23 @@
-with collateral as (
+with latest_sequence as (
     select
-        id as collateral_id,
-        credit_facility_id,
+        collateral_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_collateral_events_rollup_sequence') }}
+    group by collateral_id
+)
 
-        action,
-        cast(abs_diff as numeric) as abs_diff_sats,
-        cast(abs_diff as numeric) / {{ var('sats_per_bitcoin') }} as abs_diff_btc,
-        cast(collateral_amount as numeric) as collateral_amount_sats,
-        cast(collateral_amount as numeric) / {{ var('sats_per_bitcoin') }} as collateral_amount_btc,
-        account_id,
-        created_at as collateral_created_at,
-        modified_at as collateral_modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_collateral_events_rollup_sequence') }}
+)
 
-        * except(
-            id,
-            credit_facility_id,
-            action,
-            abs_diff,
-            collateral_amount,
-            account_id,
-            created_at,
-            modified_at,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (collateral_id, sequence)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_collateral_events_rollup') }}
 )
 
 
-select * from collateral
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['collateral_id', 'sequence'],
+    unique_key = ['collateral_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_collateral_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (collateral_id, sequence)
+        left join {{ this }} as t using (collateral_id, version)
         where t.collateral_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_collateral_events_rollup_sequence.sql
@@ -1,0 +1,54 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['collateral_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_collateral_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (collateral_id, sequence)
+        where t.collateral_id is null
+    {% endif %}
+)
+
+, transformed as (
+    select
+        collateral_id,
+        credit_facility_id,
+
+        action,
+        cast(abs_diff as numeric) as abs_diff_sats,
+        cast(abs_diff as numeric) / {{ var('sats_per_bitcoin') }} as abs_diff_btc,
+        cast(collateral_amount as numeric) as collateral_amount_sats,
+        cast(collateral_amount as numeric) / {{ var('sats_per_bitcoin') }} as collateral_amount_btc,
+        account_id,
+        created_at as collateral_created_at,
+        modified_at as collateral_modified_at,
+
+        * except(
+            collateral_id,
+            credit_facility_id,
+            action,
+            abs_diff,
+            collateral_amount,
+            account_id,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         credit_facility_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_credit_facility_events_rollup_sequence') }}
     group by credit_facility_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (credit_facility_id, sequence)
+    inner join latest_sequence using (credit_facility_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup.sql
@@ -1,104 +1,23 @@
-with credit_facility as (
+with latest_sequence as (
     select
-        id as credit_facility_id,
-        customer_id,
+        credit_facility_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_credit_facility_events_rollup_sequence') }}
+    group by credit_facility_id
+)
 
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as facility_amount_usd,
-        cast(json_value(terms, "$.annual_rate") as numeric) as annual_rate,
-        cast(json_value(terms, "$.one_time_fee_rate") as numeric) as one_time_fee_rate,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_credit_facility_events_rollup_sequence') }}
+)
 
-        cast(json_value(terms, "$.initial_cvl") as numeric) as initial_cvl,
-        cast(json_value(terms, "$.liquidation_cvl") as numeric) as liquidation_cvl,
-        cast(json_value(terms, "$.margin_call_cvl") as numeric) as margin_call_cvl,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (credit_facility_id, sequence)
 
-        cast(json_value(terms, "$.duration.value") as integer) as duration_value,
-        json_value(terms, "$.duration.type") as duration_type,
-
-        json_value(terms, "$.accrual_interval.type") as accrual_interval,
-        json_value(terms, "$.accrual_cycle_interval.type") as accrual_cycle_interval,
-
-        cast(collateral as numeric) as collateral_amount_sats,
-        cast(collateral as numeric) / {{ var('sats_per_bitcoin') }} as collateral_amount_btc,
-        cast(price as numeric) / {{ var('cents_per_usd') }} as price_usd_per_btc,
-        cast(collateral as numeric) / {{ var('sats_per_bitcoin') }} * cast(price as numeric) / {{ var('cents_per_usd') }} as collateral_amount_usd,
-        cast(collateralization_ratio as numeric) as collateralization_ratio,
-        collateralization_state,
-
-        approved,
-
-        is_approval_process_concluded,
-        is_activated,
-        cast(activated_at as timestamp) as credit_facility_activated_at,
-        is_completed,
-
-        interest_accrual_cycle_idx,
-        cast(json_value(interest_period, "$.start") as timestamp) as interest_period_start_at,
-        cast(json_value(interest_period, "$.end") as timestamp) as interest_period_end_at,
-        json_value(interest_period, "$.interval.type") as interest_period_interval_type,
-
-        cast(json_value(outstanding, "$.interest") as numeric) / {{ var('cents_per_usd') }} as outstanding_interest_usd,
-        cast(json_value(outstanding, "$.disbursed") as numeric) / {{ var('cents_per_usd') }} as outstanding_disbursed_usd,
-
-        cast(json_value(terms, "$.interest_due_duration_from_accrual.value") as integer) as interest_due_duration_from_accrual_value,
-        json_value(terms, "$.interest_due_duration_from_accrual.type") as interest_due_duration_from_accrual_type,
-
-        cast(json_value(terms, "$.obligation_overdue_duration_from_due.value") as integer) as obligation_overdue_duration_from_due_value,
-        json_value(terms, "$.obligation_overdue_duration_from_due.type") as obligation_overdue_duration_from_due_type,
-
-        cast(json_value(terms, "$.obligation_liquidation_duration_from_due.value") as integer) as obligation_liquidation_duration_from_due_value,
-        json_value(terms, "$.obligation_liquidation_duration_from_due.type") as obligation_liquidation_duration_from_due_type,
-        created_at as credit_facility_created_at,
-        modified_at as credit_facility_modified_at,
-
-        json_value(account_ids, "$.facility_account_id") as facility_account_id,
-        json_value(account_ids, "$.collateral_account_id") as collateral_account_id,
-        json_value(account_ids, "$.fee_income_account_id") as fee_income_account_id,
-        json_value(account_ids, "$.interest_income_account_id") as interest_income_account_id,
-        json_value(account_ids, "$.interest_defaulted_account_id") as interest_defaulted_account_id,
-        json_value(account_ids, "$.disbursed_defaulted_account_id") as disbursed_defaulted_account_id,
-        json_value(account_ids, "$.interest_receivable_due_account_id") as interest_receivable_due_account_id,
-        json_value(account_ids, "$.disbursed_receivable_due_account_id") as disbursed_receivable_due_account_id,
-        json_value(account_ids, "$.interest_receivable_overdue_account_id") as interest_receivable_overdue_account_id,
-        json_value(account_ids, "$.disbursed_receivable_overdue_account_id") as disbursed_receivable_overdue_account_id,
-        json_value(account_ids, "$.interest_receivable_not_yet_due_account_id") as interest_receivable_not_yet_due_account_id,
-        json_value(account_ids, "$.disbursed_receivable_not_yet_due_account_id") as disbursed_receivable_not_yet_due_account_id,
-
-        * except(
-            id,
-            customer_id,
-            amount,
-            ledger_tx_ids,
-            account_ids,
-            terms,
-            collateral,
-            price,
-            collateralization_ratio,
-            collateralization_state,
-            approved,
-            is_approval_process_concluded,
-            is_activated,
-            activated_at,
-            is_completed,
-            interest_accrual_cycle_idx,
-            interest_period,
-            outstanding,
-            created_at,
-            modified_at,
-
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_credit_facility_events_rollup') }}
 )
 
 
-select
-    *,
-    collateral_amount_usd / facility_amount_usd * 100 as current_facility_cvl,
-    case when duration_type = 'months' then timestamp_add(date(credit_facility_activated_at), interval duration_value month) end as credit_facility_maturity_at,
-from credit_facility
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup_sequence.sql
@@ -1,0 +1,128 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['credit_facility_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_credit_facility_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (credit_facility_id, sequence)
+        where t.credit_facility_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        credit_facility_id,
+        sequence,
+        customer_id,
+
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as facility_amount_usd,
+        cast(json_value(terms, "$.annual_rate") as numeric) as annual_rate,
+        cast(json_value(terms, "$.one_time_fee_rate") as numeric) as one_time_fee_rate,
+
+        cast(json_value(terms, "$.initial_cvl") as numeric) as initial_cvl,
+        cast(json_value(terms, "$.liquidation_cvl") as numeric) as liquidation_cvl,
+        cast(json_value(terms, "$.margin_call_cvl") as numeric) as margin_call_cvl,
+
+        cast(json_value(terms, "$.duration.value") as integer) as duration_value,
+        json_value(terms, "$.duration.type") as duration_type,
+
+        json_value(terms, "$.accrual_interval.type") as accrual_interval,
+        json_value(terms, "$.accrual_cycle_interval.type") as accrual_cycle_interval,
+
+        cast(collateral as numeric) as collateral_amount_sats,
+        cast(collateral as numeric) / {{ var('sats_per_bitcoin') }} as collateral_amount_btc,
+        cast(price as numeric) / {{ var('cents_per_usd') }} as price_usd_per_btc,
+        cast(collateral as numeric) / {{ var('sats_per_bitcoin') }} * cast(price as numeric) / {{ var('cents_per_usd') }} as collateral_amount_usd,
+        cast(collateralization_ratio as numeric) as collateralization_ratio,
+        collateralization_state,
+
+        approved,
+
+        is_approval_process_concluded,
+        is_activated,
+        cast(activated_at as timestamp) as credit_facility_activated_at,
+        is_completed,
+
+        interest_accrual_cycle_idx,
+        cast(json_value(interest_period, "$.start") as timestamp) as interest_period_start_at,
+        cast(json_value(interest_period, "$.end") as timestamp) as interest_period_end_at,
+        json_value(interest_period, "$.interval.type") as interest_period_interval_type,
+
+        cast(json_value(outstanding, "$.interest") as numeric) / {{ var('cents_per_usd') }} as outstanding_interest_usd,
+        cast(json_value(outstanding, "$.disbursed") as numeric) / {{ var('cents_per_usd') }} as outstanding_disbursed_usd,
+
+        cast(json_value(terms, "$.interest_due_duration_from_accrual.value") as integer) as interest_due_duration_from_accrual_value,
+        json_value(terms, "$.interest_due_duration_from_accrual.type") as interest_due_duration_from_accrual_type,
+
+        cast(json_value(terms, "$.obligation_overdue_duration_from_due.value") as integer) as obligation_overdue_duration_from_due_value,
+        json_value(terms, "$.obligation_overdue_duration_from_due.type") as obligation_overdue_duration_from_due_type,
+
+        cast(json_value(terms, "$.obligation_liquidation_duration_from_due.value") as integer) as obligation_liquidation_duration_from_due_value,
+        json_value(terms, "$.obligation_liquidation_duration_from_due.type") as obligation_liquidation_duration_from_due_type,
+        created_at as credit_facility_created_at,
+        modified_at as credit_facility_modified_at,
+
+        json_value(account_ids, "$.facility_account_id") as facility_account_id,
+        json_value(account_ids, "$.collateral_account_id") as collateral_account_id,
+        json_value(account_ids, "$.fee_income_account_id") as fee_income_account_id,
+        json_value(account_ids, "$.interest_income_account_id") as interest_income_account_id,
+        json_value(account_ids, "$.interest_defaulted_account_id") as interest_defaulted_account_id,
+        json_value(account_ids, "$.disbursed_defaulted_account_id") as disbursed_defaulted_account_id,
+        json_value(account_ids, "$.interest_receivable_due_account_id") as interest_receivable_due_account_id,
+        json_value(account_ids, "$.disbursed_receivable_due_account_id") as disbursed_receivable_due_account_id,
+        json_value(account_ids, "$.interest_receivable_overdue_account_id") as interest_receivable_overdue_account_id,
+        json_value(account_ids, "$.disbursed_receivable_overdue_account_id") as disbursed_receivable_overdue_account_id,
+        json_value(account_ids, "$.interest_receivable_not_yet_due_account_id") as interest_receivable_not_yet_due_account_id,
+        json_value(account_ids, "$.disbursed_receivable_not_yet_due_account_id") as disbursed_receivable_not_yet_due_account_id,
+
+        * except(
+            credit_facility_id,
+            sequence,
+            customer_id,
+            amount,
+            ledger_tx_ids,
+            account_ids,
+            terms,
+            collateral,
+            price,
+            collateralization_ratio,
+            collateralization_state,
+            approved,
+            is_approval_process_concluded,
+            is_activated,
+            activated_at,
+            is_completed,
+            interest_accrual_cycle_idx,
+            interest_period,
+            outstanding,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+, final as (
+    select
+        *,
+        collateral_amount_usd / facility_amount_usd * 100 as current_facility_cvl,
+        case when duration_type = 'months' then timestamp_add(date(credit_facility_activated_at), interval duration_value month) end as credit_facility_maturity_at,
+    from transformed
+)
+
+
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_credit_facility_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['credit_facility_id', 'sequence'],
+    unique_key = ['credit_facility_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_credit_facility_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (credit_facility_id, sequence)
+        left join {{ this }} as t using (credit_facility_id, version)
         where t.credit_facility_id is null
     {% endif %}
 )
@@ -20,7 +20,7 @@ with source as (
 , transformed as (
     select
         credit_facility_id,
-        sequence,
+        version,
         customer_id,
 
         cast(amount as numeric) / {{ var('cents_per_usd') }} as facility_amount_usd,
@@ -85,7 +85,7 @@ with source as (
 
         * except(
             credit_facility_id,
-            sequence,
+            version,
             customer_id,
             amount,
             ledger_tx_ids,

--- a/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup.sql
@@ -1,24 +1,23 @@
-with customer as (
+with latest_sequence as (
     select
-        id as customer_id,
-        created_at as customer_created_at,
-        modified_at as customer_modified_at,
+        customer_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_customer_events_rollup_sequence') }}
+    group by customer_id
+)
 
-        * except(
-            id,
-            created_at,
-            modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_customer_events_rollup_sequence') }}
+)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_customer_events_rollup') }}
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (customer_id, sequence)
+
 )
 
 
-select * from customer
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         customer_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_customer_events_rollup_sequence') }}
     group by customer_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (customer_id, sequence)
+    inner join latest_sequence using (customer_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup_sequence.sql
@@ -1,0 +1,42 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['customer_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_customer_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (customer_id, sequence)
+        where t.customer_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        customer_id,
+        created_at as customer_created_at,
+        modified_at as customer_modified_at,
+
+        * except(
+            customer_id,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_customer_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['customer_id', 'sequence'],
+    unique_key = ['customer_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_customer_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (customer_id, sequence)
+        left join {{ this }} as t using (customer_id, version)
         where t.customer_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         deposit_account_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_deposit_account_events_rollup_sequence') }}
     group by deposit_account_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (deposit_account_id, sequence)
+    inner join latest_sequence using (deposit_account_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup.sql
@@ -1,26 +1,23 @@
-with deposit_account as (
+with latest_sequence as (
     select
-        id as deposit_account_id,
-        account_holder_id as customer_id,
-        created_at as deposit_account_created_at,
-        modified_at as deposit_account_modified_at,
+        deposit_account_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_deposit_account_events_rollup_sequence') }}
+    group by deposit_account_id
+)
 
-        * except(
-            id,
-            account_holder_id,
-            created_at,
-            modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_deposit_account_events_rollup_sequence') }}
+)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_deposit_account_events_rollup') }}
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (deposit_account_id, sequence)
+
 )
 
 
-select * from deposit_account
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup_sequence.sql
@@ -1,0 +1,44 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['deposit_account_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_deposit_account_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (deposit_account_id, sequence)
+        where t.deposit_account_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        deposit_account_id,
+        account_holder_id as customer_id,
+        created_at as deposit_account_created_at,
+        modified_at as deposit_account_modified_at,
+
+        * except(
+            deposit_account_id,
+            account_holder_id,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_account_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['deposit_account_id', 'sequence'],
+    unique_key = ['deposit_account_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_deposit_account_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (deposit_account_id, sequence)
+        left join {{ this }} as t using (deposit_account_id, version)
         where t.deposit_account_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup.sql
@@ -1,29 +1,23 @@
-with deposit as (
+with latest_sequence as (
     select
-        id as deposit_id,
-        deposit_account_id,
+        deposit_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_deposit_events_rollup_sequence') }}
+    group by deposit_id
+)
 
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
-        created_at as deposit_created_at,
-        modified_at as deposit_modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_deposit_events_rollup_sequence') }}
+)
 
-        * except(
-            id,
-            deposit_account_id,
-            amount,
-            created_at,
-            modified_at,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (deposit_id, sequence)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_deposit_events_rollup') }}
 )
 
 
-select * from deposit
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         deposit_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_deposit_events_rollup_sequence') }}
     group by deposit_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (deposit_id, sequence)
+    inner join latest_sequence using (deposit_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup_sequence.sql
@@ -1,0 +1,47 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['deposit_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_deposit_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (deposit_id, sequence)
+        where t.deposit_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        deposit_id,
+        deposit_account_id,
+
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
+        created_at as deposit_created_at,
+        modified_at as deposit_modified_at,
+
+        * except(
+            deposit_id,
+            deposit_account_id,
+            amount,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_deposit_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['deposit_id', 'sequence'],
+    unique_key = ['deposit_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_deposit_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (deposit_id, sequence)
+        left join {{ this }} as t using (deposit_id, version)
         where t.deposit_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         disbursal_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_disbursal_events_rollup_sequence') }}
     group by disbursal_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (disbursal_id, sequence)
+    inner join latest_sequence using (disbursal_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup.sql
@@ -1,45 +1,23 @@
-with disbursal as (
+with latest_sequence as (
     select
-        id as disbursal_id,
-        credit_facility_id,
-        cast(effective as timestamp) as effective,
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
-        approved,
-        is_approval_process_concluded,
-        is_settled,
-        is_cancelled,
-        cast(due_date as timestamp) as due_date,
-        cast(overdue_date as timestamp) as overdue_date,
-        cast(liquidation_date as timestamp) as liquidation_date,
-        created_at as disbursal_created_at,
-        modified_at as disbursal_modified_at,
+        disbursal_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_disbursal_events_rollup_sequence') }}
+    group by disbursal_id
+)
 
-        * except(
-            id,
-            credit_facility_id,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_disbursal_events_rollup_sequence') }}
+)
 
-            effective,
-            amount,
-            approved,
-            is_approval_process_concluded,
-            is_settled,
-            is_cancelled,
-            due_date,
-            overdue_date,
-            liquidation_date,
-            created_at,
-            modified_at,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (disbursal_id, sequence)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_disbursal_events_rollup') }}
 )
 
 
-select * from disbursal
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup_sequence.sql
@@ -1,0 +1,63 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['disbursal_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_disbursal_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (disbursal_id, sequence)
+        where t.disbursal_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        disbursal_id,
+        credit_facility_id,
+        cast(effective as timestamp) as effective,
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
+        approved,
+        is_approval_process_concluded,
+        is_settled,
+        is_cancelled,
+        cast(due_date as timestamp) as due_date,
+        cast(overdue_date as timestamp) as overdue_date,
+        cast(liquidation_date as timestamp) as liquidation_date,
+        created_at as disbursal_created_at,
+        modified_at as disbursal_modified_at,
+
+        * except(
+            disbursal_id,
+            credit_facility_id,
+
+            effective,
+            amount,
+            approved,
+            is_approval_process_concluded,
+            is_settled,
+            is_cancelled,
+            due_date,
+            overdue_date,
+            liquidation_date,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_disbursal_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['disbursal_id', 'sequence'],
+    unique_key = ['disbursal_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_disbursal_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (disbursal_id, sequence)
+        left join {{ this }} as t using (disbursal_id, version)
         where t.disbursal_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         interest_accrual_cycle_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_interest_accrual_cycle_events_rollup_sequence') }}
     group by interest_accrual_cycle_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (interest_accrual_cycle_id, sequence)
+    inner join latest_sequence using (interest_accrual_cycle_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup.sql
@@ -1,67 +1,23 @@
-with interest_accrual_cycle as (
+with latest_sequence as (
     select
-        id as interest_accrual_cycle_id,
-        credit_facility_id,
-        cast(facility_matures_at as timestamp) as facility_matures_at,
+        interest_accrual_cycle_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_interest_accrual_cycle_events_rollup_sequence') }}
+    group by interest_accrual_cycle_id
+)
 
-        idx,
-        cast(json_value(period, "$.start") as timestamp) as period_start_at,
-        cast(json_value(period, "$.end") as timestamp) as period_end_at,
-        json_value(period, "$.interval.type") as period_interval_type,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_interest_accrual_cycle_events_rollup_sequence') }}
+)
 
-        cast(json_value(terms, "$.annual_rate") as numeric) as annual_rate,
-        cast(json_value(terms, "$.one_time_fee_rate") as numeric) as one_time_fee_rate,
-        cast(json_value(terms, "$.initial_cvl") as numeric) as initial_cvl,
-        cast(json_value(terms, "$.liquidation_cvl") as numeric) as liquidation_cvl,
-        cast(json_value(terms, "$.margin_call_cvl") as numeric) as margin_call_cvl,
-        cast(json_value(terms, "$.duration.value") as integer) as duration_value,
-        json_value(terms, "$.duration.type") as duration_type,
-        json_value(terms, "$.accrual_interval.type") as accrual_interval,
-        json_value(terms, "$.accrual_cycle_interval.type") as accrual_cycle_interval,
-        cast(json_value(terms, "$.interest_due_duration_from_accrual.value") as integer) as interest_due_duration_from_accrual_value,
-        json_value(terms, "$.interest_due_duration_from_accrual.type") as interest_due_duration_from_accrual_type,
-        cast(json_value(terms, "$.obligation_overdue_duration_from_due.value") as integer) as obligation_overdue_duration_from_due_value,
-        json_value(terms, "$.obligation_overdue_duration_from_due.type") as obligation_overdue_duration_from_due_type,
-        cast(json_value(terms, "$.obligation_liquidation_duration_from_due.value") as integer) as obligation_liquidation_duration_from_due_value,
-        json_value(terms, "$.obligation_liquidation_duration_from_due.type") as obligation_liquidation_duration_from_due_type,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (interest_accrual_cycle_id, sequence)
 
-        cast(accrued_at as timestamp) as last_accrued_at,
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as last_accrued_interest_amount_usd,
-
-        cast(effective as timestamp) as posted_effective,
-        cast(total as numeric) / {{ var('cents_per_usd') }} as posted_total_interest_usd,
-        obligation_id as posted_obligation_id,
-        is_interest_accruals_posted,
-
-        created_at as interest_accrual_cycle_created_at,
-        modified_at as interest_accrual_cycle_modified_at,
-
-        * except(
-            id,
-            credit_facility_id,
-            obligation_id,
-            facility_matures_at,
-            idx,
-            period,
-            terms,
-            accrued_at,
-            amount,
-            effective,
-            total,
-            is_interest_accruals_posted,
-            created_at,
-            modified_at,
-
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_interest_accrual_cycle_events_rollup') }}
 )
 
 
-select * from interest_accrual_cycle
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['interest_accrual_cycle_id', 'sequence'],
+    unique_key = ['interest_accrual_cycle_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_interest_accrual_cycle_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (interest_accrual_cycle_id, sequence)
+        left join {{ this }} as t using (interest_accrual_cycle_id, version)
         where t.interest_accrual_cycle_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_interest_accrual_cycle_events_rollup_sequence.sql
@@ -1,0 +1,85 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['interest_accrual_cycle_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_interest_accrual_cycle_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (interest_accrual_cycle_id, sequence)
+        where t.interest_accrual_cycle_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        interest_accrual_cycle_id,
+        credit_facility_id,
+        cast(facility_matures_at as timestamp) as facility_matures_at,
+
+        idx,
+        cast(json_value(period, "$.start") as timestamp) as period_start_at,
+        cast(json_value(period, "$.end") as timestamp) as period_end_at,
+        json_value(period, "$.interval.type") as period_interval_type,
+
+        cast(json_value(terms, "$.annual_rate") as numeric) as annual_rate,
+        cast(json_value(terms, "$.one_time_fee_rate") as numeric) as one_time_fee_rate,
+        cast(json_value(terms, "$.initial_cvl") as numeric) as initial_cvl,
+        cast(json_value(terms, "$.liquidation_cvl") as numeric) as liquidation_cvl,
+        cast(json_value(terms, "$.margin_call_cvl") as numeric) as margin_call_cvl,
+        cast(json_value(terms, "$.duration.value") as integer) as duration_value,
+        json_value(terms, "$.duration.type") as duration_type,
+        json_value(terms, "$.accrual_interval.type") as accrual_interval,
+        json_value(terms, "$.accrual_cycle_interval.type") as accrual_cycle_interval,
+        cast(json_value(terms, "$.interest_due_duration_from_accrual.value") as integer) as interest_due_duration_from_accrual_value,
+        json_value(terms, "$.interest_due_duration_from_accrual.type") as interest_due_duration_from_accrual_type,
+        cast(json_value(terms, "$.obligation_overdue_duration_from_due.value") as integer) as obligation_overdue_duration_from_due_value,
+        json_value(terms, "$.obligation_overdue_duration_from_due.type") as obligation_overdue_duration_from_due_type,
+        cast(json_value(terms, "$.obligation_liquidation_duration_from_due.value") as integer) as obligation_liquidation_duration_from_due_value,
+        json_value(terms, "$.obligation_liquidation_duration_from_due.type") as obligation_liquidation_duration_from_due_type,
+
+        cast(accrued_at as timestamp) as last_accrued_at,
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as last_accrued_interest_amount_usd,
+
+        cast(effective as timestamp) as posted_effective,
+        cast(total as numeric) / {{ var('cents_per_usd') }} as posted_total_interest_usd,
+        obligation_id as posted_obligation_id,
+        is_interest_accruals_posted,
+
+        created_at as interest_accrual_cycle_created_at,
+        modified_at as interest_accrual_cycle_modified_at,
+
+        * except(
+            interest_accrual_cycle_id,
+            credit_facility_id,
+            obligation_id,
+            facility_matures_at,
+            idx,
+            period,
+            terms,
+            accrued_at,
+            amount,
+            effective,
+            total,
+            is_interest_accruals_posted,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         liquidation_process_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_liquidation_process_events_rollup_sequence') }}
     group by liquidation_process_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (liquidation_process_id, sequence)
+    inner join latest_sequence using (liquidation_process_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup.sql
@@ -1,34 +1,23 @@
-with liquidation_process as (
+with latest_sequence as (
     select
-        id as liquidation_process_id,
-        credit_facility_id,
+        liquidation_process_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_liquidation_process_events_rollup_sequence') }}
+    group by liquidation_process_id
+)
 
-        cast(effective as timestamp) as effective,
-        is_completed,
-        cast(initial_amount as numeric) / {{ var('cents_per_usd') }} as initial_amount_usd,
-        created_at as liquidation_process_created_at,
-        modified_at as liquidation_process_modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_liquidation_process_events_rollup_sequence') }}
+)
 
-        * except(
-            id,
-            credit_facility_id,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (liquidation_process_id, sequence)
 
-            effective,
-            is_completed,
-            initial_amount,
-            created_at,
-            modified_at,
-
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_liquidation_process_events_rollup') }}
 )
 
 
-select * from liquidation_process
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['liquidation_process_id', 'sequence'],
+    unique_key = ['liquidation_process_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_liquidation_process_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (liquidation_process_id, sequence)
+        left join {{ this }} as t using (liquidation_process_id, version)
         where t.liquidation_process_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_liquidation_process_events_rollup_sequence.sql
@@ -1,0 +1,52 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['liquidation_process_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_liquidation_process_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (liquidation_process_id, sequence)
+        where t.liquidation_process_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        liquidation_process_id,
+        credit_facility_id,
+
+        cast(effective as timestamp) as effective,
+        is_completed,
+        cast(initial_amount as numeric) / {{ var('cents_per_usd') }} as initial_amount_usd,
+        created_at as liquidation_process_created_at,
+        modified_at as liquidation_process_modified_at,
+
+        * except(
+            liquidation_process_id,
+            credit_facility_id,
+
+            effective,
+            is_completed,
+            initial_amount,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         obligation_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_obligation_events_rollup_sequence') }}
     group by obligation_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (obligation_id, sequence)
+    inner join latest_sequence using (obligation_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup.sql
@@ -1,73 +1,23 @@
-with obligation as (
+with latest_sequence as (
     select
-        id as obligation_id,
-        credit_facility_id,
+        obligation_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_obligation_events_rollup_sequence') }}
+    group by obligation_id
+)
 
-        cast(effective as timestamp) as effective,
-        obligation_type,
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
-        cast(payment_allocation_amount as numeric) / {{ var('cents_per_usd') }} as payment_allocation_amount_usd,
-        cast(due_amount as numeric) / {{ var('cents_per_usd') }} as due_amount_usd,
-        cast(overdue_amount as numeric) / {{ var('cents_per_usd') }} as overdue_amount_usd,
-        cast(defaulted_amount as numeric) / {{ var('cents_per_usd') }} as defaulted_amount_usd,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_obligation_events_rollup_sequence') }}
+)
 
-        current_timestamp() >= due_date
-            and current_timestamp() >= overdue_date
-            and not is_completed
-            and not is_defaulted_recorded
-            and cast(amount as numeric) > 0
-        as overdue,
-        case
-            when is_completed
-                or is_defaulted_recorded
-                or cast(amount as numeric) <= 0
-                    then 0
-            else 1
-        end * greatest(timestamp_diff(current_timestamp(), overdue_date, DAY), 0) as overdue_days,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (obligation_id, sequence)
 
-        cast(due_date as timestamp) as due_date,
-        cast(overdue_date as timestamp) as overdue_date,
-        cast(liquidation_date as timestamp) as liquidation_date,
-        cast(defaulted_date as timestamp) as defaulted_date,
-        is_due_recorded,
-        is_overdue_recorded,
-        is_defaulted_recorded,
-        is_completed,
-        created_at as obligation_created_at,
-        modified_at as obligation_modified_at,
-
-        * except(
-            id,
-            credit_facility_id,
-
-            effective,
-            obligation_type,
-            amount,
-            payment_allocation_amount,
-            due_amount,
-            overdue_amount,
-            defaulted_amount,
-            due_date,
-            overdue_date,
-            liquidation_date,
-            defaulted_date,
-            is_due_recorded,
-            is_overdue_recorded,
-            is_defaulted_recorded,
-            is_completed,
-            created_at,
-            modified_at,
-
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_obligation_events_rollup') }}
 )
 
 
-select * from obligation
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['obligation_id', 'sequence'],
+    unique_key = ['obligation_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_obligation_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (obligation_id, sequence)
+        left join {{ this }} as t using (obligation_id, version)
         where t.obligation_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_obligation_events_rollup_sequence.sql
@@ -1,0 +1,91 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['obligation_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_obligation_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (obligation_id, sequence)
+        where t.obligation_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        obligation_id,
+        credit_facility_id,
+
+        cast(effective as timestamp) as effective,
+        obligation_type,
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
+        cast(payment_allocation_amount as numeric) / {{ var('cents_per_usd') }} as payment_allocation_amount_usd,
+        cast(due_amount as numeric) / {{ var('cents_per_usd') }} as due_amount_usd,
+        cast(overdue_amount as numeric) / {{ var('cents_per_usd') }} as overdue_amount_usd,
+        cast(defaulted_amount as numeric) / {{ var('cents_per_usd') }} as defaulted_amount_usd,
+
+        current_timestamp() >= due_date
+            and current_timestamp() >= overdue_date
+            and not is_completed
+            and not is_defaulted_recorded
+            and cast(amount as numeric) > 0
+        as overdue,
+        case
+            when is_completed
+                or is_defaulted_recorded
+                or cast(amount as numeric) <= 0
+                    then 0
+            else 1
+        end * greatest(timestamp_diff(current_timestamp(), overdue_date, DAY), 0) as overdue_days,
+
+        cast(due_date as timestamp) as due_date,
+        cast(overdue_date as timestamp) as overdue_date,
+        cast(liquidation_date as timestamp) as liquidation_date,
+        cast(defaulted_date as timestamp) as defaulted_date,
+        is_due_recorded,
+        is_overdue_recorded,
+        is_defaulted_recorded,
+        is_completed,
+        created_at as obligation_created_at,
+        modified_at as obligation_modified_at,
+
+        * except(
+            obligation_id,
+            credit_facility_id,
+
+            effective,
+            obligation_type,
+            amount,
+            payment_allocation_amount,
+            due_amount,
+            overdue_amount,
+            defaulted_amount,
+            due_date,
+            overdue_date,
+            liquidation_date,
+            defaulted_date,
+            is_due_recorded,
+            is_overdue_recorded,
+            is_defaulted_recorded,
+            is_completed,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         payment_allocation_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_payment_allocation_events_rollup_sequence') }}
     group by payment_allocation_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (payment_allocation_id, sequence)
+    inner join latest_sequence using (payment_allocation_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup.sql
@@ -1,42 +1,23 @@
-with payment_allocation as (
+with latest_sequence as (
     select
-        id as payment_allocation_id,
-        payment_id,
-        credit_facility_id,
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
-        cast(effective as timestamp) as effective,
-        obligation_type,
-        obligation_allocation_idx,
-        account_to_be_debited_id,
-        receivable_account_id,
-        obligation_id,
-        created_at as payment_allocation_created_at,
-        modified_at as payment_allocation_modified_at,
+        payment_allocation_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_payment_allocation_events_rollup_sequence') }}
+    group by payment_allocation_id
+)
 
-        * except(
-            id,
-            payment_id,
-            credit_facility_id,
-            amount,
-            effective,
-            obligation_type,
-            obligation_allocation_idx,
-            account_to_be_debited_id,
-            receivable_account_id,
-            obligation_id,
-            created_at,
-            modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_payment_allocation_events_rollup_sequence') }}
+)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_payment_allocation_events_rollup') }}
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (payment_allocation_id, sequence)
+
 )
 
 
-select * from payment_allocation
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['payment_allocation_id', 'sequence'],
+    unique_key = ['payment_allocation_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_payment_allocation_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (payment_allocation_id, sequence)
+        left join {{ this }} as t using (payment_allocation_id, version)
         where t.payment_allocation_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_allocation_events_rollup_sequence.sql
@@ -1,0 +1,60 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['payment_allocation_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_payment_allocation_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (payment_allocation_id, sequence)
+        where t.payment_allocation_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        payment_allocation_id,
+        payment_id,
+        credit_facility_id,
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
+        cast(effective as timestamp) as effective,
+        obligation_type,
+        obligation_allocation_idx,
+        account_to_be_debited_id,
+        receivable_account_id,
+        obligation_id,
+        created_at as payment_allocation_created_at,
+        modified_at as payment_allocation_modified_at,
+
+        * except(
+            payment_allocation_id,
+            payment_id,
+            credit_facility_id,
+            amount,
+            effective,
+            obligation_type,
+            obligation_allocation_idx,
+            account_to_be_debited_id,
+            receivable_account_id,
+            obligation_id,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         payment_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_payment_events_rollup_sequence') }}
     group by payment_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (payment_id, sequence)
+    inner join latest_sequence using (payment_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup.sql
@@ -1,34 +1,23 @@
-with payment as (
+with latest_sequence as (
     select
-        id as payment_id,
-        credit_facility_id,
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
-        cast(interest as numeric) / {{ var('cents_per_usd') }} as interest_usd,
-        cast(disbursal as numeric) / {{ var('cents_per_usd') }} as disbursal_usd,
-        is_payment_allocated,
-        created_at as payment_created_at,
-        modified_at as payment_modified_at,
+        payment_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_payment_events_rollup_sequence') }}
+    group by payment_id
+)
 
-        * except(
-            id,
-            credit_facility_id,
-            amount,
-            interest,
-            disbursal,
-            is_payment_allocated,
-            created_at,
-            modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_payment_events_rollup_sequence') }}
+)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_payment_events_rollup') }}
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (payment_id, sequence)
+
 )
 
 
-select * from payment
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup_sequence.sql
@@ -1,0 +1,52 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['payment_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_payment_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (payment_id, sequence)
+        where t.payment_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        payment_id,
+        credit_facility_id,
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
+        cast(interest as numeric) / {{ var('cents_per_usd') }} as interest_usd,
+        cast(disbursal as numeric) / {{ var('cents_per_usd') }} as disbursal_usd,
+        is_payment_allocated,
+        created_at as payment_created_at,
+        modified_at as payment_modified_at,
+
+        * except(
+            payment_id,
+            credit_facility_id,
+            amount,
+            interest,
+            disbursal,
+            is_payment_allocated,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_payment_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['payment_id', 'sequence'],
+    unique_key = ['payment_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_payment_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (payment_id, sequence)
+        left join {{ this }} as t using (payment_id, version)
         where t.payment_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup.sql
@@ -1,37 +1,23 @@
-with withdrawal as (
+with latest_sequence as (
     select
-        id as withdrawal_id,
-        deposit_account_id,
+        withdrawal_id,
+        max(sequence) as sequence,
+    from {{ ref('int_core_withdrawal_events_rollup_sequence') }}
+    group by withdrawal_id
+)
 
-        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
-        approved,
-        is_approval_process_concluded,
-        is_confirmed,
-        is_cancelled,
-        created_at as withdrawal_created_at,
-        modified_at as withdrawal_modified_at,
+, all_event_sequence as (
+    select *
+    from {{ ref('int_core_withdrawal_events_rollup_sequence') }}
+)
 
-        * except(
-            id,
-            deposit_account_id,
-            amount,
-            approved,
-            is_approval_process_concluded,
-            is_confirmed,
-            is_cancelled,
-            created_at,
-            modified_at,
+, final as (
+    select
+        *
+    from all_event_sequence
+    inner join latest_sequence using (withdrawal_id, sequence)
 
-            last_sequence,
-            _sdc_received_at,
-            _sdc_batched_at,
-            _sdc_extracted_at,
-            _sdc_deleted_at,
-            _sdc_sequence,
-            _sdc_table_version
-        )
-    from {{ ref('stg_core_withdrawal_events_rollup') }}
 )
 
 
-select * from withdrawal
+select * from final

--- a/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup.sql
@@ -1,7 +1,7 @@
 with latest_sequence as (
     select
         withdrawal_id,
-        max(sequence) as sequence,
+        max(version) as version,
     from {{ ref('int_core_withdrawal_events_rollup_sequence') }}
     group by withdrawal_id
 )
@@ -15,7 +15,7 @@ with latest_sequence as (
     select
         *
     from all_event_sequence
-    inner join latest_sequence using (withdrawal_id, sequence)
+    inner join latest_sequence using (withdrawal_id, version)
 
 )
 

--- a/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup_sequence.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['withdrawal_id', 'sequence'],
+    unique_key = ['withdrawal_id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_core_withdrawal_events_rollup') }} as s
 
     {% if is_incremental() %}
-        left join {{ this }} as t using (withdrawal_id, sequence)
+        left join {{ this }} as t using (withdrawal_id, version)
         where t.withdrawal_id is null
     {% endif %}
 )

--- a/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup_sequence.sql
+++ b/meltano/transform/models/intermediate/rollups/int_core_withdrawal_events_rollup_sequence.sql
@@ -1,0 +1,55 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['withdrawal_id', 'sequence'],
+    full_refresh = true,
+) }}
+
+
+with source as (
+    select
+        s.*
+    from {{ ref('stg_core_withdrawal_events_rollup') }} as s
+
+    {% if is_incremental() %}
+        left join {{ this }} as t using (withdrawal_id, sequence)
+        where t.withdrawal_id is null
+    {% endif %}
+)
+
+
+, transformed as (
+    select
+        withdrawal_id,
+        deposit_account_id,
+
+        cast(amount as numeric) / {{ var('cents_per_usd') }} as amount_usd,
+        approved,
+        is_approval_process_concluded,
+        is_confirmed,
+        is_cancelled,
+        created_at as withdrawal_created_at,
+        modified_at as withdrawal_modified_at,
+
+        * except(
+            withdrawal_id,
+            deposit_account_id,
+            amount,
+            approved,
+            is_approval_process_concluded,
+            is_confirmed,
+            is_cancelled,
+            created_at,
+            modified_at,
+
+            _sdc_received_at,
+            _sdc_batched_at,
+            _sdc_extracted_at,
+            _sdc_deleted_at,
+            _sdc_sequence,
+            _sdc_table_version
+        )
+    from source
+)
+
+
+select * from transformed

--- a/meltano/transform/models/staging/rollups/stg_core_approval_process_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_approval_process_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_approval_process_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_approval_process_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_approval_process_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_approval_process_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_approval_process_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as approval_process_id,
+    s.*
+from {{ source("lana", "public_core_approval_process_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_approval_process_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_approval_process_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_chart_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_chart_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_chart_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_chart_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_chart_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_chart_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_chart_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as chart_id,
+    s.*
+from {{ source("lana", "public_core_chart_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_chart_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_chart_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_collateral_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_collateral_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_collateral_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_collateral_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_collateral_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_collateral_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_collateral_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as collateral_id,
+    s.*
+from {{ source("lana", "public_core_collateral_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_collateral_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_collateral_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_committee_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_committee_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_committee_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_committee_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_committee_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_committee_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_committee_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as committee_id,
+    s.*
+from {{ source("lana", "public_core_committee_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_committee_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_committee_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_credit_facility_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_credit_facility_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_credit_facility_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_credit_facility_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_credit_facility_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_credit_facility_events_rollup.sql
@@ -1,28 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
-    full_refresh = false,
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_credit_facility_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as credit_facility_id,
+    s.*
+from {{ source("lana", "public_core_credit_facility_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_credit_facility_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_credit_facility_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_custodian_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_custodian_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_custodian_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_custodian_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_custodian_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_custodian_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_custodian_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as custodian_id,
+    s.*
+from {{ source("lana", "public_core_custodian_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_custodian_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_custodian_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_customer_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_customer_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_customer_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_customer_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_customer_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_customer_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_customer_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as customer_id,
+    s.*
+from {{ source("lana", "public_core_customer_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_customer_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_customer_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_deposit_account_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_deposit_account_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_deposit_account_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as deposit_account_id,
+    s.*
+from {{ source("lana", "public_core_deposit_account_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_deposit_account_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_deposit_account_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_deposit_account_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_deposit_account_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_deposit_account_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_deposit_account_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_deposit_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_deposit_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_deposit_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as deposit_id,
+    s.*
+from {{ source("lana", "public_core_deposit_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_deposit_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_deposit_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_deposit_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_deposit_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_deposit_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_deposit_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_disbursal_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_disbursal_events_rollup.sql
@@ -1,28 +1,19 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_disbursal_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    facility_id as credit_facility_id,
-    * except (facility_id, order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as disbursal_id,
+    s.facility_id as credit_facility_id,
+    s.*
+from {{ source("lana", "public_core_disbursal_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_disbursal_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_disbursal_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_disbursal_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_disbursal_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ select
 from {{ source("lana", "public_core_disbursal_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_disbursal_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_document_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_document_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_document_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as document_id,
+    s.*
+from {{ source("lana", "public_core_document_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_document_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_document_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_document_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_document_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_document_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_document_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_interest_accrual_cycle_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_interest_accrual_cycle_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -11,7 +11,7 @@ select
 from {{ source("lana", "public_core_interest_accrual_cycle_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_interest_accrual_cycle_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_interest_accrual_cycle_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_interest_accrual_cycle_events_rollup.sql
@@ -1,28 +1,19 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_interest_accrual_cycle_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    facility_id as credit_facility_id,
-    * except (facility_id, order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as interest_accrual_cycle_id,
+    s.facility_id as credit_facility_id,
+    s.*
+from {{ source("lana", "public_core_interest_accrual_cycle_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_interest_accrual_cycle_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_interest_accrual_cycle_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_liquidation_process_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_liquidation_process_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_liquidation_process_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as liquidation_process_id,
+    s.*
+from {{ source("lana", "public_core_liquidation_process_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_liquidation_process_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_liquidation_process_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_liquidation_process_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_liquidation_process_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_liquidation_process_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_liquidation_process_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_manual_transaction_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_manual_transaction_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_manual_transaction_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_manual_transaction_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_manual_transaction_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_manual_transaction_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_manual_transaction_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as manual_transaction_id,
+    s.*
+from {{ source("lana", "public_core_manual_transaction_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_manual_transaction_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_manual_transaction_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_obligation_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_obligation_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_obligation_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_obligation_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_obligation_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_obligation_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_obligation_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as obligation_id,
+    s.*
+from {{ source("lana", "public_core_obligation_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_obligation_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_obligation_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_payment_allocation_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_payment_allocation_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_payment_allocation_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as payment_allocation_id,
+    s.*
+from {{ source("lana", "public_core_payment_allocation_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_payment_allocation_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_payment_allocation_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_payment_allocation_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_payment_allocation_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_payment_allocation_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_payment_allocation_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_payment_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_payment_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_payment_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as payment_id,
+    s.*
+from {{ source("lana", "public_core_payment_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_payment_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_payment_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_payment_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_payment_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_payment_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_payment_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_permission_set_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_permission_set_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_permission_set_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_permission_set_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_permission_set_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_permission_set_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_permission_set_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as permission_set_id,
+    s.*
+from {{ source("lana", "public_core_permission_set_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_permission_set_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_permission_set_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_policy_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_policy_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_policy_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_policy_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_policy_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_policy_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_policy_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as policy_id,
+    s.*
+from {{ source("lana", "public_core_policy_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_policy_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_policy_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_role_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_role_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_role_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_role_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_role_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_role_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_role_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as role_id,
+    s.*
+from {{ source("lana", "public_core_role_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_role_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_role_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_terms_template_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_terms_template_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_terms_template_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as terms_template_id,
+    s.*
+from {{ source("lana", "public_core_terms_template_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_terms_template_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_terms_template_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_terms_template_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_terms_template_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_terms_template_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_terms_template_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_user_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_user_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_user_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_user_events_rollup_view") }})
     and t.id is null
 {% else %}

--- a/meltano/transform/models/staging/rollups/stg_core_user_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_user_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_user_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as user_id,
+    s.*
+from {{ source("lana", "public_core_user_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_user_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_user_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_withdrawal_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_withdrawal_events_rollup.sql
@@ -1,27 +1,18 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id'],
+    unique_key = ['id', 'sequence'],
+    full_refresh = true,
 ) }}
 
-with ordered as (
-    select
-        *,
-        row_number()
-            over (
-                partition by id
-                order by _sdc_received_at desc
-            )
-            as order_received_desc
-
-    from {{ source("lana", "public_core_withdrawal_events_rollup_view") }}
-
-    {% if is_incremental() %}
-        where
-            _sdc_batched_at >= (select coalesce(max(_sdc_batched_at), '1900-01-01') from {{ this }})
-    {% endif %}
-)
-
 select
-    * except (order_received_desc),
-from ordered
-where order_received_desc = 1
+    s.id as withdrawal_id,
+    s.*
+from {{ source("lana", "public_core_withdrawal_events_rollup_view") }} as s
+
+{% if is_incremental() %}
+    left join {{ this }} as t using (id, sequence)
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_withdrawal_events_rollup_view") }})
+    and t.id is null
+{% else %}
+    where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_withdrawal_events_rollup_view") }})
+{% endif %}

--- a/meltano/transform/models/staging/rollups/stg_core_withdrawal_events_rollup.sql
+++ b/meltano/transform/models/staging/rollups/stg_core_withdrawal_events_rollup.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = ['id', 'sequence'],
+    unique_key = ['id', 'version'],
     full_refresh = true,
 ) }}
 
@@ -10,7 +10,7 @@ select
 from {{ source("lana", "public_core_withdrawal_events_rollup_view") }} as s
 
 {% if is_incremental() %}
-    left join {{ this }} as t using (id, sequence)
+    left join {{ this }} as t using (id, version)
     where s._sdc_batched_at = (select max(_sdc_batched_at) from {{ source("lana", "public_core_withdrawal_events_rollup_view") }})
     and t.id is null
 {% else %}


### PR DESCRIPTION
adopting new roll-up pattern listing the sequence of events (one per row) accumulating updates so that the latest represent the current state of the object/entity
where as only one row used to be exported before.

this will allow for identifying/reporting changes in all fields

to handle this,

stg_*_rollups.sql have been updated to gather all new rows, incrementally

int_*_rollups_sequence.sql have been created to gather all transformations for all new rows, incrementally

and 

int_*_rollups.sql have been modified to still only expose the latest state (single row)


