### PR TITLE
chore: remove upgrade buffer config from yaml

### DIFF
--- a/.cursor/rules/rust-base.mdc
+++ b/.cursor/rules/rust-base.mdc
@@ -64,6 +64,8 @@ in general, because nix build deterministically, there is no need to prune the n
 -- core can import lib
 -- lana can import core
 
+do not add any `#[allow(dead_code)]`
+
 ## hexagonal architecture
 
 the incoming adapter layer is graphql. code for it is in:

--- a/core/credit/src/config.rs
+++ b/core/credit/src/config.rs
@@ -2,13 +2,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::primitives::CVLPct;
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct CreditConfig {
-    #[serde(default = "default_upgrade_buffer_cvl_pct")]
-    pub upgrade_buffer_cvl_pct: CVLPct,
     #[serde(default = "default_customer_active_check_enabled")]
     pub customer_active_check_enabled: bool,
 }
@@ -16,14 +12,9 @@ pub struct CreditConfig {
 impl Default for CreditConfig {
     fn default() -> Self {
         CreditConfig {
-            upgrade_buffer_cvl_pct: default_upgrade_buffer_cvl_pct(),
             customer_active_check_enabled: default_customer_active_check_enabled(),
         }
     }
-}
-
-fn default_upgrade_buffer_cvl_pct() -> CVLPct {
-    CVLPct::new(5)
 }
 
 fn default_customer_active_check_enabled() -> bool {

--- a/core/credit/src/jobs/collateralization_from_price.rs
+++ b/core/credit/src/jobs/collateralization_from_price.rs
@@ -19,7 +19,6 @@ use crate::{
 pub(crate) struct CreditFacilityCollateralizationFromPriceJobConfig<Perms, E> {
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     pub job_interval: Duration,
-    pub upgrade_buffer_cvl_pct: CVLPct,
     pub _phantom: std::marker::PhantomData<(Perms, E)>,
 }
 impl<Perms, E> JobConfig for CreditFacilityCollateralizationFromPriceJobConfig<Perms, E>
@@ -107,7 +106,7 @@ where
         _current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
         self.credit_facilities
-            .update_collateralization_from_price(self.config.upgrade_buffer_cvl_pct)
+            .update_collateralization_from_price(CVLPct::UPGRADE_BUFFER)
             .await?;
 
         Ok(JobCompletion::RescheduleIn(self.config.job_interval))

--- a/core/credit/src/lib.rs
+++ b/core/credit/src/lib.rs
@@ -246,7 +246,6 @@ where
                 >::new(credit_facilities.clone()),
                 collateralization_from_price::CreditFacilityCollateralizationFromPriceJobConfig {
                     job_interval: std::time::Duration::from_secs(30),
-                    upgrade_buffer_cvl_pct: config.upgrade_buffer_cvl_pct,
                     _phantom: std::marker::PhantomData,
                 },
             )
@@ -269,7 +268,6 @@ where
                     E,
                 >::new(outbox, &credit_facilities),
                 collateralization_from_events::CreditFacilityCollateralizationFromEventsJobConfig {
-                    upgrade_buffer_cvl_pct: config.upgrade_buffer_cvl_pct,
                     _phantom: std::marker::PhantomData,
                 },
             )
@@ -923,7 +921,7 @@ where
 
         let credit_facility = match self
             .facilities
-            .complete_in_op(&mut db, id, self.config.upgrade_buffer_cvl_pct)
+            .complete_in_op(&mut db, id, CVLPct::UPGRADE_BUFFER)
             .await?
         {
             CompletionOutcome::Ignored(facility) => facility,

--- a/core/credit/src/primitives/cvl.rs
+++ b/core/credit/src/primitives/cvl.rs
@@ -33,6 +33,7 @@ impl PartialOrd for CVLPct {
 
 impl CVLPct {
     pub const ZERO: Self = Self::Finite(dec!(0));
+    pub const UPGRADE_BUFFER: Self = Self::Finite(dec!(5));
 
     pub fn new(value: u64) -> Self {
         Self::Finite(Decimal::from(value))

--- a/dev/lana.default.yml
+++ b/dev/lana.default.yml
@@ -20,7 +20,6 @@ app:
   access:
     superuser_email: null
   credit:
-    upgrade_buffer_cvl_pct: !Finite '5'
     customer_active_check_enabled: true
   storage:
     provider: local


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove `upgrade_buffer_cvl_pct` from config/YAML and jobs, introduce `CVLPct::UPGRADE_BUFFER`, and update collateralization/completion logic to use the constant.
> 
> - **Core Credit Config**:
>   - Remove `CreditConfig.upgrade_buffer_cvl_pct` and its default; drop related import.
> - **Primitives**:
>   - Add `CVLPct::UPGRADE_BUFFER` constant (`5`).
> - **Jobs**:
>   - `jobs/collateralization_from_events`: remove `upgrade_buffer_cvl_pct` from job config; initializer no longer uses `job`; runner calls `update_collateralization_from_events(*id, CVLPct::UPGRADE_BUFFER)`.
>   - `jobs/collateralization_from_price`: remove `upgrade_buffer_cvl_pct` from job config; runner calls `update_collateralization_from_price(CVLPct::UPGRADE_BUFFER)`.
> - **Core Wiring** (`core/credit/src/lib.rs`):
>   - Stop passing `upgrade_buffer_cvl_pct` to job configs; use constant in `complete_in_op(..., CVLPct::UPGRADE_BUFFER)`.
> - **Config Files**:
>   - Remove `app.credit.upgrade_buffer_cvl_pct` from `dev/lana.default.yml`.
> - **Misc**:
>   - Add rule in `.cursor/rules/rust-base.mdc`: do not add `#[allow(dead_code)]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d32c88c8037abd788c25eb228b123471bd74d53e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->