### PR TITLE
fix: Add retries on concurrent modification in simulations

### DIFF
--- a/core/credit/src/credit_facility/mod.rs
+++ b/core/credit/src/credit_facility/mod.rs
@@ -629,10 +629,11 @@ where
         Ok(balances)
     }
 
+    #[es_entity::retry_on_concurrent_modification(any_error = true, max_retries = 15)]
     pub async fn has_outstanding_obligations(
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,
-        credit_facility_id: impl Into<CreditFacilityId> + std::fmt::Debug,
+        credit_facility_id: impl Into<CreditFacilityId> + std::fmt::Debug + Copy,
     ) -> Result<bool, CreditFacilityError> {
         let id = credit_facility_id.into();
 

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -907,7 +907,7 @@ where
     }
 
     #[instrument(name = "credit.record_payment_with_date", skip(self), err)]
-    #[es_entity::retry_on_concurrent_modification(any_error = true)]
+    #[es_entity::retry_on_concurrent_modification(any_error = true, max_retries = 15)]
     pub async fn record_payment_with_date(
         &self,
         sub: &<<Perms as PermissionCheck>::Audit as AuditSvc>::Subject,


### PR DESCRIPTION
During experiments, simulations sometimes panicked due to concurrent modification. This change adds more robust retries on concurrent modification to two methods that are main suspects of these situations.