### PR TITLE
chore: use start_of_day for obligation dates and expected status

### DIFF
--- a/core/credit/src/primitives/mod.rs
+++ b/core/credit/src/primitives/mod.rs
@@ -631,4 +631,13 @@ impl EffectiveDate {
                 .expect("23:59:59 was invalid"),
         )
     }
+
+    pub fn start_of_day(&self) -> DateTime<Utc> {
+        Utc.from_utc_datetime(
+            &self
+                .0
+                .and_hms_opt(00, 00, 00)
+                .expect("00:00:00 was invalid"),
+        )
+    }
 }

--- a/core/credit/src/primitives/mod.rs
+++ b/core/credit/src/primitives/mod.rs
@@ -622,6 +622,12 @@ impl From<chrono::NaiveDate> for EffectiveDate {
     }
 }
 
+impl From<DateTime<Utc>> for EffectiveDate {
+    fn from(date: DateTime<Utc>) -> Self {
+        Self(date.date_naive())
+    }
+}
+
 impl EffectiveDate {
     pub fn end_of_day(&self) -> DateTime<Utc> {
         Utc.from_utc_datetime(


### PR DESCRIPTION
## Description

This is in prep for saving the due dates as `NaiveDate` type. This PR converts the current timestamps to `NaiveDate`s and then applies `start_of_day` to get the appropriate timestamp for things like comparisons and job scheduling