### PR TITLE
feat: report generation configurable output

### DIFF
--- a/meltano/utilities/generate-es-reports/README.md
+++ b/meltano/utilities/generate-es-reports/README.md
@@ -1,5 +1,7 @@
 # generate-es-reports
 
-`generate-es-reports` is a meltano utility to generate reports.
+`generate-es-reports` is a meltano utility to generate report files out of DW tables and store them.
 
-run with `meltano invoke generate-es-reports`
+You can run it with with `meltano invoke generate-es-reports run`.
+
+Running with the environment variable `USE_LOCAL_FS` set to `1` will write to local filesystem instead of GCS. This is implemented only to make local development and debugging easier. You will find the generated reports in the same folder where the tool is.

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -24,58 +24,26 @@ class ReportGeneratorConfig:
 
 def get_config_from_env() -> ReportGeneratorConfig:
 
-    if os.getenv("AIRFLOW_CTX_DAG_RUN_ID"):
-        required_envs = [
-            "DBT_BIGQUERY_PROJECT",
-            "DBT_BIGQUERY_DATASET",
-            "DOCS_BUCKET_NAME",
-            "AIRFLOW_CTX_DAG_RUN_ID",  # automatically set by Airflow
-        ]
-        missing = [var for var in required_envs if not os.getenv(var)]
-        if missing:
-            raise RuntimeError(
-                f"Missing required environment variables: {', '.join(missing)}"
-            )
-        project_id = os.getenv("DBT_BIGQUERY_PROJECT")
-        dataset = os.getenv("DBT_BIGQUERY_DATASET")
-        bucket_name = os.getenv("DOCS_BUCKET_NAME")
-        run_id = os.getenv("AIRFLOW_CTX_DAG_RUN_ID")
-
-        keyfile = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-        if not keyfile or not os.path.isfile(keyfile):
-            raise RuntimeError(
-                "GOOGLE_APPLICATION_CREDENTIALS environment variable must be set to the path of a valid service account JSON file."
-            )
-
-        return ReportGeneratorConfig(
-            project_id=project_id,
-            dataset=dataset,
-            bucket_name=bucket_name,
-            run_id=run_id,
-            keyfile=keyfile,
+    required_envs = ["DBT_BIGQUERY_PROJECT", "DBT_BIGQUERY_DATASET", "DOCS_BUCKET_NAME"]
+    missing = [var for var in required_envs if not os.getenv(var)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing)}"
         )
 
-    if not os.getenv("AIRFLOW_CTX_DAG_RUN_ID"):
-        required_envs = ["DBT_BIGQUERY_PROJECT", "DBT_BIGQUERY_DATASET", "DOCS_BUCKET_NAME"]
-        missing = [var for var in required_envs if not os.getenv(var)]
-        if missing:
-            raise RuntimeError(
-                f"Missing required environment variables: {', '.join(missing)}"
-            )
-        project_id = os.getenv("DBT_BIGQUERY_PROJECT")
-        dataset = os.getenv("DBT_BIGQUERY_DATASET")
-        bucket_name = os.getenv("DOCS_BUCKET_NAME")
-        run_id = "dev"
+    is_airflow_run = bool(os.getenv("AIRFLOW_CTX_DAG_RUN_ID", False))
 
-        keyfile = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    run_id = "dev"
+    if is_airflow_run:
+        run_id = os.getenv("AIRFLOW_CTX_DAG_RUN_ID")     
 
-        return ReportGeneratorConfig(
-            project_id=project_id,
-            dataset=dataset,
-            bucket_name=bucket_name,
-            run_id=run_id,
-            keyfile=keyfile,
-        )
+    return ReportGeneratorConfig(
+        project_id=os.getenv("DBT_BIGQUERY_PROJECT"),
+        dataset=os.getenv("DBT_BIGQUERY_DATASET"),
+        bucket_name=os.getenv("DOCS_BUCKET_NAME"),
+        run_id=run_id,
+        keyfile=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+    )
 
 
 def main():

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -132,11 +132,15 @@ def main():
         field_names = [field.name for field in rows.schema]
         rows_data = [{name: row[name] for name in field_names} for row in rows]
 
