### PR TITLE
feat: use logger in es generator

### DIFF
--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -1,7 +1,6 @@
 import os
 import io
 import csv
-from enum import Enum
 from re import compile
 from pathlib import Path
 from abc import ABC, abstractmethod

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -3,10 +3,27 @@ import io
 import csv
 from re import compile
 from pathlib import Path
+import logging, logging.config
 from abc import ABC, abstractmethod
 from google.cloud import bigquery, storage
 from dicttoxml import dicttoxml
 from google.oauth2 import service_account
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+# Disable logging by external packages
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": True,
+    }
+)
+
+logger = logging.getLogger(name="generate-es-reports")
 
 
 class Constants:
@@ -141,9 +158,9 @@ class GCSReportStorer(ReportStorer):
 
     def store_report(self, path: str, report: StorableReport) -> None:
         blob = self._bucket.blob(path)
-        print(f"Uploading to {path}...")
+        logger.info(f"Uploading to {path}...")
         blob.upload_from_string(report.content, content_type=report.content_type)
-        print(f"Uploaded")
+        logger.info(f"Uploaded")
 
 
 class LocalReportStorer(ReportStorer):
@@ -156,10 +173,10 @@ class LocalReportStorer(ReportStorer):
         target_path = self._root_path / path
 
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
-        print(f"Storing locally at: {path}")
+        logger.info(f"Storing locally at: {path}")
         with open(target_path, "w", encoding="utf-8") as f:
             f.write(report.content)
-        print("File stored")
+        logger.info("File stored")
 
 
 def get_report_storer(config: ReportGeneratorConfig) -> ReportStorer:

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -227,10 +227,10 @@ def main():
 
     for table in tables_iter:
         table_name = table.table_id
-        logger.info(f"Working on table {table_name}.")
         match = Constants.TABLE_NAME_PATTERN.match(table_name)
         if not match:
             continue
+        logger.info(f"Working on table {table_name}.")
         norm_name = match.group(1)
         report_name = match.group(2)
 

--- a/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
+++ b/meltano/utilities/generate-es-reports/generate_es_reports/__init__.py
@@ -209,6 +209,7 @@ def get_report_storer(config: ReportGeneratorConfig) -> ReportStorer:
 
 
 def main():
+    logger.info("Starting run.")
     report_generator_config = get_config_from_env()
 
     credentials = service_account.Credentials.from_service_account_file(
@@ -226,6 +227,7 @@ def main():
 
     for table in tables_iter:
         table_name = table.table_id
+        logger.info(f"Working on table {table_name}.")
         match = Constants.TABLE_NAME_PATTERN.match(table_name)
         if not match:
             continue
@@ -292,6 +294,8 @@ def main():
                     report_content_type="text/plain",
                 ),
             )
+
+    logger.info("Finished run.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of using simple prints, we use the Python standard logger.

Also added a couple more logging points so that the lines that get sent to Airflow are more descriptive on what's going on in the script execution.