### PR TITLE
chore: remove sumsub link from list page

### DIFF
--- a/apps/admin-panel/app/withdrawals/[withdrawal-id]/details.tsx
+++ b/apps/admin-panel/app/withdrawals/[withdrawal-id]/details.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from "next-intl"
 
 import { Button } from "@lana/web/ui/button"
 
+import { LinkIcon } from "lucide-react"
+
 import { WithdrawalStatusBadge } from "../status-badge"
 
 import { WithdrawalConfirmDialog } from "./confirm"
@@ -47,16 +49,19 @@ const WithdrawalDetailsCard: React.FC<WithdrawalDetailsProps> = ({ withdrawal })
       href: `/customers/${withdrawal.account.customer.publicId}`,
     },
     {
-      label: t("fields.withdrawalId") || "ID",
+      label: t("fields.withdrawalId"),
       value: (
         <a
           href={`https://cockpit.sumsub.com/checkus#/kyt/txns?search=${withdrawal.withdrawalId}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-primary hover:underline"
+          className="flex items-center gap-1 text-blue-500 hover:underline"
           title={`Full ID: ${withdrawal.withdrawalId}`}
         >
-          {`${withdrawal.withdrawalId.substring(0, 4)}...${withdrawal.withdrawalId.substring(withdrawal.withdrawalId.length - 4)}`}
+          {`${withdrawal.withdrawalId.substring(0, 4)}...${withdrawal.withdrawalId.substring(
+            withdrawal.withdrawalId.length - 4,
+          )}`}
+          <LinkIcon className="h-4 w-4" />
         </a>
       ),
     },

--- a/apps/admin-panel/app/withdrawals/[withdrawal-id]/details.tsx
+++ b/apps/admin-panel/app/withdrawals/[withdrawal-id]/details.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl"
 
 import { Button } from "@lana/web/ui/button"
 
-import { LinkIcon } from "lucide-react"
+import { ExternalLinkIcon } from "lucide-react"
 
 import { WithdrawalStatusBadge } from "../status-badge"
 
@@ -61,7 +61,7 @@ const WithdrawalDetailsCard: React.FC<WithdrawalDetailsProps> = ({ withdrawal })
           {`${withdrawal.withdrawalId.substring(0, 4)}...${withdrawal.withdrawalId.substring(
             withdrawal.withdrawalId.length - 4,
           )}`}
-          <LinkIcon className="h-4 w-4" />
+          <ExternalLinkIcon className="h-4 w-4" />
         </a>
       ),
     },

--- a/apps/admin-panel/app/withdrawals/list.tsx
+++ b/apps/admin-panel/app/withdrawals/list.tsx
@@ -76,22 +76,9 @@ export default Withdrawals
 const columns = (t: ReturnType<typeof useTranslations>): Column<Withdrawal>[] => [
   {
     key: "withdrawalId",
-    label: t("headers.withdrawalId") || "ID",
+    label: t("headers.withdrawalId"),
     render: (withdrawalId) => {
-      // Format the withdrawal ID to show only the first 4 and last 4 characters
-      const shortId = `${withdrawalId.substring(0, 4)}...${withdrawalId.substring(withdrawalId.length - 4)}`
-
-      return (
-        <a
-          href={`https://cockpit.sumsub.com/checkus#/kyt/txns?search=${withdrawalId}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary hover:underline"
-          title={`Full ID: ${withdrawalId}`}
-        >
-          {shortId}
-        </a>
-      )
+      return `${withdrawalId.substring(0, 4)}...${withdrawalId.substring(withdrawalId.length - 4)}`
     },
   },
   {


### PR DESCRIPTION
<img width="1426" height="310" alt="image" src="https://github.com/user-attachments/assets/55b2fea8-88ed-4587-8241-76a791cb07e6" />

https://github.com/GaloyMoney/volcano-wip/issues/451


Note: The ID is still present on the list page, but it does not have a link attached to it.