### PR TITLE
chore: Add tracing to simulation scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,6 +5384,7 @@ dependencies = [
  "serde",
  "sim-time",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/lana/sim-bootstrap/Cargo.toml
+++ b/lana/sim-bootstrap/Cargo.toml
@@ -20,3 +20,4 @@ rust_decimal_macros = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
+tracing = { workspace = true }

--- a/lana/sim-bootstrap/src/scenarios/disbursal_different_months.rs
+++ b/lana/sim-bootstrap/src/scenarios/disbursal_different_months.rs
@@ -7,6 +7,11 @@ use tokio::sync::mpsc;
 use crate::helpers;
 
 // Scenario 4: A credit facility that has multiple disbursals making timely payments
+#[tracing::instrument(
+    name = "sim_bootstrap.disbursal_different_months_scenario",
+    skip(app),
+    err
+)]
 pub async fn disbursal_different_months_scenario(
     sub: Subject,
     app: &LanaApp,

--- a/lana/sim-bootstrap/src/scenarios/interest_late.rs
+++ b/lana/sim-bootstrap/src/scenarios/interest_late.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::helpers;
 
 // Scenario 2: A credit facility with an interest payment >90 days late
+#[tracing::instrument(name = "sim_bootstrap.interest_late_scenario", skip(app), err)]
 pub async fn interest_late_scenario(sub: Subject, app: &LanaApp) -> anyhow::Result<()> {
     let (customer_id, deposit_account_id) =
         helpers::create_customer(&sub, app, "2-interest-late").await?;

--- a/lana/sim-bootstrap/src/scenarios/interest_under_payment.rs
+++ b/lana/sim-bootstrap/src/scenarios/interest_under_payment.rs
@@ -7,6 +7,7 @@ use rust_decimal_macros::dec;
 use crate::helpers;
 
 // Scenario 5: A fresh credit facility with no previous payments (interest under payment)
+#[tracing::instrument(name = "sim_bootstrap.interest_under_payment_scenario", skip(app), err)]
 pub async fn interest_under_payment_scenario(sub: Subject, app: &LanaApp) -> anyhow::Result<()> {
     let (customer_id, deposit_account_id) =
         helpers::create_customer(&sub, app, "5-interest-under-payment").await?;

--- a/lana/sim-bootstrap/src/scenarios/principal_late.rs
+++ b/lana/sim-bootstrap/src/scenarios/principal_late.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::helpers;
 
 // Scenario 3: A credit facility with an principal payment >90 days late
+#[tracing::instrument(name = "sim_bootstrap.principal_late_scenario", skip(app), err)]
 pub async fn principal_late_scenario(sub: Subject, app: &LanaApp) -> anyhow::Result<()> {
     let (customer_id, deposit_account_id) =
         helpers::create_customer(&sub, app, "3-principal-late").await?;

--- a/lana/sim-bootstrap/src/scenarios/principal_under_payment.rs
+++ b/lana/sim-bootstrap/src/scenarios/principal_under_payment.rs
@@ -8,6 +8,11 @@ use tokio::sync::mpsc;
 use crate::helpers;
 
 // Scenario 6: A fresh credit facility with interests paid out (principal under payment)
+#[tracing::instrument(
+    name = "sim_bootstrap.principal_under_payment_scenario",
+    skip(app),
+    err
+)]
 pub async fn principal_under_payment_scenario(sub: Subject, app: &LanaApp) -> anyhow::Result<()> {
     let (customer_id, deposit_account_id) =
         helpers::create_customer(&sub, app, "6-principal-under-payment").await?;

--- a/lana/sim-bootstrap/src/scenarios/principal_under_payment.rs
+++ b/lana/sim-bootstrap/src/scenarios/principal_under_payment.rs
@@ -82,7 +82,9 @@ pub async fn principal_under_payment_scenario(sub: Subject, app: &LanaApp) -> an
                 obligation_type,
                 ..
             })) if { cf.id == *id && amount > &UsdCents::ZERO } => {
-                tx.send((*obligation_type, *amount)).await?;
+                if tx.send((*obligation_type, *amount)).await.is_err() {
+                    break;
+                };
             }
             Some(LanaEvent::Credit(CoreCreditEvent::FacilityCompleted { id, .. })) => {
                 if cf.id == *id {

--- a/lana/sim-bootstrap/src/scenarios/timely_payments.rs
+++ b/lana/sim-bootstrap/src/scenarios/timely_payments.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::helpers;
 
 // Scenario 1: A credit facility that made timely payments and was paid off all according to the initial payment plan
+#[tracing::instrument(name = "sim_bootstrap.timely_payments_scenario", skip(app), err)]
 pub async fn timely_payments_scenario(sub: Subject, app: &LanaApp) -> anyhow::Result<()> {
     let (customer_id, deposit_account_id) =
         helpers::create_customer(&sub, app, "1-timely-paid").await?;


### PR DESCRIPTION
This PR adds tracing to simulation scenarios. Additionally in `principal_under_payment_scenario`, eliminates raising error in a specific case.