+        blob_path = (
+            f"reports/{report_generator_config.run_id}/{norm_name}/{report_name}"
+        )
+
         if norm_name in ["nrp_41", "nrp_51"]:
             report_content_type = "text/xml"
             report_bytes = dicttoxml(rows_data, custom_root="rows", attr_type=False)
             report_content = report_bytes.decode("utf-8")
-            blob_path = f"reports/{report_generator_config.run_id}/{norm_name}/{report_name}.xml"
+            blob_path = blob_path + ".xml"
 
         if norm_name == "nrsf_03":
             report_content_type = "text/plain"
@@ -147,7 +151,7 @@ def main():
             writer.writeheader()
             writer.writerows(rows_data)
             report_content = output.getvalue()
-            blob_path = f"reports/{report_generator_config.run_id}/{norm_name}/{report_name}.txt"
+            blob_path = blob_path + ".txt"
 
         # CSV versions of all regulatory reports
         if norm_name in ["nrp_41", "nrp_51", "nrsf_03"]:
@@ -159,7 +163,7 @@ def main():
             writer.writeheader()
             writer.writerows(rows_data)
             report_content = output.getvalue()
-            blob_path = f"reports/{report_generator_config.run_id}/{norm_name}/{report_name}.csv"
+            blob_path = blob_path + ".csv"
 
         gcs_report_storer.store_report(
             path=blob_path,

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -11,8 +11,7 @@ from .validation import Validator
 
 table_name_pattern = compile(r"report_([0-9a-z_]+)_\d+_(.+)")
 
-
-def main():
+def airflow_run():
     required_envs = [
         "DBT_BIGQUERY_PROJECT",
         "DBT_BIGQUERY_DATASET",
@@ -41,6 +40,7 @@ def main():
     validator = Validator()
 
     tables_iter = bq_client.list_tables(dataset)
+    
     for table in tables_iter:
         table_name = table.table_id
         match = table_name_pattern.match(table_name)
@@ -107,6 +107,115 @@ def main():
                 report_content_type,
             )
 
+
+def non_airflow_run():
+    required_envs = [
+        "DBT_BIGQUERY_PROJECT",
+        "DBT_BIGQUERY_DATASET",
+        "DOCS_BUCKET_NAME"
+    ]
+    missing = [var for var in required_envs if not os.getenv(var)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+    project_id = os.getenv("DBT_BIGQUERY_PROJECT")
+    dataset = os.getenv("DBT_BIGQUERY_DATASET")
+    bucket_name = os.getenv("DOCS_BUCKET_NAME")
+    run_id = "dev"
+
+    keyfile = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if not keyfile or not os.path.isfile(keyfile):
+        raise RuntimeError(
+            "GOOGLE_APPLICATION_CREDENTIALS environment variable must be set to the path of a valid service account JSON file."
+        )
+    credentials = service_account.Credentials.from_service_account_file(keyfile)
+    bq_client = bigquery.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client(project=project_id, credentials=credentials)
+
+    validator = Validator()
+
+    tables_iter = bq_client.list_tables(dataset)
+    
+    for table in tables_iter:
+        table_name = table.table_id
+        match = table_name_pattern.match(table_name)
+        if not match:
+            continue
+        norm_name = match.group(1)
+        report_name = match.group(2)
+
+        query = f"SELECT * FROM `{project_id}.{dataset}.{table_name}`;"
+        query_job = bq_client.query(query)
+        rows = query_job.result()
+        field_names = [field.name for field in rows.schema]
+        rows_data = [{name: row[name] for name in field_names} for row in rows]
+
+        if norm_name in ["nrp_41", "nrp_51"]:
+            report_content_type = "text/xml"
+            report_bytes = dicttoxml(rows_data, custom_root="rows", attr_type=False)
+            report_content = report_bytes.decode("utf-8")
+            blob_path = f"reports/{run_id}/{norm_name}/{report_name}.xml"
+            store_blob(
+                storage_client,
+                bucket_name,
+                blob_path,
+                report_content,
+                report_content_type,
+            )
+            if report_name == "persona":
+                validator.validate(report_name, report_bytes)
+
+        if norm_name == "nrsf_03":
+            report_content_type = "text/plain"
+            output = io.StringIO()
+            writer = csv.DictWriter(
+                output, fieldnames=field_names, delimiter="|", lineterminator="\n"
+            )
+            writer.writeheader()
+            writer.writerows(rows_data)
+            report_content = output.getvalue()
+            blob_path = f"reports/{run_id}/{norm_name}/{report_name}.txt"
+            store_blob(
+                storage_client,
+                bucket_name,
+                blob_path,
+                report_content,
+                report_content_type,
+            )
+
+        # CSV versions of all regulatory reports
+        if norm_name in ["nrp_41", "nrp_51", "nrsf_03"]:
+            report_content_type = "text/plain"
+            output = io.StringIO()
+            writer = csv.DictWriter(
+                output, fieldnames=field_names, delimiter=",", lineterminator="\n"
+            )
+            writer.writeheader()
+            writer.writerows(rows_data)
+            report_content = output.getvalue()
+            blob_path = f"reports/{run_id}/{norm_name}/{report_name}.csv"
+            store_blob(
+                storage_client,
+                bucket_name,
+                blob_path,
+                report_content,
+                report_content_type,
+            )    
+
+
+def main():
+    if os.getenv("AIRFLOW_CTX_DAG_RUN_ID"):
+
+        print("We're running in Airflow")
+        airflow_run()
+        return
+
+    if not os.getenv("AIRFLOW_CTX_DAG_RUN_ID"):
+        print("We're not running in Airflow")
+        non_airflow_run()
+        return
+    
 
 def store_blob(
     storage_client, bucket_name, blob_path, report_content, report_content_type

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -138,9 +138,19 @@ def main():
 
         if norm_name in ["nrp_41", "nrp_51"]:
             report_content_type = "text/xml"
-            report_bytes = dicttoxml(rows_data, custom_root="rows", attr_type=False)
-            report_content = report_bytes.decode("utf-8")
-            blob_path = blob_path + ".xml"
+            xml_string = dicttoxml(
+                rows_data, custom_root="rows", attr_type=False
+            ).decode("utf-8")
+            output = io.StringIO()
+            output.write(xml_string)
+            report_content = output.getvalue()
+            full_blob_path = blob_path + ".xml"
+            gcs_report_storer.store_report(
+                path=full_blob_path,
+                report=StorableReport(
+                    report_content=report_content, report_type=report_content_type
+                ),
+            )
 
         if norm_name == "nrsf_03":
             report_content_type = "text/plain"
@@ -151,7 +161,13 @@ def main():
             writer.writeheader()
             writer.writerows(rows_data)
             report_content = output.getvalue()
-            blob_path = blob_path + ".txt"
+            full_blob_path = blob_path + ".txt"
+            gcs_report_storer.store_report(
+                path=full_blob_path,
+                report=StorableReport(
+                    report_content=report_content, report_type=report_content_type
+                ),
+            )
 
         # CSV versions of all regulatory reports
         if norm_name in ["nrp_41", "nrp_51", "nrsf_03"]:
@@ -163,14 +179,13 @@ def main():
             writer.writeheader()
             writer.writerows(rows_data)
             report_content = output.getvalue()
-            blob_path = blob_path + ".csv"
-
-        gcs_report_storer.store_report(
-            path=blob_path,
-            report=StorableReport(
-                report_content=report_content, report_type=report_content_type
-            ),
-        )
+            full_blob_path = blob_path + ".csv"
+            gcs_report_storer.store_report(
+                path=full_blob_path,
+                report=StorableReport(
+                    report_content=report_content, report_type=report_content_type
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -1,6 +1,7 @@
 import os
 import io
 import csv
+import argparse
 from abc import ABC, abstractmethod
 from datetime import datetime
 from google.cloud import bigquery, storage
@@ -8,13 +9,8 @@ from dicttoxml import dicttoxml
 from google.oauth2 import service_account
 from re import compile
 from pathlib import Path
-from typing import Any
-
-from .validation import Validator
-
 
 table_name_pattern = compile(r"report_([0-9a-z_]+)_\d+_(.+)")
-
 
 class ReportGeneratorConfig:
 

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -32,8 +32,6 @@ def get_config_from_env() -> ReportGeneratorConfig:
             f"Missing required environment variables: {', '.join(missing)}"
         )
 
-    is_airflow_run = bool(os.getenv("AIRFLOW_CTX_DAG_RUN_ID"))
-
     run_id = os.getenv("AIRFLOW_CTX_DAG_RUN_ID", "dev") # If no AIRFLOW, we assume dev env
 
     keyfile = Path(os.getenv("GOOGLE_APPLICATION_CREDENTIALS"))
@@ -59,8 +57,8 @@ def main():
     keyfile = report_generator_config.keyfile
 
     credentials = service_account.Credentials.from_service_account_file(keyfile)
-    bq_client = bigquery.Client(project=project_id, credentials=credentials)
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    bq_client = bigquery.Client(project=report_generator_config.project_id, credentials=credentials)
+    storage_client = storage.Client(project=report_generator_config.project_id, credentials=credentials)
 
     validator = Validator()
 
@@ -74,7 +72,7 @@ def main():
         norm_name = match.group(1)
         report_name = match.group(2)
 
-        query = f"SELECT * FROM `{project_id}.{dataset}.{table_name}`;"
+        query = f"SELECT * FROM `{report_generator_config.project_id}.{dataset}.{table_name}`;"
         query_job = bq_client.query(query)
         rows = query_job.result()
         field_names = [field.name for field in rows.schema]

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -68,8 +68,8 @@ def get_config_from_env() -> ReportGeneratorConfig:
 
 class StorableReport:
 
-    def __init__(self, report_type: Any, report_content: Any) -> None:
-        self.type = report_type
+    def __init__(self, report_content_type: Any, report_content: Any) -> None:
+        self.content_type = report_content_type
         self.content = report_content
 
 
@@ -96,7 +96,7 @@ class GCSReportStorer:
     def store_report(self, path: str, report: StorableReport) -> None:
         blob = self._bucket.blob(path)
         print(f"Uploading to {path}...")
-        blob.upload_from_string(report.content, content_type=report.type)
+        blob.upload_from_string(report.content, content_type=report.content_type)
         print(f"Uploaded")
 
 
@@ -148,7 +148,7 @@ def main():
             gcs_report_storer.store_report(
                 path=full_blob_path,
                 report=StorableReport(
-                    report_content=report_content, report_type=report_content_type
+                    report_content=report_content, report_content_type=report_content_type
                 ),
             )
 
@@ -165,7 +165,7 @@ def main():
             gcs_report_storer.store_report(
                 path=full_blob_path,
                 report=StorableReport(
-                    report_content=report_content, report_type=report_content_type
+                    report_content=report_content, report_content_type=report_content_type
                 ),
             )
 
@@ -183,7 +183,7 @@ def main():
             gcs_report_storer.store_report(
                 path=full_blob_path,
                 report=StorableReport(
-                    report_content=report_content, report_type=report_content_type
+                    report_content=report_content, report_content_type=report_content_type
                 ),
             )
 


### PR DESCRIPTION
This PR extends the Python script we're using to generate the file reports in meltano to be able to write the reports to the local filesystem instead of only to a GCS bucket. Both behaviors are available, and can be picked via env vars. The defaults will still write to GCS, so the script can be runned as it was and will produce the same behaviour. An abstract class `ReportStorer` now allows for easily adding more interfaces to write the files into other systems.

Another change that was necessary for this is to make the airflow env variables optional. Without this, the script could only be executed in an Airflow environment, which makes local development painful. This PR makes that env var optional.

Besides these main changes, a lot of code shuffling, renaming and general cleaning has been done. But core behavior remains unchanged.

Please note that the script still has a lot of room to improve in many ways and this PR is not trying to bring it to perfect. It would be helpful if the review limits itself to what has been improved, not what remains to be improved.