### PR TITLE
feat(ui): idle session guard

### DIFF
--- a/apps/admin-panel/app/auth/idle-session-guard.tsx
+++ b/apps/admin-panel/app/auth/idle-session-guard.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useIdleTimer, type EventsType } from "react-idle-timer"
+import { useTranslations } from "next-intl"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@lana/web/ui/dialog"
+import { Button } from "@lana/web/ui/button"
+
+import { keycloak as getKeycloak, logout as keycloakLogout } from "./keycloak"
+
+const IDLE_MS = 5 * 60 * 1000
+const PROMPT_MS = 30 * 1000
+const ACTION_THROTTLE_MS = 10 * 1000
+
+const IDLE_EVENTS: EventsType[] = [
+  "pointerdown",
+  "keydown",
+  "wheel",
+  "touchstart",
+  "scroll",
+  "mousemove",
+  "visibilitychange",
+]
+
+export default function IdleSessionGuard() {
+  const t = useTranslations("Auth.IdleSessionDialog")
+  const [showPrompt, setShowPrompt] = useState(false)
+  const [countdownSeconds, setCountdownSeconds] = useState(PROMPT_MS / 1000)
+  const countdownIntervalRef = useRef<number | null>(null)
+  const lastRefreshAtRef = useRef<number>(0)
+  const mountedRef = useRef(true)
+
+  const clearCountdown = useCallback(() => {
+    if (countdownIntervalRef.current !== null) {
+      window.clearInterval(countdownIntervalRef.current)
+      countdownIntervalRef.current = null
+    }
+  }, [])
+
+  const performLogout = useCallback(async () => {
+    setShowPrompt(false)
+    clearCountdown()
+    try {
+      await keycloakLogout()
+    } catch (err) {
+      console.error("Logout error:", err)
+      window.location.reload()
+    }
+  }, [clearCountdown])
+
+  const startCountdown = useCallback(() => {
+    setShowPrompt(true)
+    const deadline = Date.now() + PROMPT_MS
+    setCountdownSeconds(Math.ceil(PROMPT_MS / 1000))
+    clearCountdown()
+    countdownIntervalRef.current = window.setInterval(() => {
+      if (!mountedRef.current) return
+      const remaining = Math.max(0, Math.ceil((deadline - Date.now()) / 1000))
+      setCountdownSeconds(remaining)
+      if (remaining <= 0) {
+        clearCountdown()
+        performLogout()
+      }
+    }, 1000)
+  }, [clearCountdown, performLogout])
+
+  const refreshToken = useCallback(
+    async (opts: { force?: boolean } = {}) => {
+      const now = Date.now()
+      if (!opts.force && now - lastRefreshAtRef.current < ACTION_THROTTLE_MS) return
+      if (document.visibilityState !== "visible") return
+
+      const kc = await getKeycloak()
+      if (!kc) return
+      try {
+        await kc.updateToken(-1)
+        lastRefreshAtRef.current = now
+      } catch (err) {
+        console.error("Token refresh failed:", err)
+        await performLogout()
+      }
+    },
+    [performLogout],
+  )
+
+  const { reset } = useIdleTimer({
+    timeout: IDLE_MS,
+    promptBeforeIdle: PROMPT_MS,
+    crossTab: true,
+    events: showPrompt ? [] : IDLE_EVENTS,
+    eventsThrottle: ACTION_THROTTLE_MS,
+    onPrompt: () => {
+      startCountdown()
+    },
+    onIdle: () => performLogout(),
+    onAction: (event) => {
+      if (showPrompt) return
+      if (event && "isTrusted" in event && !event.isTrusted) return
+      refreshToken()
+    },
+  })
+
+  const handleStaySignedIn = useCallback(async () => {
+    setShowPrompt(false)
+    clearCountdown()
+    await refreshToken({ force: true })
+    reset()
+  }, [clearCountdown, refreshToken, reset])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearCountdown()
+    }
+  }, [clearCountdown])
+
+  return (
+    <Dialog
+      open={showPrompt}
+      onOpenChange={(open) => {
+        if (!open) {
+          handleStaySignedIn()
+        }
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription>
+            {t("description", { seconds: countdownSeconds })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex-col gap-2 sm:flex-col sm:space-y-2 sm:space-x-0">
+          <Button variant="outline" onClick={performLogout} className="w-full">
+            {t("buttons.logout")}
+          </Button>
+          <Button onClick={handleStaySignedIn} className="w-full">
+            {t("buttons.staySignedIn")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/admin-panel/app/auth/session.tsx
+++ b/apps/admin-panel/app/auth/session.tsx
@@ -10,6 +10,7 @@ import { BreadcrumbProvider } from "../breadcrumb-provider"
 import { useAppLoading } from "../app-loading"
 
 import { initKeycloak, logout } from "./keycloak"
+import IdleSessionGuard from "./idle-session-guard"
 
 import { Toast } from "@/components/toast"
 import { makeClient } from "@/lib/apollo-client/client"
@@ -63,7 +64,10 @@ export const Authenticated: React.FC<Props> = ({ children }) => {
     <BreadcrumbProvider>
       <ApolloProvider client={client}>
         <Toast />
-        <AppLayout>{children}</AppLayout>
+        <AppLayout>
+          <IdleSessionGuard />
+          {children}
+        </AppLayout>
       </ApolloProvider>
     </BreadcrumbProvider>
   )

--- a/apps/admin-panel/i18n.lock
+++ b/apps/admin-panel/i18n.lock
@@ -1149,3 +1149,7 @@ checksums:
     RolesAndPermissions/roleDetails/createdAt: 9ce495d7fc74e1a2ae86c07206a3e531
     RolesAndPermissions/roleDetails/permissionSets: 2160be68b1d6b6577e64634e9feba2ed
     RolesAndPermissions/roleDetails/editRole: b5c3ab76d07ed0d4603b2025efffc025
+    Auth/IdleSessionDialog/title: 79bc2519d69e54e889036ac6b7d5700c
+    Auth/IdleSessionDialog/description: 187addc99d1c3cec67cab0b7c32415df
+    Auth/IdleSessionDialog/buttons/logout: 9a236bb8f8bec867ec0d0950d38bcc71
+    Auth/IdleSessionDialog/buttons/staySignedIn: dced170d3bb1bf1d4c7c0b8db2f597e2

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -1916,5 +1916,15 @@
       "permissionSets": "Permissions",
       "editRole": "Edit Role"
     }
+  },
+  "Auth": {
+    "IdleSessionDialog": {
+      "title": "Session will expire soon",
+      "description": "You’ll be logged out in {seconds}s due to inactivity.",
+      "buttons": {
+        "logout": "Log out",
+        "staySignedIn": "Stay signed in"
+      }
+    }
   }
 }

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -1916,5 +1916,15 @@
       "permissionSets": "Permisos",
       "editRole": "Editar rol"
     }
+  },
+  "Auth": {
+    "IdleSessionDialog": {
+      "title": "La sesión expirará pronto",
+      "description": "Se cerrará tu sesión en {seconds}s debido a inactividad.",
+      "buttons": {
+        "logout": "Cerrar sesión",
+        "staySignedIn": "Mantener sesión iniciada"
+      }
+    }
   }
 }

