### PR TITLE
chore: Reduce tracing level of job.poll_and_dispatch

### DIFF
--- a/lib/job/src/poller.rs
+++ b/lib/job/src/poller.rs
@@ -79,6 +79,7 @@ impl JobPoller {
 
     #[instrument(
         name = "job.poll_and_dispatch",
+        level = "trace",
         skip(self),
         fields(n_jobs_running, n_jobs_to_start, now, next_poll_in),
         err


### PR DESCRIPTION
The `poll_and_dispatch` method gets called hundreds of times per second, flooding tracing. This change demotes trace level of this method to TRACE. Overriding manually via env_logger may be possible.