### PR TITLE
chore: remove dbt posthook

### DIFF
--- a/meltano/transform/dbt_project.yml
+++ b/meltano/transform/dbt_project.yml
@@ -29,8 +29,6 @@ tests:
   store_failures: true
 on-run-start:
 - '{{create_udfs()}}'
-on-run-end:
-- '{{create_data_test_results()}}'
 vars:
   sats_per_bitcoin: '100000000'
   cents_per_usd: '100'


### PR DESCRIPTION
Drops the dbt posthook since we're not really using the output it generates anymore.