### PR TITLE
chore(translation): improved translation for accounting terms

### DIFF
--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -1614,7 +1614,7 @@
       "termsTemplate": "Plantilla de Términos",
       "committee": "Comité",
       "custodian": "Agregar Custodio",
-      "executeManualTransaction": "Ejecutar transacción manual",
+      "executeManualTransaction": "Registrar partida manual",
       "role": "Rol",
       "account": "Cuenta"
     }
@@ -1804,8 +1804,8 @@
     }
   },
   "LedgerTransaction": {
-    "title": "Transacción del libro mayor",
-    "description": "Un registro de una transacción financiera en el libro mayor",
+    "title": "Partida contable",
+    "description": "Un registro de una partida contable en el libro mayor",
     "noEntries": "Sin asientos",
     "details": {
       "description": "Descripción",
@@ -1813,7 +1813,7 @@
       "effective": "Fecha valor"
     },
     "entriesTitle": "Asientos contables",
-    "entriesDescription": "Asientos asociados con esta transacción",
+    "entriesDescription": "Asientos asociados con esta partida",
     "table": {
       "entryType": "Tipo de asiento",
       "debit": "Débito",
@@ -1824,26 +1824,26 @@
     }
   },
   "ManualTransactions": {
-    "title": "Ejecutar transacción manual",
-    "description": "Crea una transacción manual proporcionando los detalles requeridos",
+    "title": "Registrar partida manual",
+    "description": "Crea una partida manual proporcionando los detalles requeridos",
     "fields": {
-      "description": "Descripción de la transacción",
-      "reference": "Referencia de la transacción",
+      "description": "Descripción de la partida",
+      "reference": "Referencia de la partida",
       "effective": "Fecha valor",
-      "entries": "Asientos contables para esta transacción",
+      "entries": "Asientos contables para esta partida",
       "usd": "USD",
       "btc": "BTC",
       "debit": "Débito",
       "credit": "Crédito"
     },
     "placeholders": {
-      "description": "Ingrese la descripción de la transacción",
-      "reference": "Ingrese la referencia de la transacción",
+      "description": "Ingrese la descripción de la partida",
+      "reference": "Ingrese la referencia de la partida",
       "effective": "Seleccionar fecha valor"
     },
-    "noEntries": "No hay asientos contables para esta transacción. Por favor, añada uno.",
+    "noEntries": "No hay asientos contables para esta partida. Por favor, añada uno.",
     "addEntryBtn": "Añadir",
-    "execute": "Ejecutar",
+    "execute": "Registrar",
     "placeholdersJournalEntry": {
       "accountRef": "Introduce la referencia de cuenta",
       "currency": "Seleccione moneda",
@@ -1858,8 +1858,8 @@
       "direction": "Dirección",
       "description": "Descripción"
     },
-    "errored": "Ocurrió un error al ejecutar la transacción",
-    "success": "Transacción ejecutada con éxito"
+    "errored": "Ocurrió un error al registrar la partida",
+    "success": "Partida registrada con éxito"
   },
   "TransactionTemplates": {
     "title": "Plantillas de transacciones",

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -135,7 +135,7 @@
       "committees": "Comités",
       "chartOfAccounts": "Catálogo de Cuentas",
       "ledgerAccounts": "Cuentas del libro mayor",
-      "journal": "Diario",
+      "journal": "Registros Contables",
       "users": "Usuarios",
       "balanceSheet": "Balance General",
       "profitAndLoss": "Pérdidas y Ganancias",
@@ -1784,9 +1784,9 @@
     }
   },
   "Journal": {
-    "title": "Diario",
-    "description": "Un registro completo de transacciones financieras en el diario",
-    "noTableData": "No hay entradas presentes en el diario",
+    "title": "Registros Contables",
+    "description": "Un registro completo de partidas contables",
+    "noTableData": "No hay registros contables",
     "table": {
       "createdAt": "Fecha de creación",
       "entryType": "Tipo de entrada",

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -272,7 +272,7 @@
         },
         "labels": {
           "email": "Correo electrónico",
-          "createdOn": "Creado el",
+          "createdOn": "Fecha de registro",
           "telegram": "Telegram",
           "status": "Estado",
           "customerType": "Tipo",
@@ -380,7 +380,7 @@
             "outstandingBalance": "Saldo Pendiente",
             "collateralBtc": "Garantía (BTC)",
             "collateralizationState": "Estado de Colateralización",
-            "createdAt": "Creado El"
+            "createdAt": "Fecha de registro"
           }
         }
       },