--- a/apps/admin-panel/package.json
+++ b/apps/admin-panel/package.json
@@ -38,6 +38,7 @@
     "next-intl": "^4.3.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-idle-timer": "^5.7.2",
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "sonner": "^2.0.7",

--- a/dev/keycloak/internal-realm.json
+++ b/dev/keycloak/internal-realm.json
@@ -4,6 +4,8 @@
   "browserFlow": "DEV browser",
   "registrationEmailAsUsername": true,
   "directGrantFlow": "DEV direct grant",
+  "ssoSessionIdleTimeout": 300,
+  "accessTokenLifespan": 300,
   "components": {
     "org.keycloak.userprofile.UserProfileProvider": [
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.1.1)
+      react-idle-timer:
+        specifier: ^5.7.2
+        version: 5.7.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -7546,6 +7549,12 @@ packages:
     resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
     peerDependencies:
       react: '*'
+
+  react-idle-timer@5.7.2:
+    resolution: {integrity: sha512-+BaPfc7XEUU5JFkwZCx6fO1bLVK+RBlFH+iY4X34urvIzZiZINP6v2orePx3E6pAztJGE7t4DzvL7if2SL/0GQ==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -17353,6 +17362,11 @@ snapshots:
   react-icons@5.5.0(react@19.1.1):
     dependencies:
       react: 19.1.1
+
+  react-idle-timer@5.7.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
https://github.com/GaloyMoney/volcano-wip/issues/304

Approach: 5-minute idle with a 30-second warning. 
On real UI actions we force-refresh the Keycloak token (updateToken(-1)), but we throttle the refresh calls to once every 10s—so even during continuous user actions we send at most one refresh per 10s. This pings Keycloak on actual activity, letting it know we’re not idle, and keeps SSO idle in sync with a small 10-second (throttle) margin  that may have edge cases.