### PR TITLE
feat: otel agent dev dataset tagging

### DIFF
--- a/dev/otel-agent-config.yaml
+++ b/dev/otel-agent-config.yaml
@@ -11,6 +11,13 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 
+processors:
+  resource:
+    attributes:
+    - key: developer.dataset
+      value: ${HONEYCOMB_DATASET}
+      action: upsert
+
 exporters:
   debug:
     verbosity: detailed
@@ -30,5 +37,5 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, otlp]
+      processors: [resource]
       exporters: [otlp, debug]
-


### PR DESCRIPTION
- adding a tag to discriminate between devs events in honeycomb's DEV env.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a resource processor to the dev OTEL agent to upsert `developer.dataset` from `${HONEYCOMB_DATASET}` and wires it into the traces pipeline.
> 
> - **Config — OpenTelemetry Collector (`dev/otel-agent-config.yaml`)**:
>   - Add `processors.resource` to upsert `developer.dataset` from `${HONEYCOMB_DATASET}`.
>   - Attach the processor to `service.pipelines.traces.processors`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b61d322f5d9a34bea87440911049a8d95c71ea68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->