@@ -422,7 +422,7 @@
         "outstanding": "Pendiente",
         "collateralizationState": "Estado",
         "cvl": "CVL",
-        "createdAt": "Creado El"
+        "createdAt": "Fecha de registro"
       }
     },
     "CreditFacilityStatus": {
@@ -474,7 +474,7 @@
         "description": "Desembolsos asociados con esta línea de crédito",
         "columns": {
           "amount": "Monto",
-          "createdAt": "Creado El",
+          "createdAt": "Fecha de registro",
           "status": "Estado"
         },
         "messages": {
@@ -789,7 +789,7 @@
         "title": "Plantilla de Términos",
         "fields": {
           "name": "Nombre",
-          "createdAt": "Creado El",
+          "createdAt": "Fecha de registro",
           "duration": "Duración",
           "annualRate": "Tasa Anual",
           "initialCvl": "CVL Inicial (%)",
@@ -949,7 +949,7 @@
       "detailsCard": {
         "title": "Comité",
         "fields": {
-          "createdAt": "Creado El",
+          "createdAt": "Fecha de registro",
           "name": "Nombre",
           "totalMembers": "Total de Miembros"
         },
@@ -1266,7 +1266,7 @@
         "title": "Aprobar Proceso",
         "fields": {
           "processType": "Tipo de Proceso",
-          "createdAt": "Creado El"
+          "createdAt": "Fecha de registro"
         },
         "buttons": {
           "approve": "Aprobar"
@@ -1282,7 +1282,7 @@
         "title": "Rechazar Proceso",
         "fields": {
           "processType": "Tipo de Proceso",
-          "createdAt": "Creado El",
+          "createdAt": "Fecha de registro",
           "reasonLabel": "Razón del Rechazo"
         },
         "placeholders": {
@@ -1375,7 +1375,7 @@
     "userDetails": {
       "title": "Usuario",
       "fields": {
-        "createdAt": "Creado El",
+        "createdAt": "Fecha de registro",
         "email": "Correo Electrónico",
         "role": "Rol"
       },
@@ -1591,7 +1591,7 @@
     }
   },
   "dateTime": {
-    "created": "Creado el {date}",
+    "created": "Fecha de registro {date}",
     "format": {
       "short": "d 'de' MMMM 'de' yyyy, HH:mm"
     }
@@ -1809,7 +1809,7 @@
     "noEntries": "Sin asientos",
     "details": {
       "description": "Descripción",
-      "createdAt": "Creado el",
+      "createdAt": "Fecha de registro",
       "effective": "Fecha efectiva"
     },
     "entriesTitle": "Asientos contables",
@@ -1873,7 +1873,7 @@
     "table": {
       "noData": "No se encontraron transacciones contables para este código de plantilla",
       "headers": {
-        "createdAt": "Creado el",
+        "createdAt": "Fecha de registro",
         "description": "Descripción"
       }
     }
@@ -1885,7 +1885,7 @@
       "headers": {
         "name": "Nombre del rol",
         "permissionSets": "Permisos",
-        "createdAt": "Creado el"
+        "createdAt": "Fecha de registro"
       },
       "emptyMessage": "No se encontraron roles. Haz clic en el botón crear para añadir un nuevo rol.",
       "noPermissionSetsAssigned": "Sin permisos asignados",
@@ -1915,7 +1915,7 @@
       "roleDetails": "Detalles del rol",
       "roleDetailsDescription": "Ver y gestionar información y permisos del rol",
       "name": "Nombre",
-      "createdAt": "Creado el",
+      "createdAt": "Fecha de registro",
       "permissionSets": "Permisos",
       "editRole": "Editar rol"
     }

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -41,7 +41,7 @@
     },
     "accounting_writer": {
       "label": "Editor de contabilidad",
-      "description": "Puede crear y gestionar planes de cuentas, transacciones manuales y del libro mayor, balances, informes de pérdidas y ganancias, y datos contables relacionados"
+      "description": "Puede crear y gestionar planes de cuentas, transacciones manuales y del libro mayor, balances, informes del estado de resultados, y datos contables relacionados"
     },
     "audit_viewer": {
       "label": "Visor de auditoría",
@@ -138,7 +138,7 @@
       "journal": "Registros Contables",
       "users": "Usuarios",
       "balanceSheet": "Balance General",
-      "profitAndLoss": "Pérdidas y Ganancias",
+      "profitAndLoss": "Estado de Resultados",
       "regulatoryReporting": "Informes Regulatorios",
       "trialBalance": "Balance de Comprobación",
       "modules": "Módulos",
@@ -1708,9 +1708,9 @@
       "chartOfAccountsExpensesCode": "Código de gastos"
     },
     "profitAndLoss": {
-      "title": "Pérdidas y ganancias",
-      "description": "Configuración del estado de pérdidas y ganancias",
-      "setTitle": "Establecer configuración de pérdidas y ganancias",
+      "title": "Estado de resultados",
+      "description": "Configuración del estado de resultados",
+      "setTitle": "Establecer configuración del estado de resultados",
       "chartOfAccountsId": "ID del catálogo de cuentas",
       "chartOfAccountsRevenueCode": "Código de ingresos",
       "chartOfAccountsCostOfRevenueCode": "Código de costo de ingresos",

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -117,7 +117,7 @@
       "loans": "Préstamos",
       "transactions": "Transacciones",
       "administration": "Administración",
-      "financialReports": "Informes Financieros",
+      "financialReports": "Reportes",
       "accounting": "Contabilidad",
       "governance": "Gobernanza"
     },

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -487,7 +487,7 @@
         "columns": {
           "entryType": "Tipo de entrada",
           "recordedAt": "Registrado El",
-          "effective": "Fecha efectiva",
+          "effective": "Fecha valor",
           "amount": "Monto"
         },
         "entryTypes": {
@@ -646,7 +646,7 @@
         "form": {
           "labels": {
             "amount": "Monto",
-            "effectiveDate": "Fecha efectiva"
+            "effectiveDate": "Fecha valor"
           },
           "placeholders": {
             "amount": "Ingrese el monto principal deseado"
@@ -1795,7 +1795,7 @@
       "direction": "Dirección",
       "amount": "Monto",
       "description": "Descripción",
-      "effective": "Fecha efectiva",
+      "effective": "Fecha valor",
       "closestAccountWithCode": "Código de cuenta principal"
     },
     "debitOrCredit": {
@@ -1810,7 +1810,7 @@
     "details": {
       "description": "Descripción",
       "createdAt": "Fecha de registro",
-      "effective": "Fecha efectiva"
+      "effective": "Fecha valor"
     },
     "entriesTitle": "Asientos contables",
     "entriesDescription": "Asientos asociados con esta transacción",
@@ -1829,7 +1829,7 @@
     "fields": {
       "description": "Descripción de la transacción",
       "reference": "Referencia de la transacción",
-      "effective": "Fecha efectiva",
+      "effective": "Fecha valor",
       "entries": "Asientos contables para esta transacción",
       "usd": "USD",
       "btc": "BTC",
@@ -1839,7 +1839,7 @@
     "placeholders": {
       "description": "Ingrese la descripción de la transacción",
       "reference": "Ingrese la referencia de la transacción",
-      "effective": "Seleccionar fecha efectiva"
+      "effective": "Seleccionar fecha valor"
     },
     "noEntries": "No hay asientos contables para esta transacción. Por favor, añada uno.",
     "addEntryBtn": "Añadir",


### PR DESCRIPTION
- "Transacción del libro mayor" to "Partida contable" for LedgerTransaction
- "Ejecutar transacción manual" to "Registrar partida manual" for ManualTransactions
- "Fecha efectiva" to "Fecha valor" for effictiveDate
- "Creado el" to "Fecha de registro" for createdAt
- "Pérdidas y Ganancias" to "Estado de resultados" for profitAndLoss
- switch to more general "Reportes" for financialReports
- "Diario" to "Registros Contables" for journal
